### PR TITLE
Support omitting object array dimension sizes when redundant -- SIMICS-18580

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -291,4 +291,14 @@
   <build-id value="next"><add-note> <tt>break</tt> may now be used within
       <tt>foreach</tt> statements <bug number="SIMICS-18719"/>.
   </add-note></build-id>
+  <build-id value="next"><add-note> When declaring an object array, any
+      dimension size specification may now be omitted if already defined through
+      a different declaration of the same object array
+      <bug number="22014423596"/>. Omission is done by specifying <tt>...</tt>
+      instead of the dimension size; for example, the following is now
+      supported:
+      <pre>
+      group g[i &lt; 4][j &lt; ...] { }
+      group g[i &lt; ...][j &lt; 7] { }
+      </pre></add-note></build-id>
 </rn>

--- a/doc/1.4/language.md
+++ b/doc/1.4/language.md
@@ -1841,6 +1841,15 @@ defines an array named `regs` of 16 registers (numbered from 0 to
 See Section [Universal Templates](dml-builtins.html#universal-templates)
 for details about arrays and index parameters.
 
+The size specification of an array dimension may be replaced with `...` if the
+size has already been defined by a different declaration of the same object
+array. For example, the following is valid:
+
+```
+register regs[i < 16][j < ...] size 2 @ 0x0100 + 16 * i + 2 * j;
+register regs[i < ...][j < 8] is (read_only);
+```
+
 Note that in Simics 5, `port` arrays and `bank` arrays
 cannot be multi-dimensional.
 

--- a/py/dml/dmlparse.py
+++ b/py/dml/dmlparse.py
@@ -569,6 +569,11 @@ def arraydef(t):
     '''arraydef : ident LT expression'''
     t[0] = (t[1], t[3])
 
+@prod_dml14
+def arraydef_implicit(t):
+    '''arraydef : ident LT ELLIPSIS'''
+    t[0] = (t[1], None)
+
 # Traits
 
 @prod_dml12

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -820,6 +820,14 @@ class EAINCOMP(DMLError):
         if self.othersite:
             self.print_site_message(self.othersite, "conflicting declaration")
 
+class EAUNKDIMSIZE(DMLError):
+    """
+    The size of an array dimension of an object array must be defined at least
+    once across all declarations of that object array.
+    """
+    fmt = ("the size of dimension %d (with index variable '%s') is never "
+           + "defined")
+
 class ENCONST(DMLError):
     """
     A constant expression was expected.

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -713,19 +713,25 @@ def merge_subobj_defs(def1, def2, parent):
                        "mixing declarations with different number "
                        "of array dimensions")
 
+    merged_arrayinfo = []
     if arrayinfo:
         parent_scope = Location(parent, static_indices(parent))
 
-        for (idxvar1, len1), (idxvar2, len2) in zip(arrayinfo, arrayinfo2):
+        for ((idxvar1, len1), (idxvar2, len2)) in zip(arrayinfo, arrayinfo2):
             if idxvar1 != idxvar2:
                 raise EAINCOMP(site1, site2, name,
                                "mismatching index variables")
 
-            if (eval_arraylen(len1, parent_scope)
-                != eval_arraylen(len2, parent_scope)):
+            if len1 is None:
+                merged_arrayinfo.append((idxvar1, len2))
+            elif len2 is not None and (eval_arraylen(len1, parent_scope)
+                                       != eval_arraylen(len2, parent_scope)):
                 raise EAINCOMP(site1, site2, name, "mismatching array sizes")
+            else:
+                merged_arrayinfo.append((idxvar1, len1))
 
-    return (objtype, name, arrayinfo, obj_specs1 + obj_specs2)
+
+    return (objtype, name, merged_arrayinfo, obj_specs1 + obj_specs2)
 
 def method_is_std(node, methname):
     """
@@ -1458,6 +1464,12 @@ def mkobj2(obj, obj_specs, params, each_stmts):
             else:
                 symbols[ident] = subobj_spec.site
                 subobj_defs[ident] = subobj_def
+
+    for (_, _, arrayinfo, specs) in subobj_defs.values():
+        for (i, (idx, dimsize_ast)) in enumerate(arrayinfo):
+            if dimsize_ast is None:
+                report(EAUNKDIMSIZE(specs[0].site, i, idx))
+                arrayinfo[i] = (idx, ast.int(specs[0].site, 1))
 
     explicit_traits = {t for (_, t) in obj_traits}
     ancestors = explicit_traits.union(

--- a/test/1.4/errors/T_EAINCOMP.dml
+++ b/test/1.4/errors/T_EAINCOMP.dml
@@ -1,0 +1,11 @@
+/*
+  © 2022 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+
+/// ERROR EAINCOMP
+group g[i < ...];
+/// ERROR EAINCOMP
+group g[j < 4];

--- a/test/1.4/errors/T_EAUNKDIMSIZE.dml
+++ b/test/1.4/errors/T_EAUNKDIMSIZE.dml
@@ -1,0 +1,31 @@
+/*
+  © 2022 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+/// ERROR EAUNKDIMSIZE
+group g1[i < ...];
+
+// no error
+group g2[i < ...];
+group g2[i < 4];
+group g2[i < ...];
+
+
+template t {
+    group g3[i < 4];
+}
+// no error
+group g3[i < ...];
+is t;
+
+/// ERROR EAUNKDIMSIZE
+group g4[i < 4][j < ...];
+group g4[i < ...][j < ...];
+
+// no error
+group g5[i < 4][j < ...];
+group g5[i < ...][j < 7];


### PR DESCRIPTION
HSD-ES ticket 22014423596.

We decided to finish the discussion on this, and settled on `register foo[i < ...]` as the syntax.