### PR TITLE
Improve generation of array de/serialization functions -- SIMICS-18440

### DIFF
--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1681,4 +1681,8 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
   <build-id value="6132"><add-note> Unicode BiDi control characters
       are no longer permitted in DML source files, for security
       reasons. </add-note></build-id>
+  <build-id value="next"><add-note> Addressed code generation efficiency issues
+      when using array types in <tt>saved</tt> variables or parameters to
+      methods called with <tt>after</tt> <bug number="SIMICS-18440"/>.
+  </add-note></build-id>
 </rn>

--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1684,5 +1684,7 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
   <build-id value="next"><add-note> Addressed code generation efficiency issues
       when using array types in <tt>saved</tt> variables or parameters to
       methods called with <tt>after</tt> <bug number="SIMICS-18440"/>.
-  </add-note></build-id>
+
+      Serialized representation of <tt>uint8[(be|le)_t]</tt> array types has
+      been changed. </add-note></build-id>
 </rn>

--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1686,5 +1686,7 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
       methods called with <tt>after</tt> <bug number="SIMICS-18440"/>.
 
       Serialized representation of <tt>uint8[(be|le)_t]</tt> array types has
-      been changed. </add-note></build-id>
+      been changed. The old serialized representation is still accepted for
+      deserialization in order to preserve checkpoint compatibility.
+  </add-note></build-id>
 </rn>

--- a/include/simics/dmllib.h
+++ b/include/simics/dmllib.h
@@ -1660,13 +1660,16 @@ _callback_after_write(conf_object_t *bank,
                                   Callback_After_Write);
 }
 
