### PR TITLE
map_target template

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -257,4 +257,8 @@
       now by default log one <tt>spec-violation</tt> message on log level 1
       on first such write, and no logging on further such writes.
   </add-note></build-id>
+  <build-id value="next"><add-note> Added a
+      template <tt>map_target</tt> which can be used
+      on <tt>connect</tt> objects to expose methods for reading and
+      writing data from/to the connected object.</add-note></build-id>
 </rn>

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -6,6 +6,10 @@
 dml 1.4;
 
 import "simics/devs/signal.dml";
+import "simics/devs/ram.dml";
+import "simics/devs/memory-space.dml";
+import "simics/devs/translator.dml";
+import "simics/model-iface/transaction.dml";
 
 template _reg_or_field {
     param is_register : bool;
@@ -1210,5 +1214,163 @@ template bank_obj is (bank, name) {
     shared method bank_obj() -> (conf_object_t *) {
         // Defer to default implementation
         return _bank_obj();
+    }
+}
+
+/**
+   ## Connect related templates
+
+   ### map\_target
+
+   A `connect` object can instantiate the template `map_target`. The template
+   defines a default implementation of `validate` which verifies that the
+   object can be used to create a map target, i.e. the Simics API
+   `SIM_new_map_target` returns a valid pointer. The template provides a
+   session variable `map_target` of the type `map_target_t *` which can be used
+   to issue transactions to the connected object.
+
+   The template defines the following methods:
+*/
+template map_target is (connect, _qname) {
+    session map_target_t *map_target;
+
+    interface ram { param required = false; }
+    interface rom  { param required = false; }
+    interface io_memory  { param required = false; }
+    interface port_space { param required = false; }
+    interface translator { param required = false; }
+    interface transaction_translator { param required = false; }
+    interface transaction { param required = false; }
+    interface memory_space { param required = false; }
+
+    method validate(conf_object_t *obj) -> (bool) default {
+        if (port) {
+            SIM_attribute_error(
+                "port interfaces are not supported, use port objects instead");
+            return false;
+        }
+        local map_target_t *tmp = SIM_new_map_target(obj, NULL, NULL);
+        if (!tmp) {
+            SIM_clear_exception();
+            SIM_attribute_error(SIM_last_error());
+            return false;
+        }
+        SIM_free_map_target(tmp);
+        return true;
+    }
+
+    method set(conf_object_t *obj) {
+        SIM_free_map_target(this.map_target);
+        default(obj);
+        this.map_target = obj ? SIM_new_map_target(obj, NULL, NULL) : NULL;
+    }
+
+    /**
+       * `read(uint64 addr, uint64 size) -> (uint64) throws`
+
+         Reads `size` bytes starting at `addr` in the connected object. Size
+         must be 8 or less. Throws an exception if the read fails.
+     */
+    shared method read(uint64 addr, uint64 size) -> (uint64) throws {
+        if (size > 8) {
+            log error: "%s.read: size must be less than or equal to 8",
+                _qname();
+            throw;
+        }
+        local uint8 val[size];
+        local atom_t atoms[4] = {
+            ATOM_data(val),
+            ATOM_size(size),
+            ATOM_initiator(dev.obj),
+            ATOM_list_end(0)
+        };
+        local transaction_t t;
+        t.atoms = atoms;
+        if (issue(&t, addr) != Sim_PE_No_Exception)
+            throw;
+        return SIM_get_transaction_value_le(&t);
+    }
+
+    /**
+       * `read_bytes(uint64 addr, uint64 size, uint8 *bytes) throws`
+
+         Reads `size` bytes into `bytes`, starting at `addr` in the connected
+         object. Throws an exception if the read fails.
+    */
+    shared method read_bytes(uint64 addr, uint64 size, uint8 *bytes) throws {
+        local atom_t atoms[4] = {
+            ATOM_data(bytes),
+            ATOM_size(size),
+            ATOM_initiator(dev.obj),
+            ATOM_list_end(0),
+        };
+        local transaction_t t;
+        t.atoms = atoms;
+        if (issue(&t, addr) != Sim_PE_No_Exception)
+            throw;
+    }
+
+    /**
+       * `write(uint64 addr, uint64 size, uint64 value) throws`
+
+         Writes `value` of `size` bytes, starting at `addr` in the connected
+         object. Size must be 8 or less. Throws an exception if the write fails.
+    */
+    shared method write(uint64 addr, uint64 size, uint64 value) throws {
+        if (size > 8) {
+            log error: "%s.write: size must be less than or equal to 8",
+                _qname();
+            throw;
+        }
+        local uint8 buf[size];
+        local atom_t atoms[5] = {
+            ATOM_data(buf),
+            ATOM_size(size),
+            ATOM_flags(Sim_Transaction_Write),
+            ATOM_initiator(dev.obj),
+            ATOM_list_end(0)
+        };
+        local transaction_t t;
+        t.atoms = atoms;
+        SIM_set_transaction_value_le(&t, value);
+        if (issue(&t, addr) != Sim_PE_No_Exception)
+            throw;
+    }
+
+    /**
+       * `write_bytes(uint64 addr, uint64 size, const uint8 *bytes) throws`
+
+         Writes `size` bytes from `bytes`, starting at `addr` in the connected
+         object. Throws an exception if the write fails.
+    */
+    shared method write_bytes(uint64 addr, uint64 size,
+                              const uint8 *bytes) throws {
+        local atom_t atoms[5] = {
+            ATOM_flags(Sim_Transaction_Write),
+            ATOM_data(cast(bytes, uint8 *)),  // we trust Simics not to touch it
+            ATOM_size(size),
+            ATOM_initiator(dev.obj),
+            ATOM_list_end(0),
+        };
+        local transaction_t t;
+        t.atoms = atoms;
+        if (issue(&t, addr) != Sim_PE_No_Exception)
+            throw;
+    }
+
+    /**
+       * `issue(transaction_t *t, uint64 addr) -> (exception_type_t)`
+
+         Provides a shorthand to the API function `SIM_issue_transaction`.
+    */
+    shared method issue(transaction_t *t, uint64 addr) -> (exception_type_t);
+    method issue(transaction_t *t, uint64 addr) -> (exception_type_t) {
+        #if (configuration == "optional") {
+            if (!map_target) {
+                log error: "%s not set, transaction terminated", _qname();
+                return Sim_PE_IO_Not_Taken;
+            }
+        }
+        return SIM_issue_transaction(map_target, t, addr);
     }
 }

