### PR TITLE
Improvements on const -- SIMICS-9440, SIMICS-10197

### DIFF
--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1700,4 +1700,10 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
       <tt>foreach</tt> statements in DML 1.2 and <tt>#foreach</tt> statements in
       DML 1.4 <bug number="1309451301"/>.
   </add-note></build-id>
+  <build-id value="next"><add-note> (Partially) const-qualified <tt>session</tt>
+      variables no longer result in invalid generated C
+      <bug number="SIMICS-9440"/>.</add-note></build-id>
+  <build-id value="next"><add-note> Implicitly initialized <tt>local</tt>
+      variables of (partially) const-qualified struct type no longer result in
+      invalid generated C <bug number="SIMICS-10197"/>.</add-note></build-id>
 </rn>

--- a/py/dml/clone_test.py
+++ b/py/dml/clone_test.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import dml.types as dt
+import dml.globals
 from dml import ctree
 from dml import logging
 from dml import types
@@ -24,7 +25,8 @@ class TestClone(unittest.TestCase):
                     dt.TTrait(object()),
                     dt.TStruct({"name": types.TInt(32, False)}),
                     dt.TLayout("big-endian", {}),
-                    dt.TFunction([], dt.TVoid())):
+                    dt.TFunction([], dt.TVoid()),
+                    dt.TDevice("a")):
             typ_clone = typ.clone()
             self.assertEqual(
                 types.realtype(typ_clone).cmp(types.realtype(typ)), 0)
@@ -39,6 +41,7 @@ class TestClone(unittest.TestCase):
         self.assertEqual(typ.cmp(typ_clone), 0)
         self.assertEqual(typ_clone.cmp(typ), 0)
         self.assertEqual(typ.const, True)
+        dml.globals.dml_version = (1, 2)
         # types which do not support clone
         with self.assertRaises(logging.ICE):
