### PR TITLE
Fix dmlc profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ stderr. The default is to hide tracebacks in a file `dmlc-error.log`.
 
 ### DMLC_CC
 Override the default compiler in unit tests.
+
+### DMLC_PROFILE
+When set, DMLC does self-profiling and writes the profile to a .prof file.

--- a/py/README.md
+++ b/py/README.md
@@ -29,8 +29,7 @@ setting time_dmlc to True, which will print a little information about
 how much time the compiler stages take, although this isn't all that useful.
 
 You can also set the DMLC_PROFILE environment variable to create a
-hotshot profile (which probably requires you to install the hotshot
-Python module in your simics tree.
+cProfile profile.
 
 There is a similar environment variable DMLC_HEAPY to do some
 profiling with heapy/guppy, but that's a bit more complicated.

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -479,9 +479,9 @@ def main(argv):
 
     # Profiling setup
     if os.getenv('DMLC_PROFILE') and not options.makedep:
-        import hotshot, hotshot.stats
-        dmlc_profiler = hotshot.Profile('%s.prof' % outputbase)
-        dmlc_profiler.start()
+        import cProfile, pstats
+        dmlc_profiler = cProfile.Profile()
+        dmlc_profiler.enable()
     else:
         dmlc_profiler = False
 
@@ -596,11 +596,12 @@ def main(argv):
 
     finally:
         if dmlc_profiler:
-            dmlc_profiler.close()
-            stats = hotshot.stats.load("%s.prof" % outputbase)
+            dmlc_profiler.disable()
+            stats = pstats.Stats(dmlc_profiler)
             stats.strip_dirs()
             stats.sort_stats('time', 'calls')
             stats.print_stats(20)
+            stats.dump_stats(f'{outputbase}.prof')
         if options.porting_filename:
             flush_porting_log(logging.PortingMessage.outfile,
                               options.porting_filename)


### PR DESCRIPTION
hotshot is not available in Python 3. So setting DMLC_PROFILE would make dmlc fail with following error message:

_ModuleNotFoundError: No module named 'hotshot'_

This pull request fixes the issue by replacing hotshot with cProfile. A unit test was added to cover DMLC_PROFILE.