### PR TITLE
Allocate trait vtable instances on the heap -- quick-fix for SIMICS-18498, SIMICS-18640, SIMICS-18596

### DIFF
--- a/include/simics/dmllib.h
+++ b/include/simics/dmllib.h
@@ -601,10 +601,12 @@ _identity_eq(const _identity_t a, const _identity_t b) {
 
 // List of vtables of a specific trait in one specific object
 typedef struct {
-        // first trait vtable instance. Instances are stored linearly in a
-        // possibly multi-dimensional array, with outer index corresponding to
-        // index of outer DML object.
-        uintptr_t base;
+        // *base + base_offset is the pointer to the first trait vtable
+        // instance. Instances are stored linearly in a possibly
+        // multi-dimensional array, with outer index corresponding to index of
+        // outer DML object.
+        uintptr_t *base;
+        uint64 base_offset;
         // total number of elements (product of object's dimsizes)
         uint64 num;
         // offset between two vtable instances; at least sizeof(<vtable type>)

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -1910,7 +1910,8 @@ def foreach_each_in(site, itername, trait, each_in,
     inner_scope = Symtab(scope)
     trait_type = TTrait(trait)
     trait_ptr = (f'(struct _{cident(trait.name)} *) '
-                 + '(_list.base + _inner_idx * _list.offset)')
+                 + '(*_list.base + _list.base_offset + _inner_idx '
+                 + '* _list.offset)')
     obj_ref = '(_identity_t) { .id = _list.id, .encoded_index = _inner_idx}'
     inner_scope.add_variable(
         itername, type=trait_type,

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -3195,7 +3195,8 @@ class ObjTraitRef(Expression):
             indices = tuple(mkLit(self.site, '__indices[%d]' % (i,),
                                   TInt(32, False))
                             for i in range(self.node.dimensions))
-        structref = (self.node.traits.vtable_cname(self.ancestry_path[0])
+        vtable_name = self.node.traits.vtable_cname(self.ancestry_path[0])
+        structref = (f'(*{vtable_name})'
                      + ''.join('[%s]' % (i.read(),) for i in indices))
         pointer = '(&%s)' % ('.'.join([structref] + [
             cident(t.name) for t in self.ancestry_path[1:]]))

--- a/py/dml/traits_test.py
+++ b/py/dml/traits_test.py
@@ -32,7 +32,7 @@ class Test_traits(unittest.TestCase):
             dml.ctree.mkCast(
                 self.site, dml.ctree.mkNodeRef(self.site, self.dev, ()),
                 t.type()).read(),
-            '((t) {(&_tr__dev__t), '
+            '((t) {(&(*_tr__dev__t)), '
             + '((_identity_t) {.id = 0, .encoded_index = 0})})'
             )
 


### PR DESCRIPTION
SSM has encountered issues multiple times relating to .bss being too large due to large arrays of trait vtable instances. Properly addressing this issue requires optimizing the generation and use of vtables such that vtable arrays will no longer be necessary, but the difficulty of implementing that solution justifies implementing a simpler fix in the meantime -- simply allocate trait vtable instances on the heap.

I'm unsure if t126 exhaustively covers every case this change would affect, so this should probably be tested against VP.