-            dt.TDevice("a").clone()
+            dt.TUnknown().clone()

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1439,6 +1439,21 @@ class EVLALEN(DMLError):
     """
     fmt = "'.len' cannot be used with variable-length arrays"
 
+class ESAVEDCONST(DMLError):
+    """
+    Declaring a saved variable with a type that is (partially) const-qualified
+    is not allowed, as they can be modified due to checkpoint restoration.
+    """
+    fmt = "saved variable declared with (partially) const-qualified type %s"
+
+class EVLACONST(DMLError):
+    """
+    Variable length arrays may not be declared const-qualified or with a base
+    type that is (partially) const-qualified.
+    """
+    fmt = ("variable length array declared with (partially) const-qualified "
+           + "type")
+
 #
 # WARNINGS (keep these as few as possible)
 #

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -763,6 +763,8 @@ def mksaved(spec, parent):
     (struct_defs, dtype) = eval_type(typ, site, parent_scope, global_scope)
     TStruct.late_global_struct_defs.extend(struct_defs)
     dtype.resolve()
+    if deep_const(dtype):
+        raise ESAVEDCONST(site, dtype)
     obj = objects.Saved(name, dtype, astinit, site, parent)
     if astinit:
         dml.globals.device.add_init_data(obj)

--- a/test/1.2/errors/T_ECONST.dml
+++ b/test/1.2/errors/T_ECONST.dml
@@ -16,8 +16,13 @@ method init() {
     foo = 5;
 
     local a_t x;
+    local a_t y;
+    // no error
+    x.a = 4;
     /// ERROR ECONST
     x.c = 4;
+    /// ERROR ECONST
+    x = y;
 
     {
         local const a_t *p = &x;
@@ -38,7 +43,7 @@ method init() {
     }
 
     // bug 24069
-    local const_int_t y;
+    local const_int_t z;
     /// ERROR ECONST
-    y = 3;
+    z = 3;
 }

--- a/test/1.2/errors/T_EVLACONST.dml
+++ b/test/1.2/errors/T_EVLACONST.dml
@@ -1,0 +1,43 @@
+/*
+  © 2022 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.2;
+device test;
+
+extern int nc;
+
+typedef struct {
+    struct {
+        const int y;
+    } x[4];
+} s_t;
+
+typedef layout "little-endian" {
+    layout "little-endian" {
+        const int32 y;
+    } x[4];
+} lo_t;
+
+method init() {
+    // no error
+    local int a[nc];
+    /// ERROR EVLACONST
+    local const int b[nc];
+    /// ERROR EVLACONST
+    local const typeof(a) c;
+    // no error
+    local const int *d[nc];
+
+    /// ERROR EVLACONST
+    local s_t e[nc];
+    /// ERROR EVLACONST
+    local lo_t f[nc];
+
+    // no error
+    local const int h[4];
+    local const typeof(h) i;
+    local s_t j[4];
+    local lo_t k[4];
+}
+

--- a/test/1.2/misc/T_init_data.dml
+++ b/test/1.2/misc/T_init_data.dml
@@ -7,7 +7,9 @@ device test;
 import "testing.dml";
 
 data int simple_int = 17;
+data const int const_int = 17;
 data int simple_array[4] = {0, 256, 128, 4096};
+data const int const_array[4] = {0, 256, 128, 4096};
 data int d2_array[2][4] = {
     {1, 2, 3, 4},
     {5, 6, 7, 8}
@@ -21,6 +23,12 @@ struct simple_struct_t {
     bool b;
 }
 data simple_struct_t simple_struct = {42, true};
+
+struct const_struct_t {
+    int i;
+    const bool b;
+}
+data const_struct_t const_struct = {42, true};
 
 struct a_struct_t {
     int i;
@@ -51,11 +59,24 @@ method test -> (bool ok) {
     if (!ok)
         return;
 
+    // const scalar
+    ok = $const_int == 17;
+    if (!ok)
+        return;
+
     // simple array
     ok = $simple_array[0] == 0
       && $simple_array[1] == 256
       && $simple_array[2] == 128
       && $simple_array[3] == 4096;
+    if (!ok)
+        return;
+
+    // const array
+    ok = $const_array[0] == 0
+      && $const_array[1] == 256
+      && $const_array[2] == 128
+      && $const_array[3] == 4096;
     if (!ok)
         return;
 
@@ -78,9 +99,16 @@ method test -> (bool ok) {
       && $str_array[1][1] == 0x0;
     if (!ok)
         return;
-    
+
     // simple struct
     ok = $simple_struct.i == 42 && $simple_struct.b == true;
+    if (!ok)
+        return;
+
+    // const struct
+    ok = $const_struct.i == 42 && $const_struct.b == true;
+    $const_struct.i = -24;
+    ok = $const_struct.i == -24 && $const_struct.b == true;
     if (!ok)
         return;
 

--- a/test/1.2/statements/T_local_const_struct.dml
+++ b/test/1.2/statements/T_local_const_struct.dml
@@ -6,6 +6,5 @@ dml 1.2;
 device test;
 /// COMPILE-ONLY
 method init() {
-    // CC fails, bug 25248
     local const struct { int i; } x;
 }

--- a/test/1.4/errors/T_ESAVEDCONST.dml
+++ b/test/1.4/errors/T_ESAVEDCONST.dml
@@ -1,0 +1,39 @@
+/*
+  © 2022 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+
+typedef struct {
+    struct {
+        const int y;
+    } x[4];
+} s_t;
+
+typedef layout "little-endian" {
+    layout "little-endian" {
+        const int32 y;
+    } x[4];
+} lo_t;
+
+// no error
+saved int a;
+
+/// ERROR ESAVEDCONST
+saved const int b;
+
+/// ERROR ESAVEDCONST
+saved const int c[4];
+
+/// ERROR ESAVEDCONST
+saved s_t d;
+
+/// ERROR ESAVEDCONST
+saved lo_t e;
+
+// no error
+session const int g;
+session const int h[4];
+session s_t i;
+session lo_t j;

--- a/test/XFAIL
+++ b/test/XFAIL
@@ -54,9 +54,6 @@
 # bug 25244
 1.2/errors/ETREC_layout
 
-# bug 25248
-1.2/statements/local_const_struct
-
 # bug 7099
 1.2/methods/inline_array
 


### PR DESCRIPTION
This PR makes DML perform more thorough checks to confirm that assignments aren't done to const-qualified targets. It also rejects (partially) const-qualified VLAs or saved variables. Code generation for various initializers have been rewritten to avoid GCC errors when the destination is (partially) const-qualified, in order to allow for initialization of const-qualified session variables to codegen correctly.