### PR TITLE
vtable array optimizations (branch "pr/rename-crep")

### DIFF
--- a/include/simics/dmllib.h
+++ b/include/simics/dmllib.h
@@ -205,6 +205,10 @@ DML_eq(uint64 a, uint64 b)
                    __tref.id.encoded_index]                                  \
            : *(typeof(((vtable_type*)NULL)->member))__member; })
 
+#define VTABLE_SESSION(dev, traitref, vtable_type, member, var_type)    \
+      ({_traitref_t __tref = traitref;                                  \
+        (var_type)((uintptr_t)dev + ((vtable_type *)__tref.trait)->member) \
+           + __tref.id.encoded_index; })
 
 #define _raw_load_uint8_be_t   UNALIGNED_LOAD_BE8
 #define _raw_load_uint16_be_t  UNALIGNED_LOAD_BE16

--- a/include/simics/dmllib.h
+++ b/include/simics/dmllib.h
@@ -1051,14 +1051,10 @@ _deserialize_simple_event_data(
 
 // List of vtables of a specific trait in one specific object
 typedef struct {
-        // first trait vtable instance. Instances are stored linearly in a
-        // possibly multi-dimensional array, with outer index corresponding to
-        // index of outer DML object.
-        uintptr_t base;
+        // trait vtable instance
+        void *vtable;
         // total number of elements (product of object's dimsizes)
-        uint64 num;
-        // offset between two vtable instances; at least sizeof(<vtable type>)
-        uint32 offset;
+        uint32 num;
         // The unique object id
         uint32 id;
 } _vtable_list_t;

--- a/include/simics/dmllib.h
+++ b/include/simics/dmllib.h
@@ -1047,12 +1047,10 @@ _deserialize_simple_event_data(
 
 // List of vtables of a specific trait in one specific object
 typedef struct {
-        // *base + base_offset is the pointer to the first trait vtable
-        // instance. Instances are stored linearly in a possibly
-        // multi-dimensional array, with outer index corresponding to index of
-        // outer DML object.
-        uintptr_t *base;
-        uint64 base_offset;
+        // first trait vtable instance. Instances are stored linearly in a
+        // possibly multi-dimensional array, with outer index corresponding to
+        // index of outer DML object.
+        uintptr_t base;
         // total number of elements (product of object's dimsizes)
         uint64 num;
         // offset between two vtable instances; at least sizeof(<vtable type>)

--- a/include/simics/dmllib.h
+++ b/include/simics/dmllib.h
@@ -189,6 +189,10 @@ DML_eq(uint64 a, uint64 b)
     ({_traitref_t __tref = traitref;                                    \
       ((struct _ ## type *) __tref.trait)->method(__tref);})
 
+#define VTABLE_PARAM(traitref, vtable_type, member)                        \
+        ({_traitref_t __tref = traitref;                                   \
+         ((vtable_type *)__tref.trait)->member[__tref.id.encoded_index];})
+
 #define _raw_load_uint8_be_t   UNALIGNED_LOAD_BE8
 #define _raw_load_uint16_be_t  UNALIGNED_LOAD_BE16
 #define _raw_load_uint32_be_t  UNALIGNED_LOAD_BE32

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -785,9 +785,9 @@ def generate_implement_method(device, ifacestruct, meth, indices):
                             mt, '<return value>', ifacemethtype.output_type,
                             'method')
         if indices is PORTOBJ:
-            name = '_DML_PIFACE_' + crep.cref(meth)
+            name = '_DML_PIFACE_' + crep.cref_method(meth)
         else:
-            name = '_DML_IFACE_' + crep.cref(meth) + "".join([
+            name = '_DML_IFACE_' + crep.cref_method(meth) + "".join([
                 "__%d" % idx for idx in indices])
 
         wrap_method(meth, name, indices)
@@ -1114,7 +1114,7 @@ def event_callbacks(event, indices):
         if not method:
             raise ICE(event.site, 'cannot find method %s' % (method_name))
         result.append((method, '_DML_EV_%s%s' % (
-            crep.cref(method),
+            crep.cref_method(method),
             '_'.join(str(i) for i in indices))))
     return result
 
@@ -1201,15 +1201,15 @@ def generate_register_tables(device):
             dims = r.dimsizes or []
             getter = r.node.get_component('_get64')
             setter = r.node.get_component('_set64')
-            generate_reg_callback(getter, '_DML_MI_%s' % crep.cref(getter),
+            generate_reg_callback(getter, '_DML_MI_%s' % crep.cref_method(getter),
                                   )
-            generate_reg_callback(setter, '_DML_MI_%s' % crep.cref(setter))
+            generate_reg_callback(setter, '_DML_MI_%s' % crep.cref_method(setter))
             name = r.node.logname_anonymized(tuple("" for _ in dims),
                                              relative='bank')
             regs.append((name,
                          len(dims),
-                         '_DML_MI_%s' % crep.cref(getter),
-                         '_DML_MI_%s' % crep.cref(setter)))
+                         '_DML_MI_%s' % crep.cref_method(getter),
+                         '_DML_MI_%s' % crep.cref_method(setter)))
             mark_method_referenced(method_instance(getter))
             mark_method_referenced(method_instance(setter))
             regidxs[r] = i
@@ -2058,7 +2058,7 @@ fields.
 
 def trait_trampoline_name(method, vtable_trait):
     return "%s__trampoline_from_%s" % (
-        crep.cref(method), vtable_trait.name)
+        crep.cref_method(method), vtable_trait.name)
 
 def flatten_object_subtree(node):
     '''return a list of all composite subobjects inside node'''

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -2101,7 +2101,10 @@ def init_trait_vtables_for_node(node, param_values, dims, parent_indices):
                     assert session_node.objtype in ('session', 'saved')
                     args.append('offsetof(%s, %s)' % (
                         crep.structtype(dml.globals.device),
-                        crep.cref_session(session_node, indices)))
+                        crep.cref_session(
+                            session_node,
+                            (mkIntegerConstant(node.site, 0, False),)
+                            * len(indices))))
             # initialize vtable instance
             vtable_arg = '&%s%s' % (node.traits.vtable_cname(trait), index_str)
             init_calls.append(

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -2041,7 +2041,7 @@ fields.
             out(', %s' % (mtype.declaration(scrambled_name),))
         elif member_kind == 'parameter':
             (site, typ) = vtable_trait.vtable_params[name]
-            out(', %s' % (typ.declaration(scrambled_name)))
+            out(', %s' % (TPtr(typ).declaration(scrambled_name)))
         else:
             assert member_kind == 'session'
             out(', uint32 %s' % (scrambled_name))
@@ -2085,6 +2085,9 @@ def init_trait_vtables_for_node(node, param_values, dims, parent_indices):
         param_overrides = param_values[node]
         for trait in node.traits.referenced:
             args = []
+            param_decl = []
+            param_init = []
+            param_indices = ''.join(f'[_i{i}]' for i in range(node.dimensions))
             for name in tinit_args(trait):
                 member_kind = trait.member_kind(name)
                 if member_kind == 'method':
@@ -2094,7 +2097,17 @@ def init_trait_vtables_for_node(node, param_values, dims, parent_indices):
                         if name in method_overrides else "NULL")
                 elif member_kind == 'parameter':
                     # param_overrides contains C expression strings
-                    args.append(param_overrides[name])
+                    (value, t) = param_overrides[name]
+                    var = f'_param_{name}'
+                    args.append(f'{var}' + '[0]' * node.dimensions)
+                    array_type = t
+                    for d in reversed(node.dimsizes):
+                        array_type = TArray(array_type,
+                                            mkIntegerLiteral(node.site, d))
+                    param_decl.append(f'''\
+{TPtr(array_type).declaration(var)} = MM_MALLOC(1, typeof(*{var}));
+''')
+                    param_init.append(f'(*{var}){param_indices} = {value};')
                 else:
                     assert member_kind == 'session'
                     session_node = node.get_component(name)
@@ -2107,9 +2120,26 @@ def init_trait_vtables_for_node(node, param_values, dims, parent_indices):
                             * len(indices))))
             # initialize vtable instance
             vtable_arg = '&%s%s' % (node.traits.vtable_cname(trait), index_str)
-            init_calls.append(
-                (dims, '_tinit_%s(%s);\n'
-                 % (trait.name, ', '.join([vtable_arg] + args))))
+            init_call = ('_tinit_%s(%s);\n'
+                 % (trait.name, ', '.join([vtable_arg] + args)))
+
+            if param_init:
+                code = param_decl
+                close = []
+                for (i, d) in enumerate(node.dimsizes):
+                    indent = '    ' * i
+                    code.append(
+                        indent + f'for (unsigned _i{i} = 0; _i{i} < {d}; ++_i{i}) {{')
+                    close.append(indent + '}')
+                code.extend('    ' * node.dimensions + init
+                            for init in param_init)
+                code.extend(reversed(close))
+                code.append(init_call)
+                code = ['{'] + ['    ' + line for line in code] + ['}']
+            else:
+                assert not param_decl
+                code = [init_call]
+            init_calls.append((dims, ''.join(f'{line}\n' for line in code)))
     for subnode in node.get_components():
         if isinstance(subnode, objects.CompositeObject):
             init_calls.extend(init_trait_vtables_for_node(
@@ -2472,11 +2502,12 @@ def trait_param_value(node, param_type_site, param_type):
                   for dim in range(node.dimensions)))
         if isinstance(expr, NonValue):
             raise expr.exc()
-        return source_for_assignment(expr.site, param_type, expr).read()
+        return (source_for_assignment(expr.site, param_type, expr).read(),
+                param_type)
 
     except DMLError as e:
         report(e)
-        return "0"
+        return ("0", param_type)
 
 def resolve_trait_param_values(node):
     '''Generate code for parameter initialization of all traits

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -1717,7 +1717,6 @@ def generate_init(device, initcode, outprefix):
             ');\n')
         out('}\n', preindent = -1)
 
-    out('_allocate_traits();\n')
     out('_initialize_traits();\n')
     out('_initialize_identity_ht();\n')
     out('_register_events(class);\n')
@@ -1806,16 +1805,16 @@ def generate_each_in_table(node, trait, subnodes):
         # vtables exist, because trait instances are marked referenced
         # when an 'each in' instance is referenced
         ancestry_path = sub.traits.ancestry_paths[trait][0]
-        base = '&%s' % (sub.traits.vtable_cname(ancestry_path[0]),)
-        base_offset = ('offsetof(struct _%s, %s)'
-                       % (cident(ancestry_path[0].name),
-                          '.'.join(cident(t.name) for t in ancestry_path[1:]))
-                       if len(ancestry_path) > 1 else '0')
+        base = '&%s%s%s' % (
+            sub.traits.vtable_cname(ancestry_path[0]),
+            '[0]' * sub.dimensions,
+            ''.join('.' + cident(t.name)
+                    for t in ancestry_path[1:]))
         num = reduce(operator.mul, sub.dimsizes, 1)
         uniq = sub.uniq
         offset = 'sizeof(struct _%s)' % (cident(ancestry_path[0].name),)
-        items.append("{(uintptr_t *)%s, %s, %d, %s, %d}\n"
-                     % (base, base_offset, num, offset, uniq))
+        items.append("{(uintptr_t)%s, %d, %s, %d}\n"
+                     % (base, num, offset, uniq))
     init = '{\n%s}' % (',\n'.join('    %s' % (item,) for item in items),)
     add_variable_declaration(
         'const _vtable_list_t %s[%d]' % (ident, len(subnodes)), init)
@@ -2104,9 +2103,7 @@ def init_trait_vtables_for_node(node, param_values, dims, parent_indices):
                         crep.structtype(dml.globals.device),
                         crep.cref_session(session_node, indices)))
             # initialize vtable instance
-            vtable_name = node.traits.vtable_cname(trait)
-            vtable_arg = (f'&(*{vtable_name}){index_str}'
-                          if index_str else vtable_name)
+            vtable_arg = '&%s%s' % (node.traits.vtable_cname(trait), index_str)
             init_calls.append(
                 (dims, '_tinit_%s(%s);\n'
                  % (trait.name, ', '.join([vtable_arg] + args))))
@@ -2144,10 +2141,9 @@ def generate_trait_trampoline(method, vtable_trait):
                 downcast = 'DOWNCAST(%s, %s, %s)' % (
                     tname, cident(path[0].name),
                     '.'.join(cident(t.name) for t in path[1:]))
-            name = cident(path[0].name)
-            out(('int _flat_index = ((struct _%s *)%s.trait) '
-                 + '- (struct _%s *)%s;\n')
-                % (name, downcast, name, obj.traits.vtable_cname(path[0])))
+            out('int _flat_index = ((struct _%s *)%s.trait) - &%s%s;\n' % (
+                cident(path[0].name), downcast, obj.traits.vtable_cname(path[0]),
+                '[0]' * obj.dimensions))
         indices = [
             mkLit(site, '((_flat_index / %d) %% %d)' % (
                 reduce(operator.mul, obj.dimsizes[dim + 1:], 1),
@@ -2178,8 +2174,8 @@ def generate_vtable_instances(devnode):
         if subnode.traits:
             for trait in subnode.traits.referenced:
                 add_variable_declaration(
-                    'struct _%s (*%s)%s'
-                    % (cident(trait.name), subnode.traits.vtable_cname(trait),
+                    'struct _%s %s%s'
+                     % (cident(trait.name), subnode.traits.vtable_cname(trait),
                        ''.join('[%d]' % i for i in subnode.dimsizes)))
 
 def calculate_saved_userdata(node, dimsizes, attr_name, sym_spec = None):
@@ -2313,17 +2309,6 @@ def register_saved_attributes(initcode, node):
                  postindent = -1)
     initcode.out('}\n', preindent=-1)
     initcode.out('}\n', preindent=-1)
-
-def generate_alloc_trait_vtables(node):
-    start_function_definition('void _allocate_traits(void)')
-    out('{\n', postindent=1)
-    for subnode in flatten_object_subtree(node):
-        if subnode.traits:
-            for trait in subnode.traits.referenced:
-                name = subnode.traits.vtable_cname(trait)
-                out(f'{name} = MM_ZALLOC(1, typeof(*{name}));\n')
-    out('}\n', preindent=-1)
-    splitting_point()
 
 def generate_startup_call_loops(startup_methods):
     by_dims = {}
@@ -2677,7 +2662,6 @@ def generate_cfile_body(device, footers, full_module, filename_prefix):
         register_saved_attributes(init_code, device)
         generate_init(device, init_code, filename_prefix)
 
-    generate_alloc_trait_vtables(device)
     generate_init_trait_vtables(device, trait_param_values)
     for ((node, trait), subobjs) in list(EachIn.instances.items()):
         generate_each_in_table(node, trait, subobjs)

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -2133,17 +2133,8 @@ def generate_trait_trampoline(method, vtable_trait):
         [(tname, ttype)] = implicit_inargs
         site = method.site
         obj = method.parent
-        path = obj.traits.ancestry_paths[vtable_trait][0]
         if obj.dimensions:
-            if path[0] is vtable_trait:
-                downcast = tname
-            else:
-                downcast = 'DOWNCAST(%s, %s, %s)' % (
-                    tname, cident(path[0].name),
-                    '.'.join(cident(t.name) for t in path[1:]))
-            out('int _flat_index = ((struct _%s *)%s.trait) - &%s%s;\n' % (
-                cident(path[0].name), downcast, obj.traits.vtable_cname(path[0]),
-                '[0]' * obj.dimensions))
+            out(f'int _flat_index = {tname}.id.encoded_index;\n')
         indices = [
             mkLit(site, '((_flat_index / %d) %% %d)' % (
                 reduce(operator.mul, obj.dimsizes[dim + 1:], 1),

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -2092,8 +2092,14 @@ def init_trait_vtables_for_node(node, param_values):
                         param_decl.append(
                             f'{TPtr(array_type).declaration(var)} = malloc('
                             f'sizeof(*{var}));\n')
-                        param_init.append(
-                            f'(*{var}){param_indices} = {value};\n')
+                        if deep_const(t):
+                            k = TArray(t, mkIntegerLiteral(node.site, 1)).declaration("")
+                            param_init.append(
+                                f' memcpy(&(*{var}){param_indices},'
+                                f' ({k}){{{value}}}, sizeof({t.declaration("")}));\n')
+                        else:
+                            param_init.append(
+                                f'(*{var}){param_indices} = {value};\n')
                     else:
                         # Reasons for alignment explained along with test
                         # in 1.4/structure/T_trait.dml

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -2022,7 +2022,7 @@ fields.
             parent.name, ", ".join(['&_ret->' + cident(parent.name)]
                                    + args)))
 
-    out('static void\n')
+    out('static void __attribute__((optimize("O0")))\n')
     out('_tinit_%s(struct _%s *_ret' % (trait.name,
                                         cident(trait.name)))
     inargs = tinit_args(trait)
@@ -2437,7 +2437,8 @@ def generate_init_trait_vtables(node, param_values):
     # where optimum chunk size seems to be between 10 and 100.
     chunks = [init_blocks[n:n+20] for n in range(0, len(init_blocks), 20)]
     for (i, blocks) in enumerate(chunks):
-        out(f'static void _initialize_traits{i}(void) {{\n', postindent=1)
+        out('static void __attribute__((optimize("O0")))'
+            f' _initialize_traits{i}(void) {{\n', postindent=1)
         for block in blocks:
             out(block)
         out('}\n', preindent=-1)

--- a/py/dml/clone_test.py
+++ b/py/dml/clone_test.py
@@ -35,12 +35,11 @@ class TestClone(unittest.TestCase):
             typ_clone.const = True
             self.assertEqual(typ.const, False)
         # special case for TraitList, because realtype requires global
-        # state (typedefs) and always has const=True
+        # state (typedefs)
         typ = dt.TTraitList("a")
         typ_clone = typ.clone()
         self.assertEqual(typ.cmp(typ_clone), 0)
         self.assertEqual(typ_clone.cmp(typ), 0)
-        self.assertEqual(typ.const, True)
         dml.globals.dml_version = (1, 2)
         # types which do not support clone
         with self.assertRaises(logging.ICE):

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -347,7 +347,8 @@ class SharedIndependentMemoized(Memoization):
         traitname = cident(self.method.trait.name)
         return mkLit(self.method.site,
                      f'((struct _{traitname} *) _{traitname}.trait)'
-                     + f'->_{self.method.name}_outs.{ref}', typ)
+                     + f'->_memo_outs_{self.method.name}'
+                     + f'[_{traitname}.id.encoded_index].{ref}', typ)
     def prelude(self):
         return memoization_common_prelude(
             self.method.name, self.method.site, self.method.outp,

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -2868,7 +2868,7 @@ class MethodFunc(object):
         return name
 
     def get_cname(self):
-        base = crep.cref(self.method)
+        base = crep.cref_method(self.method)
         return '_DML_M_' + base + self.suffix
 
 def canonicalize_signature(signature):

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -2235,8 +2235,7 @@ def foreach_each_in(site, itername, trait, each_in,
     inner_scope = Symtab(scope)
     trait_type = TTrait(trait)
     trait_ptr = (f'(struct _{cident(trait.name)} *) '
-                 + '(*_list.base + _list.base_offset + _inner_idx '
-                 + '* _list.offset)')
+                 + '(_list.base + _inner_idx * _list.offset)')
     obj_ref = '(_identity_t) { .id = _list.id, .encoded_index = _inner_idx}'
     inner_scope.add_variable(
         itername, type=trait_type,

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -2250,14 +2250,15 @@ def foreach_each_in(site, itername, trait, each_in,
             + codegen_statements([body_ast], location, inner_scope))
     loop = mkFor(
         site,
-        [mkLit(site, 'int _outer_idx = %s.starti' % (ident,), TVoid())],
-        mkLit(site, '_outer_idx < %s.endi' % (ident,), TBool()),
+        [mkLit(site, 'int _outer_idx = 0', TVoid())],
+        mkLit(site, f'_outer_idx < {ident}.num', TBool()),
         [mkExpressionStatement(
             site, mkLit(site, '++_outer_idx', TInt(32, True)))],
         mkCompound(
             site,
-            [mkInline(site,
-                      '_vtable_list_t _list = %s.base[_outer_idx];' % (ident,)),
+            [mkInline(
+                site, f'_vtable_list_t _list = {EachIn.array_ident(trait)}['
+                f'{ident}.base_idx + _outer_idx];'),
              mkInline(site, 'uint64 _num = _list.num / %s.array_size;' % (ident,)),
              mkInline(site, 'uint64 _start = _num * %s.array_idx;' % (ident,)),
              mkFor(site,

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -2234,8 +2234,7 @@ def foreach_each_in(site, itername, trait, each_in,
     ident = each_in_sym.value
     inner_scope = Symtab(scope)
     trait_type = TTrait(trait)
-    trait_ptr = (f'(struct _{cident(trait.name)} *) '
-                 + '(_list.base + _inner_idx * _list.offset)')
+    trait_ptr = (f'(struct _{cident(trait.name)} *) _list.vtable')
     obj_ref = '(_identity_t) { .id = _list.id, .encoded_index = _inner_idx}'
     inner_scope.add_variable(
         itername, type=trait_type,

--- a/py/dml/crep.py
+++ b/py/dml/crep.py
@@ -13,7 +13,7 @@ from .messages import *
 
 __all__ = (
     'cname',
-    'cref',
+    'cref_method',
     'cref_portobj',
     'cref_session',
     'ctype',
@@ -101,7 +101,7 @@ def ancestor_cnames(node):
         node = node.parent
     return list(reversed(names))
 
-def cref(method_node):
+def cref_method(method_node):
     assert method_node.objtype == 'method'
     # This might actually conflict, but the chances are small.
     return '__'.join(ancestor_cnames(method_node)[1:])

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -3214,8 +3214,7 @@ class ObjTraitRef(Expression):
             indices = tuple(mkLit(self.site, '__indices[%d]' % (i,),
                                   TInt(32, False))
                             for i in range(self.node.dimensions))
-        structref = (self.node.traits.vtable_cname(self.ancestry_path[0])
-                     + ''.join('[%s]' % (i.read(),) for i in indices))
+        structref = self.node.traits.vtable_cname(self.ancestry_path[0])
         pointer = '(&%s)' % ('.'.join([structref] + [
             cident(t.name) for t in self.ancestry_path[1:]]))
         id = ObjIdentity(self.site, self.node, indices).read()

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -3362,9 +3362,9 @@ class TraitSessionRef(Expression):
         return TPtr(self.type_)
 
     def read(self):
-        return '(%s)((uintptr_t)_dev + %s->%s)' % (
+        return '((%s)((uintptr_t)_dev + %s->%s) + (%s).id.encoded_index)' % (
             TPtr(self.type_).declaration(''), vtable_read(self.traitref),
-            self.name)
+            self.name, self.traitref.read())
 
 class TraitMethodRef(NonValue):
     '''A reference to a bound method in a trait. The expression

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -2863,6 +2863,9 @@ class EachIn(Expression):
         self.trait = trait
         self.node = node
         assert isinstance(indices, tuple)
+        for index in indices:
+            if isinstance(index, NonValue):
+                raise index.exc()
         self.indices = indices
 
     def __str__(self):

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -3187,6 +3187,9 @@ class ObjTraitRef(Expression):
         if not isinstance(indices, tuple):
             raise ICE(site, 'bad indices: %r' % (indices,))
         assert len(indices) == node.dimensions
+        for index in indices:
+            if isinstance(index, NonValue):
+                raise index.exc()
         self.node = node
         self.trait = trait
         self.indices = indices

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -2903,7 +2903,7 @@ class EachIn(Expression):
             for sub in subobjs:
                 sub.traits.mark_referenced(self.trait)
 
-    def read(self):
+    def read(self, each_in_this=False):
         subobjs = list(self.subobjs_implementing(self.node, self.trait))
         if not subobjs:
             # Iteration will never start, so NULL will suffice
@@ -2916,6 +2916,8 @@ class EachIn(Expression):
         else:
             array_size = 1
             array_idx = "0"
+        if each_in_this:
+            array_idx = "0xffffffffu"
         return '(_each_in_t){%s, 0, %d, %s, %d}' % (
             self.ident(self.node, self.trait),
             len(subobjs), array_idx, array_size)
@@ -3231,7 +3233,6 @@ class ObjTraitRef(Expression):
         else:
             return traitref_expr
 
-
 def try_convert_identity(expr, convert_value_noderefs = True):
     if (isinstance(expr, NodeRef)
         and isinstance(expr.node, objects.CompositeObject)
@@ -3349,8 +3350,12 @@ class TraitParameter(Expression):
         t = realtype(self.traitref.ctype())
         assert isinstance(t, TTrait)
         vtable_type = f'struct _{cident(t.trait.name)}'
-        return (f'VTABLE_PARAM({self.traitref.read()}, {vtable_type}'
-                f', {self.name})')
+        if isinstance(realtype(self.type), TTraitList):
+            return (f'_vtable_sequence_param({self.traitref.read()},'
+                    f' offsetof({vtable_type}, {self.name}))')
+        else:
+            return (f'VTABLE_PARAM({self.traitref.read()}, {vtable_type}'
+                    f', {self.name})')
 
 class TraitSessionRef(Expression):
     '''A reference to a trait session variable.

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -3333,7 +3333,7 @@ def vtable_read(expr):
                                             expr.read())
 
 class TraitParameter(Expression):
-    priority = 160 # SubRef.priority
+    priority = dml.expr.Apply.priority
     @auto_init
     def __init__(self, site, traitref, name, type): pass
 
@@ -3341,8 +3341,11 @@ class TraitParameter(Expression):
         return "%s.%s" % (self.traitref, self.name)
 
     def read(self):
-        return ("%s->%s"
-                % (vtable_read(self.traitref), self.name))
+        t = realtype(self.traitref.ctype())
+        assert isinstance(t, TTrait)
+        vtable_type = f'struct _{cident(t.trait.name)}'
+        return (f'VTABLE_PARAM({self.traitref.read()}, {vtable_type}'
+                f', {self.name})')
 
 class TraitSessionRef(Expression):
     '''A reference to a trait session variable.

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -3370,9 +3370,11 @@ class TraitSessionRef(Expression):
         return TPtr(self.type_)
 
     def read(self):
-        return '((%s)((uintptr_t)_dev + %s->%s) + (%s).id.encoded_index)' % (
-            TPtr(self.type_).declaration(''), vtable_read(self.traitref),
-            self.name, self.traitref.read())
+        t = realtype(self.traitref.ctype())
+        assert isinstance(t, TTrait)
+        vtable_type = f'struct _{cident(t.trait.name)}'
+        return (f'VTABLE_SESSION(_dev, {self.traitref.read()}, {vtable_type}'
+                f', {self.name}, {self.ctype().declaration("")})')
 
 class TraitMethodRef(NonValue):
     '''A reference to a bound method in a trait. The expression

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -3214,8 +3214,7 @@ class ObjTraitRef(Expression):
             indices = tuple(mkLit(self.site, '__indices[%d]' % (i,),
                                   TInt(32, False))
                             for i in range(self.node.dimensions))
-        vtable_name = self.node.traits.vtable_cname(self.ancestry_path[0])
-        structref = (f'(*{vtable_name})'
+        structref = (self.node.traits.vtable_cname(self.ancestry_path[0])
                      + ''.join('[%s]' % (i.read(),) for i in indices))
         pointer = '(&%s)' % ('.'.join([structref] + [
             cident(t.name) for t in self.ancestry_path[1:]]))

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -2237,7 +2237,7 @@ class AddressOf(UnaryOp):
                and node.name == 'callback' \
                and node.parent.objtype == 'event':
                 return AddressOf(site, mkLit(
-                    site, '_DML_EV_'+crep.cref(node),
+                    site, '_DML_EV_'+crep.cref_method(node),
                     TFunction([TPtr(TNamed('conf_object_t')),
                                TPtr(TVoid())],
                               TVoid())))
@@ -3564,7 +3564,7 @@ class NodeRefWithStorage(NodeRef, LValue):
             from . import codegen
             method = codegen.method_instance(node)
             codegen.mark_method_referenced(method)
-            expr = '_DML_M_' + crep.cref(node)
+            expr = '_DML_M_' + crep.cref_method(node)
         elif node.objtype == 'device':
             assert dml.globals.dml_version == (1, 2)
             return '_dev'

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1452,10 +1452,6 @@ class ENSHARED(DMLError):
         if self.decl_site:
             self.print_site_message(self.decl_site, "declared here")
 
-class EMDOBJECT(DMLError):
-    """ Bank arrays and port arrays cannot be multi-dimensional in simics 5"""
-    fmt = "cannot declare a multi-dimensional %s in simics 5"
-
 class ESERIALIZE(DMLError):
     """Some complex types, in particular most pointer types, cannot be
     automatically checkpointed by DML, and are therefore disallowed in

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -847,6 +847,16 @@ class EASZR(DMLError):
     def __init__(self, site):
         DMLError.__init__(self, site)
 
+class EASZLARGE(DMLError):
+    """
+    Object arrays with huge dimensions are not allowed; the product of
+    dimension sizes must be smaller than 2<sup>31</sup>.
+    """
+    # It would be cheap to bump the limit to 2**32 elements, but that
+    # would require some additional testing to check that we never use
+    # signed 32-bit integer arithmetic on packed indices.
+    fmt = f"array has too many elements (%d >= {2**31})"
+
 class EAINCOMP(DMLError):
     """
     The array has been declared more than once, in an incompatible way.

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -8,6 +8,8 @@ import collections
 import abc
 import re
 from contextlib import ExitStack
+import functools
+import operator
 from . import objects, logging, crep, ast
 from . import traits
 from . import toplevel
@@ -889,6 +891,9 @@ def mkobj(ident, objtype, arrayinfo, obj_specs, parent, each_stmts):
 
     obj = create_object(site, ident, objtype, parent,
                         arraylen_asts, index_vars)
+    num_elems = functools.reduce(operator.mul, obj.dimsizes, 1)
+    if num_elems >= 1 << 31:
+        raise EASZLARGE(site, num_elems)
 
     with ErrorContext(obj):
         obj_specs = add_templates(obj_specs, each_stmts)

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -2219,8 +2219,13 @@ def check_register_fields(reg):
             reg_indices = tuple(StaticIndex(field.site, var)
                                 for var in reg.idxvars())
             indices = reg_indices + field_indices
-            lsb_expr = param_expr(field, 'lsb', indices)
-            msb_expr = param_expr(field, 'msb', indices)
+            try:
+                lsb_expr = param_expr(field, 'lsb', indices)
+                msb_expr = param_expr(field, 'msb', indices)
+            except EIDXVAR:
+                # msb/lsb expression dependent on bank/register indices.
+                # Disregard this field when checking ranges.
+                return []
             for expr in (lsb_expr, msb_expr):
                 if isinstance(expr, NonValue):
                     raise expr.exc()

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -1375,7 +1375,7 @@ def process_method_implementations(obj, name, implementations,
                     raise EEXTERN(method.site)
                 func = method_instance(method)
                 mark_method_referenced(func)
-                mark_method_exported(func, crep.cref(method), msite)
+                mark_method_exported(func, crep.cref_method(method), msite)
                 break
         # Export hard_reset and soft_reset from device objects in 1.2
         # automatically
@@ -1383,7 +1383,7 @@ def process_method_implementations(obj, name, implementations,
             name in ('hard_reset', 'soft_reset')):
             func = method_instance(method)
             mark_method_referenced(func)
-            mark_method_exported(func, crep.cref(method), obj.site)
+            mark_method_exported(func, crep.cref_method(method), obj.site)
 
     return method
 

--- a/py/dml/traits.py
+++ b/py/dml/traits.py
@@ -753,7 +753,9 @@ class Trait(SubTrait):
 
     def vtable(self):
         for (name, (_, ptype)) in list(self.vtable_params.items()):
-            yield (name, TPtr(ptype))
+            yield (name,
+                   ptype if isinstance(realtype(ptype), TTraitList)
+                   else TPtr(ptype))
         for (name, (_, ptype)) in list(self.vtable_sessions.items()):
             yield (name, TInt(32, False))
         for (name, (_, inp, outp, throws, independent, startup, memoized)) \

--- a/py/dml/traits.py
+++ b/py/dml/traits.py
@@ -751,21 +751,6 @@ class Trait(SubTrait):
                 outp, throws)],
             c_rettype(outp, throws)))
 
-    def vtable(self):
-        for (name, (_, ptype)) in list(self.vtable_params.items()):
-            yield (name,
-                   ptype if isinstance(realtype(ptype), TTraitList)
-                   else TPtr(ptype))
-        for (name, (_, ptype)) in list(self.vtable_sessions.items()):
-            yield (name, TInt(32, False))
-        for (name, (_, inp, outp, throws, independent, startup, memoized)) \
-            in list(self.vtable_methods.items()):
-            yield (name, self.vtable_method_type(inp, outp, throws,
-                                                 independent))
-        for method in self.method_impls.values():
-            if method.independent and method.memoized:
-                yield (f'_{method.name}_outs', method.memo_outs_struct)
-
     def mark_referenced(self):
         if not self in Trait.referenced:
             for p in self.direct_parents:

--- a/py/dml/traits.py
+++ b/py/dml/traits.py
@@ -753,7 +753,7 @@ class Trait(SubTrait):
 
     def vtable(self):
         for (name, (_, ptype)) in list(self.vtable_params.items()):
-            yield (name, ptype)
+            yield (name, TPtr(ptype))
         for (name, (_, ptype)) in list(self.vtable_sessions.items()):
             yield (name, TInt(32, False))
         for (name, (_, inp, outp, throws, independent, startup, memoized)) \

--- a/py/dml/traits_test.py
+++ b/py/dml/traits_test.py
@@ -45,9 +45,6 @@ class Test_traits(unittest.TestCase):
                   {}, {}, {}, {}, {})
         ot = ObjTraits(self.dev, {t}, {'m': t}, {}, {})
         self.dev.set_traits(ot)
-        [(m, typ)] = list(t.vtable())
-        # don't worry about the type for now
-        self.assertEqual(m, 'm')
         ref = ot.lookup_shared_method_impl(self.site, 'm', ())
         self.assertTrue(ref)
         # does not crash

--- a/py/dml/traits_test.py
+++ b/py/dml/traits_test.py
@@ -33,7 +33,7 @@ class Test_traits(unittest.TestCase):
             dml.ctree.mkCast(
                 self.site, dml.ctree.mkNodeRef(self.site, self.dev, ()),
                 t.type()).read(),
-            '((t) {(&(*_tr__dev__t)), '
+            '((t) {(&_tr__dev__t), '
             + '((_identity_t) {.id = 0, .encoded_index = 0})})'
             )
 

--- a/py/dml/types.py
+++ b/py/dml/types.py
@@ -828,16 +828,15 @@ class TTrait(DMLType):
 class TTraitList(DMLType):
     __slots__ = ('traitname')
 
-    def __init__(self, traitname):
+    def __init__(self, traitname, const=False):
+        DMLType.__init__(self, const)
         self.traitname = traitname
-
-    const = True
 
     def __repr__(self):
         return "TTraitList(%s)" % (self.traitname,)
 
     def clone(self):
-        return TTraitList(self.traitname)
+        return TTraitList(self.traitname, self.const)
 
     def cmp(self, other):
         if isinstance(other, TTraitList) and self.traitname == other.traitname:

--- a/py/dml/types.py
+++ b/py/dml/types.py
@@ -812,19 +812,6 @@ class TTrait(DMLType):
     def declaration(self, var):
         return '%s %s' % (cident(self.trait.name), var)
 
-    def print_vtable_struct_declaration(self):
-        out('struct _%s {\n' % cident(self.trait.name), postindent=1)
-        empty = True
-        for p in self.trait.direct_parents:
-            out("struct _%s %s;\n" % (cident(p.name), cident(p.name)))
-            empty = False
-        for (name, typ) in self.trait.vtable():
-            out("%s;\n" % (typ.declaration(name),))
-            empty = False
-        if empty:
-            out('uint8 _dummy;\n')
-        out('};\n', preindent=-1)
-
 class TTraitList(DMLType):
     __slots__ = ('traitname')
 

--- a/test/1.4/errors/T_EASZLARGE.dml
+++ b/test/1.4/errors/T_EASZLARGE.dml
@@ -1,0 +1,18 @@
+/*
+  © 2022 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+// ok
+group g1[i < (1 << 31) - 1];
+
+/// ERROR EASZLARGE
+group g2[i < 1 << 31];
+
+group g3[i < 1 << 16] {
+    /// ERROR EASZLARGE
+    group g[j < 1 << 15];
+}

--- a/test/1.4/errors/T_EIDXVAR.dml
+++ b/test/1.4/errors/T_EIDXVAR.dml
@@ -1,0 +1,13 @@
+/*
+  © 2021-2022 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+
+group g[i < 2] {
+    // this is EIDXVAR rather than ENCONST, because the 'each in' expression
+    // implicitly references an index which is static in this context.
+    /// ERROR EIDXVAR
+    #if ((each group in (this)).len == 13) {}
+}

--- a/test/1.4/structure/T_trait.dml
+++ b/test/1.4/structure/T_trait.dml
@@ -66,6 +66,44 @@ group bytes is byte_params {
     param ac = 5;
 }
 
+// Test that sequence params work. They are represented differently from
+// params of other types; three cases:
+// a: "each T in this" represented as one each_in_t, with a certain marker
+// b: each T in <object expr that doesn't depend on index params>: represented
+//    as a single each_in_t
+// c: each T in <object expr that depends on index params>: represented
+//    as an array of each_in_t:s
+template marker { param val : int; }
+method marker_sum(sequence(marker) markers) -> (int) {
+    local int sum = 0;
+    foreach marker in (markers) {
+        sum += marker.val;
+    }
+    return sum;
+}
+template seqs {
+    param a : sequence(marker);
+    param b : sequence(marker);
+    param c : sequence(marker);
+    shared method expect_sums(int a, int b, int c) {
+        assert marker_sum(this.a) == a;
+        assert marker_sum(this.b) == b;
+        assert marker_sum(this.c) == c;
+    }
+}
+group seqs[i<2][j<3] is seqs {
+    param a = each marker in (this);
+    param b = each marker in (seqs[i][1-j]);
+    param c = each marker in (dev);
+    group x is marker { param val = i*100 + j*10; }
+    group y[k < 4] is marker { param val = i * 100 + j * 10 + k; }
+    method test() {
+        this.expect_sums(5 * (i * 100 + j * 10) + 6,
+                         5 * (i * 100 + (1 - j) * 10) + 6,
+                         100 * 3 * 5 + 10 * 2 * (1+2) * 5 + 6 * 2 * 3);
+    }
+}
+
 session int count = 0;
 method side() -> (int) {
     ++count;
@@ -126,6 +164,12 @@ method test() throws {
     assert cast(bytes, byte_params).aa == 3;
     assert cast(bytes, byte_params).ab == 4;
     assert cast(bytes, byte_params).ac == 5;
+
+    for (local int i = 0; i < 2; i++) {
+        for (local int j = 0; j < 2; j++) {
+            seqs[i][j].test();
+        }
+    }
 
     dc[0].test(0);
     dc[1].test(1);

--- a/test/1.4/structure/T_trait.dml
+++ b/test/1.4/structure/T_trait.dml
@@ -66,6 +66,12 @@ group bytes is byte_params {
     param ac = 5;
 }
 
+session int count = 0;
+method side() -> (int) {
+    ++count;
+    return 0;
+}
+
 method test() throws {
     local child c = cast(p[1], child);
     local base pp;
@@ -84,9 +90,12 @@ method test() throws {
     p[1].d = 4;
     p[1].e = 5;
     p[0].d = 6;
-    expect(ppp->d == 4, "ppp->d == 4");
+    count = 0;
+    expect((ppp + side())->d == 4, "ppp->d == 4");
+    assert count == 1;
     expect(ppp->e == 5, "ppp->e == 5");
-    expect(p[1].traitref_param.d == 6, "p[1].traitref_param.d == 6");
+    expect(p[1 + side()].traitref_param.d == 6, "p[1].traitref_param.d == 6");
+    assert count == 2;
     expect(p[0].traitref_param.e == 5, "p[0].traitref_param.e == 5");
     expect(p[1].param == 14.2, "p[1].param == 14.2");
     p[1].hello();

--- a/test/1.4/structure/T_trait.dml
+++ b/test/1.4/structure/T_trait.dml
@@ -116,21 +116,32 @@ header %{
         const int y;
     } deep_const_t;
     static deep_const_t dc_val[2] = {{00,01},{10,11}};
+    static const int sc_val[2] = {1, 2};
 %}
 extern typedef struct {
     int x;
     const int y;
 } deep_const_t;
 extern deep_const_t dc_val[2];
+extern const int sc_val[2];
 template deep_const {
-    param val : deep_const_t;
+    param d_val : deep_const_t;
+    param s_val : const int;
     shared method test(int i) {
-        assert val.x == i * 10;
-        assert val.y == i * 10 + 1;
+        assert d_val.x == i * 10;
+        assert d_val.y == i * 10 + 1;
+        assert s_val == i + 1;
     }
 }
-group  dc[i<2] is deep_const {
-    param val = dc_val[i];
+
+group dc[i<2] is deep_const {
+    param d_val = dc_val[i];
+    param s_val = sc_val[i];
+}
+
+group dc_nonindexed is deep_const {
+    param d_val = dc_val[0];
+    param s_val = sc_val[0];
 }
 
 method test() throws {
@@ -173,4 +184,5 @@ method test() throws {
 
     dc[0].test(0);
     dc[1].test(1);
+    dc_nonindexed.test(0);
 }

--- a/test/1.4/structure/T_trait.dml
+++ b/test/1.4/structure/T_trait.dml
@@ -52,6 +52,20 @@ port p[i < 2] {
     }
 }
 
+// The way param pointers are stored, param values must appear on addresses
+// aligned by two; without the alignment logic, references to one of the below
+// params will break.
+template byte_params {
+    param aa : uint8;
+    param ab : uint8;
+    param ac : uint8;
+}
+group bytes is byte_params {
+    param aa = 3;
+    param ab = 4;
+    param ac = 5;
+}
+
 method test() throws {
     local child c = cast(p[1], child);
     local base pp;
@@ -76,4 +90,8 @@ method test() throws {
     expect(p[0].traitref_param.e == 5, "p[0].traitref_param.e == 5");
     expect(p[1].param == 14.2, "p[1].param == 14.2");
     p[1].hello();
+
+    assert cast(bytes, byte_params).aa == 3;
+    assert cast(bytes, byte_params).ab == 4;
+    assert cast(bytes, byte_params).ac == 5;
 }

--- a/test/1.4/structure/T_trait.dml
+++ b/test/1.4/structure/T_trait.dml
@@ -53,26 +53,27 @@ port p[i < 2] {
 }
 
 method test() throws {
-    local child c = cast(p[0], child);
+    local child c = cast(p[1], child);
     local base pp;
     local base *ppp = &pp;
     *ppp = cast(cast(c, base), base);
     pp.m(0);
     c.m(0);
     c.o(0);
-    expect(ppp->o(3) == 12, "ppp->o(3) == 12");
-    expect(p[1].o(3) == 16, "p[1].o(3) == 16");;
+    expect(ppp->o(3) == 16, "ppp->o(3) == 16");
+    expect(p[0].o(3) == 12, "p[0].o(3) == 12");;
     // The parameters value is given as a float value 14.2; the parameter's type
     // causes this to be truncated to an integer when referenced
     // dynamically as a trait parameter.
     expect(cast(p[1], child).param == 14, "cast(p[1], child).param == 14");
     expect(p[1].param == 14.2, "p[1].param == 14.2");
-    p[0].d = 4;
-    p[0].e = 5;
+    p[1].d = 4;
+    p[1].e = 5;
+    p[0].d = 6;
     expect(ppp->d == 4, "ppp->d == 4");
     expect(ppp->e == 5, "ppp->e == 5");
-    expect(p[1].traitref_param.d == 4, "p[1].traitref_param.d == 4");
-    expect(p[1].traitref_param.e == 5, "p[1].traitref_param.e == 5");
+    expect(p[1].traitref_param.d == 6, "p[1].traitref_param.d == 6");
+    expect(p[0].traitref_param.e == 5, "p[0].traitref_param.e == 5");
     expect(p[1].param == 14.2, "p[1].param == 14.2");
     p[1].hello();
 }

--- a/test/1.4/structure/T_trait.dml
+++ b/test/1.4/structure/T_trait.dml
@@ -72,6 +72,29 @@ method side() -> (int) {
     return 0;
 }
 
+header %{
+    typedef struct {
+        int x;
+        const int y;
+    } deep_const_t;
+    static deep_const_t dc_val[2] = {{00,01},{10,11}};
+%}
+extern typedef struct {
+    int x;
+    const int y;
+} deep_const_t;
+extern deep_const_t dc_val[2];
+template deep_const {
+    param val : deep_const_t;
+    shared method test(int i) {
+        assert val.x == i * 10;
+        assert val.y == i * 10 + 1;
+    }
+}
+group  dc[i<2] is deep_const {
+    param val = dc_val[i];
+}
+
 method test() throws {
     local child c = cast(p[1], child);
     local base pp;
@@ -103,4 +126,7 @@ method test() throws {
     assert cast(bytes, byte_params).aa == 3;
     assert cast(bytes, byte_params).ab == 4;
     assert cast(bytes, byte_params).ac == 5;
+
+    dc[0].test(0);
+    dc[1].test(1);
 }

--- a/test/1.4/structure/T_trait_largearray.dml
+++ b/test/1.4/structure/T_trait_largearray.dml
@@ -1,0 +1,21 @@
+/*
+  © 2022 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+import "testing.dml";
+
+// Vtable size: 8 bytes
+template t {
+    shared method m() {}
+}
+
+// Before vtables were optimized to not naively allocate per element,
+// this declaration would cost 8 petabytes worth of memory.
+group g[i < 1 << 25][j < 1 << 25] is t;
+
+// prevent DCE of vtable
+method test() throws {
+    g[0][0].m();
+}

--- a/test/1.4/structure/T_trait_largearray.dml
+++ b/test/1.4/structure/T_trait_largearray.dml
@@ -3,19 +3,22 @@
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;
+
+/// INSTANTIATE-MANUALLY
 device test;
+
 import "testing.dml";
 
-// Vtable size: 8 bytes
+// vtable size: 8 bytes
 template t {
-    shared method m() {}
+    shared method m() default {}
 }
 
-// Before vtables were optimized to not naively allocate per element,
-// this declaration would cost 8 petabytes worth of memory.
-group g[i < 1 << 25][j < 1 << 25] is t;
+// This large number of elements takes no space, since we no longer create one
+// vtable per instance.
+group g[i < 2000000000] is t;
 
 // prevent DCE of vtable
 method test() throws {
-    g[0][0].m();
+    cast(g[0], t).m();
 }

--- a/test/1.4/structure/T_trait_largearray.py
+++ b/test/1.4/structure/T_trait_largearray.py
@@ -1,0 +1,17 @@
+# © 2022 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+from simicsutils.host import is_windows
+if is_windows():
+    # resource module only available on linux
+    SIM_create_object('test')
+    exit(0)
+
+import resource
+import stest
+
+before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+SIM_create_object('test', 'obj', [])
+after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+print(after - before)
+stest.expect_true(after - before < 100)

--- a/test/tests.py
+++ b/test/tests.py
@@ -716,11 +716,14 @@ class CTestCase(DMLFileTestCase):
         env['SIMICS_HOST'] = os.path.basename(host_path())
         env['SIMICS_ROOT'] = simics_root_path()
         # self.pr("ARGS: %r" % args)
-        return subprocess.call(args,
-                               stdout = open(self.simics_stdout, "w"),
-                               stderr = open(self.simics_stderr, "w"),
-                               env = env,
-                               cwd=self.scratchdir)
+        ret = subprocess.call(args,
+                              stdout = open(self.simics_stdout, "w"),
+                              stderr = open(self.simics_stderr, "w"),
+                              env = env,
+                              cwd=self.scratchdir)
+        if ret:
+            self.pr(f"Simics command-line: {' '.join(args)}")
+        return ret
 
     def test(self):
         "This actually runs the test, after filtering"


### PR DESCRIPTION
- Use indices from traitref, instead of inferring from pointer arithmetic
- Cover nontrivial indexing of session variables
- Rearrange device struct: propagate array dimensions to leaf members
- Rename crep
