### PR TITLE
Add logging on map-target access

### DIFF
--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1371,6 +1371,12 @@ template map_target is (connect, _qname) {
                 return Sim_PE_IO_Not_Taken;
             }
         }
-        return SIM_issue_transaction(map_target, t, addr);
+        local exception_type_t exc = SIM_issue_transaction(map_target, t, addr);
+        local bool fail = exc != Sim_PE_No_Exception;
+        log info, (fail ? 2 : 4) : "%s%s %d bytes @ 0x%x in %s",
+            fail ? "failed to " : "",
+            SIM_transaction_is_read(t) ? "read" : fail ? "write" : "wrote",
+            SIM_transaction_size(t), addr, SIM_object_name(obj);
+        return exc;
     }
 }

--- a/test/1.4/lib/T_map_target_connect.py
+++ b/test/1.4/lib/T_map_target_connect.py
@@ -4,6 +4,7 @@
 import stest
 import simics
 from dev_util import Register_LE
+import re
 
 stest.expect_equal(obj.y_value, 42)
 
@@ -11,9 +12,9 @@ obj.x_target = obj.y.target
 stest.expect_equal(obj.x_value, 42)
 
 obj.x_target = None
-with stest.expect_log_mgr(obj):
+with stest.expect_log_mgr(obj, regex="not set"):
     stest.expect_equal(obj.x_value, None)
-with stest.expect_log_mgr(obj):
+with stest.expect_log_mgr(obj, regex="not set"):
     with stest.expect_exception_mgr(simics.SimExc_Attribute):
         obj.x_value = 3
 
@@ -38,3 +39,25 @@ stest.expect_equal(r.read(), int.from_bytes(data, 'little'))
 data = tuple(reversed(data))
 r.write(int.from_bytes(data, 'little'))
 stest.expect_equal(obj.x_data, data)
+
+obj.log_level = 4
+rex = re.compile("^read 8 bytes @ 0x100")
+with stest.expect_log_mgr(obj, log_type="info", regex=rex):
+    _ = obj.x_value
+
+rex = re.compile("^wrote 8 bytes @ 0x100")
+with stest.expect_log_mgr(obj, log_type="info", regex=rex):
+    obj.x_value = 42
+
+obj.x_address = 0
+obj.log_level = 2
+with stest.expect_log_mgr(obj, log_type="spec-viol"):
+    rex = re.compile("^failed to read 8 bytes @ 0x0")
+    with stest.expect_log_mgr(obj, log_type="info", regex=rex):
+        _ = obj.x_value
+
+    rex = re.compile("^failed to write 8 bytes @ 0x0")
+    with stest.expect_exception_mgr(simics.SimExc_Attribute):
+        with stest.expect_log_mgr(obj, log_type="info", regex=rex):
+            obj.x_value = 42
+


### PR DESCRIPTION
Log on level 2 if access fails, level 4 otherwise