+typedef set_error_t (*_deserializer_t)(attr_value_t *val, void *addr);
+typedef void (*_serializer_t)(const void *addr, attr_value_t *val);
+
 UNUSED static set_error_t
 _set_device_member(attr_value_t val,
                    char *ptr,
                    const uint32 *dimension_sizes,
                    const uint32 *dimension_strides,
                    unsigned int remaining_dimensions,
-                   set_error_t (*setter)(attr_value_t *val, void *addr)) {
+                   _deserializer_t setter) {
         if (remaining_dimensions == 0) {
                 return setter(&val, (void*)ptr);
         } else {
@@ -1690,10 +1693,10 @@ _get_device_member(char *ptr,
                    const uint32 *dimension_sizes,
                    const uint32 *dimension_strides,
                    unsigned int remaining_dimensions,
-                   void (*getter)(void *addr, attr_value_t *target)) {
+                   _serializer_t getter) {
         attr_value_t to_return;
         if (remaining_dimensions == 0) {
-                getter((void*)ptr, &to_return);
+                getter((const void *)ptr, &to_return);
         } else {
                 to_return = SIM_alloc_attr_list(dimension_sizes[0]);
                 attr_value_t im_attr;
@@ -1713,13 +1716,13 @@ _get_device_member(char *ptr,
 typedef struct {
         ptrdiff_t relative_base;
         // excluding port dimensions
-        unsigned int ndims;
+        unsigned int    ndims;
         // excluding port dimensions
-        const uint32 *dimension_sizes;
+        const uint32    *dimension_sizes;
         // including port dimensions
-        const uint32 *dimension_strides;
-        set_error_t (*setter)(attr_value_t *val, void *addr);
-        void (*getter)(void *addr, attr_value_t *val);
+        const uint32    *dimension_strides;
+        _deserializer_t setter;
+        _serializer_t   getter;
 } _saved_userdata_t;
 
 UNUSED static set_error_t
@@ -1784,6 +1787,98 @@ _get_port_saved_variable(lang_void *saved_access, conf_object_t *_portobj,
 UNUSED static uint64 _identity_to_key(_identity_t id) {
         return (uint64)id.id << 32 | (uint64)id.encoded_index;
 }
+
+static attr_value_t
+_serialize_array_aux(const uint8 *data, size_t elem_size,
+                     const uint32 *dimsizes, uint32 dims,
+                     uint64 total_elem_count, _serializer_t serialize_elem) {
+    uint32 len = *dimsizes;
+    size_t children_elem_count = total_elem_count/len;
+
+    attr_value_t val = SIM_alloc_attr_list(len);
+    attr_value_t *items = SIM_attr_list(val);
+
+    for (uint32 i = 0; i < len; ++i) {
+        if (dims == 1) {
+            serialize_elem(&data[i*elem_size], &items[i]);
+        } else {
+            items[i] = _serialize_array_aux(
+                data + children_elem_count * elem_size * i, elem_size,
+                dimsizes + 1, dims - 1, children_elem_count, serialize_elem);
+        }
+    }
+    return val;
+}
+
+UNUSED static attr_value_t
+_serialize_array(const void *data, size_t elem_size,
+                 const uint32 *dimsizes, uint32 dims,
+                 _serializer_t serialize_elem) {
+    ASSERT(dims > 0);
+    size_t total_elem_count = 1;
+    for (uint32 i = 0; i < dims; ++i) {
+        total_elem_count *= dimsizes[i];
+    }
+    return _serialize_array_aux((const uint8 *)data, elem_size, dimsizes, dims,
+                                total_elem_count, serialize_elem);
+}
+
+
+static set_error_t
+_deserialize_array_aux(attr_value_t val, uint8 *data, size_t elem_size,
+                       const uint32 *dimsizes, uint32 dims,
+                       size_t total_elem_count,
+                       _deserializer_t deserialize_elem) {
+    uint32 len = *dimsizes;
+    if (unlikely(!SIM_attr_is_list(val))) {
+        SIM_attribute_error("Invalid serialized representation of array: "
+                            "not a list");
+        return Sim_Set_Illegal_Type;
+    } else if (unlikely(SIM_attr_list_size(val) != len)) {
+        SIM_c_attribute_error(
+            "Invalid serialized representation of array: expected %u "
+            "elements, got %u", len, SIM_attr_list_size(val));
+        return Sim_Set_Illegal_Type;
+    }
+    attr_value_t *items = SIM_attr_list(val);
+    size_t children_elem_count = total_elem_count/len;
+    for (uint32 i = 0; i < len; ++i) {
+        set_error_t error;
+        if (dims == 1) {
+            error = deserialize_elem(&items[i], &data[i*elem_size]);
+        } else {
+            error = _deserialize_array_aux(
+                items[i], &data[i*children_elem_count*elem_size], elem_size,
+                dimsizes + 1, dims - 1, children_elem_count, deserialize_elem);
+        }
+        if (error != Sim_Set_Ok) {
+            return error;
+        }
+    }
+    return Sim_Set_Ok;
+}
+
+UNUSED static set_error_t
+_deserialize_array(attr_value_t in_val, void *out_data, size_t elem_size,
+                   const uint32 *dimsizes, uint32 dims,
+                   _deserializer_t deserialize_elem) {
+    ASSERT(dims > 0);
+    size_t total_elem_count = 1;
+    for (uint32 i = 0; i < dims; ++i) {
+        total_elem_count *= dimsizes[i];
+    }
+
+    uint8 *temp_out = MM_MALLOC(total_elem_count * elem_size, uint8);
+    set_error_t error = _deserialize_array_aux(
+        in_val, temp_out, elem_size, dimsizes, dims, total_elem_count,
+        deserialize_elem);
+    if (error == Sim_Set_Ok) {
+        memcpy(out_data, temp_out, total_elem_count*elem_size);
+    }
+    MM_FREE(temp_out);
+    return error;
+}
+
 
 // The internal format for ht is:
 // dict(trait_identifier -> dict(statement_idx -> bool))

--- a/test/1.4/serialize/T_saved_declaration.dml
+++ b/test/1.4/serialize/T_saved_declaration.dml
@@ -35,6 +35,11 @@ typedef struct {
 saved struct { i_ii_t v0; int i; } saved_struct;
 
 saved int saved_array[4];
+saved int saved_nested_array[4][3];
+
+// This declaration only exists to test that de/serialization functions for
+// large (nested) arrays are generated efficiently, and do not hang dmlc/gcc
+saved int64 saved_big_array[8][8192];
 
 // The unused sessions in these objects will complicate the strides of the
 // struct arrays in the device
@@ -173,6 +178,7 @@ attribute test_later is write_only_attr {
             for (local int j = 0; j < 3; j++) {
                 assert port_array[i].array_saved_int[j].v == matrix[i][j];
                 assert b[i].r.f[j].v == matrix[i][j];
+                assert saved_nested_array[i][j] == matrix[i][j];
             }
         }
 

--- a/test/1.4/serialize/T_saved_declaration.dml
+++ b/test/1.4/serialize/T_saved_declaration.dml
@@ -41,6 +41,14 @@ saved int saved_nested_array[4][3];
 // large (nested) arrays are generated efficiently, and do not hang dmlc/gcc
 saved int64 saved_big_array[8][8192];
 
+// uint8 array types -- both implicit and explicit endian -- are serialized as
+// data in the final dimension
+saved uint8 saved_byte_array[4];
+saved uint8_be_t saved_nested_byte_array[4][3];
+
+// no other array types are serialized as data
+saved char saved_char_array[4];
+
 // The unused sessions in these objects will complicate the strides of the
 // struct arrays in the device
 port port_array[i < 4] {
@@ -162,6 +170,8 @@ attribute test_later is write_only_attr {
 
         for (local int i = 0; i < 4; i++) {
             assert saved_array[i] == 3-i;
+            assert saved_byte_array[i] == 3-i;
+            assert saved_char_array[i] == 3-i;
         }
 
         for (local int i = 0; i < 4; i++) {
@@ -179,6 +189,8 @@ attribute test_later is write_only_attr {
                 assert port_array[i].array_saved_int[j].v == matrix[i][j];
                 assert b[i].r.f[j].v == matrix[i][j];
                 assert saved_nested_array[i][j] == matrix[i][j];
+                assert saved_nested_byte_array[i][j]
+                    == cast(matrix[i][j], uint8);
             }
         }
 

--- a/test/1.4/serialize/T_saved_declaration.dml
+++ b/test/1.4/serialize/T_saved_declaration.dml
@@ -41,13 +41,21 @@ saved int saved_nested_array[4][3];
 // large (nested) arrays are generated efficiently, and do not hang dmlc/gcc
 saved int64 saved_big_array[8][8192];
 
-// uint8 array types -- both implicit and explicit endian -- are serialized as
-// data in the final dimension
-saved uint8 saved_byte_array[4];
-saved uint8_be_t saved_nested_byte_array[4][3];
+// The final dimension of uint8 array types -- both implicit and explicit
+// endian -- is serialized as data, and can be deserialized either through data
+// or an integer list.
+saved uint8 saved_byte_array_via_data[4];
+saved uint8_be_t saved_nested_byte_array_via_data[4][3];
+saved uint8 saved_byte_array_via_list[4];
+saved uint8_be_t saved_nested_byte_array_via_list[4][3];
 
-// no other array types are serialized as data
-saved char saved_char_array[4];
+// The final dimension of int8 array types -- both implicit and explicit
+// endian -- is serialized as an integer list, and can be deserialized either
+// through data or an integer list
+saved char saved_signed_byte_array_via_data[4];
+saved int8_be_t saved_nested_signed_byte_array_via_data[4][3];
+saved char saved_signed_byte_array_via_list[4];
+saved int8_be_t saved_nested_signed_byte_array_via_list[4][3];
 
 // The unused sessions in these objects will complicate the strides of the
 // struct arrays in the device
@@ -170,8 +178,11 @@ attribute test_later is write_only_attr {
 
         for (local int i = 0; i < 4; i++) {
             assert saved_array[i] == 3-i;
-            assert saved_byte_array[i] == 3-i;
-            assert saved_char_array[i] == 3-i;
+            assert saved_byte_array_via_data[i] == 3-i;
+            assert saved_byte_array_via_list[i] == 3-i;
+
+            assert saved_signed_byte_array_via_data[i] == 1-i;
+            assert saved_signed_byte_array_via_list[i] == 1-i;
         }
 
         for (local int i = 0; i < 4; i++) {
@@ -189,8 +200,14 @@ attribute test_later is write_only_attr {
                 assert port_array[i].array_saved_int[j].v == matrix[i][j];
                 assert b[i].r.f[j].v == matrix[i][j];
                 assert saved_nested_array[i][j] == matrix[i][j];
-                assert saved_nested_byte_array[i][j]
+                assert saved_nested_byte_array_via_data[i][j]
                     == cast(matrix[i][j], uint8);
+                assert saved_nested_byte_array_via_list[i][j]
+                    == cast(matrix[i][j], uint8);
+                assert saved_nested_signed_byte_array_via_data[i][j]
+                    == matrix[i][j];
+                assert saved_nested_signed_byte_array_via_list[i][j]
+                    == matrix[i][j];
             }
         }
 

--- a/test/1.4/serialize/T_saved_declaration.py
+++ b/test/1.4/serialize/T_saved_declaration.py
@@ -34,6 +34,8 @@ stest.expect_equal([p.array_saved_int_v for p in obj.port.port_array], matrix)
 for (i, arr) in enumerate(matrix):
     obj.bank.b[i].r_f_v = arr
 stest.expect_equal([b.r_f_v for b in obj.bank.b], matrix)
+obj.saved_nested_array = matrix
+stest.expect_equal(obj.saved_nested_array, matrix)
 
 obj.saved_int24_le = 0xF00F00 #-1044736 in dml
 stest.expect_equal(obj.saved_int24_le, -1044736)

--- a/test/1.4/serialize/T_saved_declaration.py
+++ b/test/1.4/serialize/T_saved_declaration.py
@@ -17,6 +17,11 @@ obj.saved_float = -0.5
 stest.expect_equal(obj.saved_float, -0.5)
 obj.saved_array = [3, 2, 1, 0]
 stest.expect_equal(obj.saved_array, [3, 2, 1, 0])
+obj.saved_char_array = [3, 2, 1, 0]
+stest.expect_equal(obj.saved_char_array, [3, 2, 1, 0])
+# uint8 arrays are serialized as data instead of list
+obj.saved_byte_array = (3, 2, 1, 0)
+stest.expect_equal(obj.saved_byte_array, (3, 2, 1, 0))
 obj.saved_struct = [[0, [-1, 2], [3], [-2]], 4]
 stest.expect_equal(obj.saved_struct, [[0, [-1, 2], [3], [-2]], 4])
 
@@ -36,6 +41,11 @@ for (i, arr) in enumerate(matrix):
 stest.expect_equal([b.r_f_v for b in obj.bank.b], matrix)
 obj.saved_nested_array = matrix
 stest.expect_equal(obj.saved_nested_array, matrix)
+
+# Only the final dimension of a nested byte array is serialized as data.
+byte_matrix = [tuple(byte & 0xff for byte in row) for row in matrix]
+obj.saved_nested_byte_array = byte_matrix
+stest.expect_equal(obj.saved_nested_byte_array, byte_matrix)
 
 obj.saved_int24_le = 0xF00F00 #-1044736 in dml
 stest.expect_equal(obj.saved_int24_le, -1044736)

--- a/test/1.4/serialize/T_saved_declaration.py
+++ b/test/1.4/serialize/T_saved_declaration.py
@@ -17,11 +17,19 @@ obj.saved_float = -0.5
 stest.expect_equal(obj.saved_float, -0.5)
 obj.saved_array = [3, 2, 1, 0]
 stest.expect_equal(obj.saved_array, [3, 2, 1, 0])
-obj.saved_char_array = [3, 2, 1, 0]
-stest.expect_equal(obj.saved_char_array, [3, 2, 1, 0])
-# uint8 arrays are serialized as data instead of list
-obj.saved_byte_array = (3, 2, 1, 0)
-stest.expect_equal(obj.saved_byte_array, (3, 2, 1, 0))
+# uint8 arrays are serialized as data instead of list, and can be
+# deserialized through either
+obj.saved_byte_array_via_data = (3, 2, 1, 0)
+stest.expect_equal(obj.saved_byte_array_via_data, (3, 2, 1, 0))
+obj.saved_byte_array_via_list = [3, 2, 1, 0]
+stest.expect_equal(obj.saved_byte_array_via_list, (3, 2, 1, 0))
+# int8 arrays are serialized as list, but can be deserialized
+# either through data or list
+obj.saved_signed_byte_array_via_data = tuple(x & 0xff for x in [1, 0, -1, -2])
+stest.expect_equal(obj.saved_signed_byte_array_via_data, [1, 0, -1, -2])
+obj.saved_signed_byte_array_via_list = [1, 0, -1, -2]
+stest.expect_equal(obj.saved_signed_byte_array_via_list, [1, 0, -1, -2])
+
 obj.saved_struct = [[0, [-1, 2], [3], [-2]], 4]
 stest.expect_equal(obj.saved_struct, [[0, [-1, 2], [3], [-2]], 4])
 
@@ -42,10 +50,19 @@ stest.expect_equal([b.r_f_v for b in obj.bank.b], matrix)
 obj.saved_nested_array = matrix
 stest.expect_equal(obj.saved_nested_array, matrix)
 
-# Only the final dimension of a nested byte array is serialized as data.
+# Only the final dimension of a nested uint8 array is serialized as data,
+# and may be deserialized as data.
 byte_matrix = [tuple(byte & 0xff for byte in row) for row in matrix]
-obj.saved_nested_byte_array = byte_matrix
-stest.expect_equal(obj.saved_nested_byte_array, byte_matrix)
+obj.saved_nested_byte_array_via_data = byte_matrix
+stest.expect_equal(obj.saved_nested_byte_array_via_data, byte_matrix)
+obj.saved_nested_byte_array_via_list = matrix
+stest.expect_equal(obj.saved_nested_byte_array_via_list, byte_matrix)
+
+# Only the final dimension of a nested int8 array may be deserialized as data.
+obj.saved_nested_signed_byte_array_via_data = byte_matrix
+stest.expect_equal(obj.saved_nested_signed_byte_array_via_data, matrix)
+obj.saved_nested_signed_byte_array_via_list = matrix
+stest.expect_equal(obj.saved_nested_signed_byte_array_via_list, matrix)
 
 obj.saved_int24_le = 0xF00F00 #-1044736 in dml
 stest.expect_equal(obj.saved_int24_le, -1044736)


### PR DESCRIPTION
Due to how serializable types work, we can't entirely avoid creating dedicated de/serialization functions for each array type which is implicitly serialized in the program -- however, these functions now simply serve as thin wrappers over calls to _deserialize_array and _serialize_array, which this PR introduces into dmllib.h.

We've discussed revamping the architecture of serialize.py to permit returning set_error_t in the future -- perhaps we could make use of that opportunity to also revamp de/serialization function generation to avoid the generation of these thin wrappers.