### PR TITLE
Correct path to public Simics simulator + more

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ future.
 
 ## Building and testing DMLC 
 
-To build the DML compiler (DMLC), you need to have a Simics
+To build DMLC, you need to have a Simics
 simulator installation and a Simics project set up.
 
 
@@ -29,7 +29,8 @@ simulator installation and a Simics project set up.
 
 If you do not already have a Simics simulator installation or access to the
 Simics simulator via commercial channels, install the [Public Release of
-the Intel Simics simulator](https://software.intel.com/simics-simulator) and create a Simics project (automatic in the default installation flow).
+the Intel Simics simulator](https://software.intel.com/simics-simulator) 
+and create a Simics project (automatic in the default installation flow).
 
 ### Building DMLC from a Simics project
 In your Simics project, check out the DML repository into the `modules/dmlc`
@@ -48,7 +49,8 @@ The following environment variables are handy when developing DMLC.
 ### DMLC_DIR
 After building DMLC, you need to set `DMLC_DIR` to `<your-project>/<hosttype>/bin`
 in subsequent invocations of `make` in order to build devices with the locally
-build compiler. `<hosttype>` is either `linux64` or `win64` depending on your host type. 
+build compiler. `<hosttype>` is either `linux64` or `win64` depending on your 
+host type. 
 
 ### T126_JOBS
 When set, the given number of tests are run in parallel.
@@ -58,7 +60,8 @@ The DMLC build copies a few DML library files, e.g. `dml-builtins.dml`, into
 `<hosttype>/bin`. When a compile error happens, error messages will normally point
 to this copy rather than the source. By setting `DMLC_PATHSUBST` to
 `<hosttype>/bin/dml=modules/dmlc/lib`, error messages will be rewritten to point
-to the source file instead.  `<hosttype>` is either `linux64` or `win64` depending on your host type. 
+to the source file instead.  `<hosttype>` is either `linux64` or `win64` 
+depending on your host type. 
 
 ### PY_SYMLINKS
 When set to `1`, `make dmlc` will symlink Python files instead of copying

--- a/README.md
+++ b/README.md
@@ -5,34 +5,60 @@
 
 # Device Modeling Language
 
-DML is a language for writing device models for computer architecture
-simulators. Currently, the compiler only supports building models for
-the
-[Simics®](https://www.intel.com/content/www/us/en/download/645996/simics-simulator-public-release-preview.html)
-simulator, but other back-ends may be added in the future.
+The Device Modeling Language (DML) is a domain-specific language for
+writing fast functional or transaction-level device models for virtual
+platforms.  DML provides high-level abstractions suitable for
+functional device models, including constructs like register banks,
+registers, bit fields, event posting, interfaces between models, and
+logging. DML code is compiled by the DML Compiler (DMLC), producing C
+code with API calls tailored for a particular simulator.
 
-## Building and testing
+Currently, the compiler supports building models for the Intel®
+[Simics®](https://www.intel.com/content/www/us/en/developer/articles/tool/simics-simulator.html)
+simulator, but other back-ends may be added in the
+future.
+
+
+## Building and testing DMLC 
+
+To build the DML compiler (DMLC), you need to have a Simics
+simulator installation and a Simics project set up.
+
+
+### Using the Public Release of the Intel Simics Simulator
+
+If you do not already have a Simics simulator installation or access to the
+Simics simulator via commercial channels, install the [Public Release of
+the Intel Simics simulator](https://software.intel.com/simics-simulator) and create a Simics project (automatic in the default installation flow).
+
+### Building DMLC from a Simics project
 In your Simics project, check out the DML repository into the `modules/dmlc`
-directory, `make dmlc`. To run unit tests, run `make test-dmlc` or
-`bin/test-runner --suite modules/dmlc/test`.
+directory.  At the top-level of the project, do `make dmlc`
+(or `bin\make dmlc` on Windows). 
+
+### Testing DMLC from a Simics project
+To run the unit tests provided with DMLC, run `make test-dmlc` or
+`bin/test-runner --suite modules/dmlc/test` from the top-level
+of the project.
+
 
 ## Environment variables
 The following environment variables are handy when developing DMLC.
 
 ### DMLC_DIR
-After building DMLC, you need to set `DMLC_DIR` to `<your-project>/linux64/bin`
+After building DMLC, you need to set `DMLC_DIR` to `<your-project>/<hosttype>/bin`
 in subsequent invocations of `make` in order to build devices with the locally
-build compiler.
+build compiler. `<hosttype>` is either `linux64` or `win64` depending on your host type. 
 
 ### T126_JOBS
 When set, the given number of tests are run in parallel.
 
 ### DMLC_PATHSUBST
 The DMLC build copies a few DML library files, e.g. `dml-builtins.dml`, into
-`linux64/bin`. When a compile error happens, error messages will normally point
+`<hosttype>/bin`. When a compile error happens, error messages will normally point
 to this copy rather than the source. By setting `DMLC_PATHSUBST` to
-`linux64/bin/dml=modules/dmlc/lib`, error messages will be rewritten to point
-to the source file instead.
+`<hosttype>/bin/dml=modules/dmlc/lib`, error messages will be rewritten to point
+to the source file instead.  `<hosttype>` is either `linux64` or `win64` depending on your host type. 
 
 ### PY_SYMLINKS
 When set to `1`, `make dmlc` will symlink Python files instead of copying


### PR DESCRIPTION
Update readme to point at the correct location for the public release of the Intel Simics simulator.  Added a bit more substance to the introduction. 