### PR TITLE
If the preferred GCC path does not exist on Linux, fall back

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ files.
 ### DMLC_DEBUG
 When set to `1`, unexpected exceptions in the compiler are echoed to
 stderr. The default is to hide tracebacks in a file `dmlc-error.log`.
+
+### DMLC_CC
+Override the default compiler in unit tests.

--- a/test/tests.py
+++ b/test/tests.py
@@ -95,10 +95,10 @@ if is_windows():
     if not cc:
         try:
             cc = testparams.mingw_cc()
-            cc_not_found = not os.path.exists(cc)
+            cc_found = os.path.exists(cc)
         except Exception:
-            cc_not_found = True
-        if cc_not_found:
+            cc_found = False
+        if not cc_found:
             raise TestFail('gcc not found(specify gcc by env var DMLC_CC)')
         ldflags = [f"-L{testparams.mingw_root()}/lib/gcc/x86_64-w64-mingw32/lib"]
     else:

--- a/test/tests.py
+++ b/test/tests.py
@@ -90,29 +90,29 @@ def dmlc_reaper_args(exitcode_file, timeout_multiplier = 1):
 
 common_cflags = ["-O2", "-std=gnu99", '-Wall', '-Werror', '-Wpointer-arith',
                  '-Wwrite-strings', '-Wformat-nonliteral',]
-cc = [os.environ.get('DMLC_CC')]
+cc = os.environ.get('DMLC_CC')
 if is_windows():
-    if not cc[0]:
+    if not cc:
         try:
-            cc = [testparams.mingw_cc()]
-            cc_not_found = not os.path.exists(cc[0])
-        except FileNotFoundError:
+            cc = testparams.mingw_cc()
+            cc_not_found = not os.path.exists(cc)
+        except Exception:
             cc_not_found = True
         if cc_not_found:
             raise TestFail('gcc not found(specify gcc by env var DMLC_CC)')
-    cflags = common_cflags + [
-        "-DUSE_MODULE_HOST_CONFIG", "-D__USE_MINGW_ANSI_STDIO=1"]
-    if not cc[0]:
         ldflags = [f"-L{testparams.mingw_root()}/lib/gcc/x86_64-w64-mingw32/lib"]
     else:
         ldflags = []
+    cflags = common_cflags + [
+        "-DUSE_MODULE_HOST_CONFIG", "-D__USE_MINGW_ANSI_STDIO=1"]
 else:
-    if not cc[0]:
-        cc = [join(package_path(), "gcc_6.4.0", "bin", "gcc")]
-        if not os.path.exists(cc[0]):
+    if not cc:
+        cc = join(package_path(), "gcc_6.4.0", "bin", "gcc")
+        if not os.path.exists(cc):
             raise TestFail('gcc not found(specify gcc by env var DMLC_CC)')
     cflags = ['-g', '-fPIC', '-Wundef'] + common_cflags
     ldflags = []
+cc = [cc]
 cflags_shared = ["-shared"]
 
 os.environ['DMLC_DEBUG'] = 't'

--- a/test/tests.py
+++ b/test/tests.py
@@ -90,21 +90,29 @@ def dmlc_reaper_args(exitcode_file, timeout_multiplier = 1):
 
 common_cflags = ["-O2", "-std=gnu99", '-Wall', '-Werror', '-Wpointer-arith',
                  '-Wwrite-strings', '-Wformat-nonliteral',]
+cc = [os.environ.get('DMLC_CC')]
 if is_windows():
-    dmlc_default_cc = testparams.mingw_cc()
+    if not cc[0]:
+        try:
+            cc = [testparams.mingw_cc()]
+            cc_not_found = not os.path.exists(cc[0])
+        except FileNotFoundError:
+            cc_not_found = True
+        if cc_not_found:
+            raise TestFail('gcc not found(specify gcc by env var DMLC_CC)')
     cflags = common_cflags + [
         "-DUSE_MODULE_HOST_CONFIG", "-D__USE_MINGW_ANSI_STDIO=1"]
-    ldflags = [f"-L{testparams.mingw_root()}/lib/gcc/x86_64-w64-mingw32/lib"]
+    if not cc[0]:
+        ldflags = [f"-L{testparams.mingw_root()}/lib/gcc/x86_64-w64-mingw32/lib"]
+    else:
+        ldflags = []
 else:
-    dmlc_default_cc = join(package_path(), "gcc_6.4.0", "bin", "gcc")
+    if not cc[0]:
+        cc = [join(package_path(), "gcc_6.4.0", "bin", "gcc")]
+        if not os.path.exists(cc[0]):
+            raise TestFail('gcc not found(specify gcc by env var DMLC_CC)')
     cflags = ['-g', '-fPIC', '-Wundef'] + common_cflags
     ldflags = []
-if os.environ.get('DMLC_CC'):
-    cc = [os.environ.get('DMLC_CC')]
-elif os.path.exists(dmlc_default_cc):
-    cc = [dmlc_default_cc]
-else:
-    raise TestFail('gcc not found(specify gcc by env var DMLC_CC)')
 cflags_shared = ["-shared"]
 
 os.environ['DMLC_DEBUG'] = 't'

--- a/test/tests.py
+++ b/test/tests.py
@@ -92,6 +92,9 @@ if is_windows():
     ldflags = [f"-L{testparams.mingw_root()}/lib/gcc/x86_64-w64-mingw32/lib"]
 else:
     cc = [join(package_path(), "gcc_6.4.0", "bin", "gcc")]
+    if not os.path.exists(cc[0]):
+        # If the preferred path does not exist, fall back
+        cc = ["gcc"]
     cflags = ['-g', '-fPIC', '-Wundef'] + common_cflags
     ldflags = []
 cflags_shared = ["-shared"]


### PR DESCRIPTION
If build-deps does not exist, use the default path of GCC. 

Otherwise, a lot of unit tests would end up with the following error message:

FileNotFoundError: [Errno 2] No such file or directory: '/nfs/simics/build-deps/linux64/6.18/packages/gcc_6.4.0/bin/gcc': '/nfs/simics/build-deps/linux64/6.18/packages/gcc_6.4.0/bin/gcc'