### PR TITLE
Fix reset port templates

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -237,4 +237,10 @@
       The internal representation of values of template types has been changed.
       It is no longer allowed to cast such values to integer or pointer types.
   </add-note></build-id>
+  <build-id value="next"><add-note>Added a new
+      template <tt>state_signal</tt> which implements a signal
+      interface with saved state. It logs an <tt>error</tt> if the
+      signal is raised or lowered when already high or low. The
+      templates <tt>hreset</tt>, <tt>sreset</tt> and <tt>poreset</tt>
+      use the <tt>state_signal</tt> template.</add-note></build-id>
 </rn>

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -192,14 +192,49 @@ template _init_val_power_on_reset is (init_val, power_on_reset) {
     }
 }
 
+/**
+### state_signal
+
+<section>
+
+#### Description
+
+Implements a signal interface with saved state. The current state of the signal
+is stored in the saved boolean `high` and an error is logged if the signal is
+raised or lowered when already high or low. The methods `signal_raise` and
+`signal_lower` can be overridden to add side effects.
+
+#### Related Templates
+
+poreset, hreset, sreset
+
+</section>
+*/
+template state_signal {
+    implement signal {
+        saved bool high;
+        method signal_raise() default {
+            if (high)
+                log error: "%s raised when already high", qname;
+            else
+                high = true;
+        }
+        method signal_lower() default {
+            if (!high)
+                log error: "%s lowered when already low", qname;
+            else
+                high = false;
+        }
+    }
+}
+
 // Instantiate this on top level to support power-on reset.
 template poreset is power_on_reset {
-    port POWER {
+    port POWER is state_signal {
         implement signal {
             method signal_raise() {
+                default();
                 dev.power_on_reset();
-            }
-            method signal_lower() {
             }
         }
     }
@@ -234,12 +269,11 @@ template _init_val_hard_reset is (init_val, hard_reset) {
 
 // Instantiate this on top level to support hard reset.
 template hreset is hard_reset {
-    port HRESET {
+    port HRESET is state_signal {
         implement signal {
             method signal_raise() {
+                default();
                 dev.hard_reset();
-            }
-            method signal_lower() {
             }
         }
     }
@@ -301,19 +335,18 @@ for power-on reset, hard reset and soft reset, respectively.
 
 #### Related Templates
 
-power\_on\_reset, hard\_reset, soft\_reset
+state\_signal, power\_on\_reset, hard\_reset, soft\_reset
 
 </section>
 */
 
 // Instantiate this on top level to support soft reset.
 template sreset is soft_reset {
-    port SRESET {
+    port SRESET is state_signal {
         implement signal {
             method signal_raise() {
+                default();
                 dev.soft_reset();
-            }
-            method signal_lower() {
             }
         }
     }

--- a/test/1.4/lib/T_regdisp.py
+++ b/test/1.4/lib/T_regdisp.py
@@ -57,6 +57,7 @@ def test_some(mem, obj, port, allow_partial, allow_overlapping,
     def access(offset, length, partial = False, overlapping = False,
                illegal = False):
         obj.ports.HRESET.signal.signal_raise()
+        obj.ports.HRESET.signal.signal_lower()
         write(offset, length, partial, overlapping, illegal)
         read(offset, length, partial, overlapping, illegal)
 

--- a/test/1.4/lib/T_state_signal.dml
+++ b/test/1.4/lib/T_state_signal.dml
@@ -1,0 +1,51 @@
+/*
+  © 2021 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+import "utility.dml";
+
+saved bool on_raise_called;
+saved bool on_lower_called;
+
+method on_raise() {
+    on_raise_called = true;
+}
+
+method on_lower() {
+    on_lower_called = true;
+}
+
+port both is state_signal {
+    implement signal {
+        method signal_raise() {
+            default();
+            on_raise_called = true;
+        }
+        method signal_lower() {
+            default();
+            on_lower_called = true;
+        }
+    }
+}
+
+port up is state_signal {
+    implement signal {
+        method signal_raise() {
+            default();
+            on_raise_called = true;
+        }
+    }
+}
+
+port down is state_signal {
+    implement signal {
+        method signal_lower() {
+            default();
+            on_lower_called = true;
+        }
+    }
+}

--- a/test/1.4/lib/T_state_signal.py
+++ b/test/1.4/lib/T_state_signal.py
@@ -1,0 +1,58 @@
+# © 2021 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+import stest
+stest.expect_equal(obj.on_raise_called, False)
+stest.expect_equal(obj.on_lower_called, False)
+stest.expect_equal(obj.port.both.signal_high, False)
+
+obj.port.both.iface.signal.signal_raise()
+stest.expect_equal(obj.port.both.signal_high, True)
+stest.expect_equal(obj.on_raise_called, True)
+stest.expect_equal(obj.on_lower_called, False)
+
+obj.on_raise_called = False
+obj.on_lower_called = False
+
+with stest.expect_log_mgr(obj=obj.port.both, regex="already high"):
+    obj.port.both.iface.signal.signal_raise()
+stest.expect_equal(obj.port.both.signal_high, True)
+stest.expect_equal(obj.on_raise_called, True)
+
+obj.port.both.iface.signal.signal_lower()
+stest.expect_equal(obj.port.both.signal_high, False)
+stest.expect_equal(obj.on_lower_called, True)
+
+obj.on_raise_called = False
+obj.on_lower_called = False
+
+with stest.expect_log_mgr(obj=obj.port.both, regex="already low"):
+    obj.port.both.iface.signal.signal_lower()
+stest.expect_equal(obj.port.both.signal_high, False)
+stest.expect_equal(obj.on_lower_called, True)
+
+obj.on_raise_called = False
+obj.on_lower_called = False
+
+obj.port.up.iface.signal.signal_raise()
+stest.expect_equal(obj.on_raise_called, True)
+stest.expect_equal(obj.on_lower_called, False)
+
+obj.on_raise_called = False
+obj.on_lower_called = False
+
+obj.port.up.iface.signal.signal_lower()
+stest.expect_equal(obj.on_raise_called, False)
+stest.expect_equal(obj.on_lower_called, False)
+
+
+obj.port.down.iface.signal.signal_raise()
+stest.expect_equal(obj.on_raise_called, False)
+stest.expect_equal(obj.on_lower_called, False)
+
+obj.on_raise_called = False
+obj.on_lower_called = False
+
+obj.port.down.iface.signal.signal_lower()
+stest.expect_equal(obj.on_raise_called, False)
+stest.expect_equal(obj.on_lower_called, True)


### PR DESCRIPTION
Signal interface API docs say that raise and lower represent the
rising and falling edge of the signal, and that it is an error for an
initiator to call raise twice, without an intervening call to lower.

Continuation of this PR
https://github.com/intel-innersource/applications.simulators.simics.simics-base/pull/942