--- a/test/1.4/lib/T_map_target_connect.dml
+++ b/test/1.4/lib/T_map_target_connect.dml
@@ -1,0 +1,82 @@
+/*
+  © 2021 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+import "utility.dml";
+import "simics/simulator-api.dml";
+
+import "testing.dml";
+
+template map_target_tester {
+    connect target is map_target;
+
+    saved uint64 address = 123;
+    saved uint64 size = 1;
+
+    attribute value is (pseudo_attr) {
+        param type = "i|n";
+
+        method set(attr_value_t value) throws {
+            target.write(address, size, SIM_attr_integer(value));
+        }
+
+        method get() -> (attr_value_t) {
+            local uint64 val;
+            try
+                val = target.read(address, size);
+            catch
+                return SIM_make_attr_nil();
+            return SIM_make_attr_uint64(val);
+        }
+    }
+
+    attribute data is pseudo_attr {
+        param type = "d|n";
+        method set(attr_value_t value) throws {
+            target.write_bytes(
+                address, SIM_attr_data_size(value), SIM_attr_data(value));
+        }
+
+        method get() -> (attr_value_t) {
+            local uint8 bytes[size];
+            try
+                target.read_bytes(address, size, bytes);
+            catch
+                return SIM_make_attr_nil();
+            return SIM_make_attr_data(size, bytes);
+        }
+    }
+}
+
+group x is map_target_tester;
+group y is map_target_tester {
+    connect target is init_as_subobj {
+        param classname = "set-memory";
+        method init() {
+            default();
+            SIM_set_attribute_default(this.obj, "value",
+                                      SIM_make_attr_uint64(42));
+        }
+    }
+}
+bank z {
+    register r size 8 @ 0x100;
+}
+
+method set_attr(conf_object_t *obj, const char *name,
+                conf_object_t *val) -> (set_error_t) {
+    local attr_value_t attr = SIM_make_attr_object(val);
+    return SIM_set_attribute(obj, name, &attr);
+}
+
+method test() throws {
+    set_attr(obj, x.target.name, y.target.obj);
+    expect(x.target.map_target != NULL, "map_target should not be NULL");
+
+    set_attr(obj, x.target.name, NULL);
+    expect(x.target.map_target == NULL, "map_target should be NULL");
+}

--- a/test/1.4/lib/T_map_target_connect.py
+++ b/test/1.4/lib/T_map_target_connect.py
@@ -1,0 +1,40 @@
+# © 2021 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+import stest
+import simics
+from dev_util import Register_LE
+
+stest.expect_equal(obj.y_value, 42)
+
+obj.x_target = obj.y.target
+stest.expect_equal(obj.x_value, 42)
+
+obj.x_target = None
+with stest.expect_log_mgr(obj):
+    stest.expect_equal(obj.x_value, None)
+with stest.expect_log_mgr(obj):
+    with stest.expect_exception_mgr(simics.SimExc_Attribute):
+        obj.x_value = 3
+
+with stest.expect_exception_mgr(simics.SimExc_Attribute):
+    obj.x_target = obj  # not a valid map target
+
+with stest.expect_exception_mgr(simics.SimExc_Attribute):
+    obj.x_target = [obj, "z"]  # port interface not allowed
+
+r = Register_LE(obj.bank.z, 0x100, 8)
+
+obj.x_target = obj.bank.z
+obj.x_size = 8
+obj.x_address = 0x100
+obj.x_value = 0xaaaaaaaabbbbbbbb
+stest.expect_equal(r.read(), 0xaaaaaaaabbbbbbbb)
+stest.expect_equal(obj.x_value, 0xaaaaaaaabbbbbbbb)
+
+data = tuple((0x12345678abcdef).to_bytes(8, 'little'))
+obj.x_data = data
+stest.expect_equal(r.read(), int.from_bytes(data, 'little'))
+data = tuple(reversed(data))
+r.write(int.from_bytes(data, 'little'))
+stest.expect_equal(obj.x_data, data)


### PR DESCRIPTION
Add map_target template

This template makes the connect represent a Simics `map_target`, which
accepts read and writes to a given address.  This is achieved by the
use of a `map_target_t *` and `SIM_issue_transaction`.
