### PR TITLE
Add environment variable DMLC_DUMP_INPUT_FILES

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ directory, `make dmlc`. To run unit tests, run `make test-dmlc` or
 `bin/test-runner --suite modules/dmlc/test`.
 
 ## Environment variables
-The following environment variables are handy when developing DMLC.
+The following environment variables are handy when developing DMLC. If you work
+regularly with a locally built DMLC, then consider setting the variables
+`DMLC_DIR` `T126_JOBS`, `DMLC_PATHSUBST` and `PY_SYMLINKS` in your
+`.bashrc`. Remaining variables are better to only enable when needed.
 
 ### DMLC_DIR
 After building DMLC, you need to set `DMLC_DIR` to `<your-project>/linux64/bin`
 in subsequent invocations of `make` in order to build devices with the locally
-build compiler.
+built compiler.
 
 ### T126_JOBS
 When set, the given number of tests are run in parallel.
@@ -49,3 +52,9 @@ Override the default compiler in unit tests.
 
 ### DMLC_PROFILE
 When set, DMLC does self-profiling and writes the profile to a .prof file.
+
+### DMLC_DUMP_INPUT_FILES
+When set, DMLC emits a `.tar.xz` archive containing all DML source files,
+packaged on a form that can be compiled standalone. This is useful when a DML
+problem appears within a complex build environment, and you want to reproduce
+the problem in isolation.

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -20,6 +20,7 @@ import dml.dmlparse
 from .logging import *
 from .messages import *
 from .env import api_versions, default_api_version
+import tarfile
 
 def prerr(msg):
     sys.stderr.write(msg + "\n")
@@ -152,6 +153,60 @@ def print_cdep(outputbase, headers, footers):
             block.toc()
     f.close()
     f.commit()
+
+def dotdot_depth(path):
+    '''return how many levels of parent directories are required to resolve a
+    relative path'''
+    return os.path.normpath(path).count('..' + os.path.sep)
+
+assert dotdot_depth('./../../foo/../../../bar.dml') == 4
+
+def dump_input_files(outputbase, imported):
+    # DML is often invoked within a complex build system, with a large
+    # number of -I flags and many auto-generated files. It is often
+    # hard to reproduce a DML issue outside of this build system. This
+    # function tries to save all relevant DML files in a tree that is
+    # buildable or near-buildable, by placing all DML files in the
+    # same directory. For each files that is imported with a relative
+    # path, a back-pointing symlink is created on that relative path.
+    max_dotdot = max(dotdot_depth(p)
+                     for (_, paths) in imported.items()
+                     for p in paths)
+    prefix = '/'.join(['_'] * max_dotdot)
+    basenames = set()
+    with tarfile.open(outputbase + ".tar.xz", 'w:xz') as tf:
+        # if two different files foo.dml are imported, where one is
+        # imported as "foo.dml" or "./foo.dml" and the other is only
+        # imported using a qualified path such as "bar/foo.dml", then
+        # the rename hack below has a better chance to work if we process
+        # the unqualified paths first.
+        for f in sorted(imported, key=lambda f: min(map(len, imported[f]))):
+            paths = imported[f]
+            base = os.path.basename(f)
+            while base in basenames:
+                # all DML files end up in the same directory; if two
+                # have the same name, then dodge that by renaming. In
+                # this case we may need to change some import directive
+                # manually in order for all files to be imported.
+                base = '_' + base
+            basenames.add(base)
+            path_in_tar = f'{prefix}/{base}'
+            tf.add(f, path_in_tar)
+            (_, hfile) = ctree.dmldir_macro(f)
+            if os.path.exists(hfile):
+                (_, h_path_in_tar) = ctree.dmldir_macro(path_in_tar)
+                tf.add(hfile, h_path_in_tar)
+            for path in paths:
+                symlink = os.path.normpath(os.path.join(prefix, path))
+                if os.path.dirname(symlink) == os.path.normpath(prefix):
+                    # import path resolves to file already present in tarfile
+                    continue
+                # file imported through relative path, create symlink there
+                ti = tarfile.TarInfo(symlink)
+                ti.type = tarfile.SYMTYPE
+                ti.linkname = os.path.normpath(os.path.join(
+                    '../' * (len(symlink.split(os.sep)) - 1) + prefix, base))
+                tf.addfile(ti)
 
 def is_warning_tag(w):
     return w and w[0] == 'W' and hasattr(messages, w)
@@ -498,11 +553,14 @@ def main(argv):
 
         dml.globals.strict_int_flag = options.strict or options.strict_int
 
+        if 'DMLC_DUMP_INPUT_FILES' in os.environ:
+            dump_input_files(outputbase, dict(
+                imported, **{inputfilename: [os.path.basename(inputfilename)]}))
         if options.makedep:
             print_cdep(outputbase, headers, footers)
             if logging.failure:
                 sys.exit(2)
-            deplist = [inputfilename] + imported
+            deplist = [inputfilename] + list(imported)
             now = time.time()
             future_timestamps = [path for path in deplist
                                  if os.stat(path).st_mtime > now]
@@ -546,7 +604,7 @@ def main(argv):
 
         if output_c:
             dml.c_backend.generate(dev, headers, footers, outputbase,
-                                   [inputfilename] + imported,
+                                   [inputfilename] + list(imported),
                                    options.full_module)
             logtime("c")
             structure.check_unused_and_warn(dev)

--- a/py/dml/toplevel.py
+++ b/py/dml/toplevel.py
@@ -332,8 +332,8 @@ def parse_main_file(inputfilename, explicit_import_path, strict):
     # seen spellings. One spelling is a string in an import statement which
     # resolves to the file.
     imported = {}
-    # List of dependencies
-    deps = []
+    # imported file -> list of spellings
+    deps = {}
 
     while unimported:
         (importfile, importsite) = unimported.pop()
@@ -352,6 +352,8 @@ def parse_main_file(inputfilename, explicit_import_path, strict):
             if path is None:
                 raise EIMPORT(importsite, importfile)
 
+            deps.setdefault(path, set()).add(importfile)
+
             path = os.path.abspath(os.path.realpath(path))
             normalized = os.path.normcase(path)
             if normalized in imported:
@@ -366,7 +368,6 @@ def parse_main_file(inputfilename, explicit_import_path, strict):
                 continue
 
             imported[normalized] = [importfile]
-            deps.append(path)
 
             (i_site, i_stmts) = import_file(importsite, path)
         except DMLError as e:

--- a/test/tests.py
+++ b/test/tests.py
@@ -202,7 +202,7 @@ class DMLFileTestCase(BaseTestCase):
         self.dmlc_extraargs = []
         self.cc_extraargs = []
         self.status = 0
-        self.extraenv = dict()
+        self.extraenv = {}
         # Override defaults
         for k,v in info.items():
             setattr(self, k, v)
@@ -808,12 +808,6 @@ class XmlTestCase(CTestCase):
 
 class DMLCProfileTestCase(CTestCase):
     __slots__ = ()
-    def __init__(self, path, filename, **info):
-        extraenv_arg = 'extraenv'
-        if extraenv_arg not in info:
-            info[extraenv_arg] = dict()
-        info[extraenv_arg].update({'DMLC_PROFILE': '1'})
-        super().__init__(path, filename, **info)
 
     def test(self):
         super().test()
@@ -860,7 +854,7 @@ all_tests.append(ErrorTest(["noinclude"], join(testdir, "minimal.dml"),
 # Test DMLC_PROFILE
 all_tests.append(DMLCProfileTestCase(["dmlc_profile"],
                                      join(testdir, "minimal.dml"),
-                                     api_version=latest_api_version))
+                                     extraenv={'DMLC_PROFILE': '1'}))
 
 # Test that it fails with a good error message if it can't create the
 # output files.

--- a/test/tests.py
+++ b/test/tests.py
@@ -322,7 +322,7 @@ class DMLFileTestCase(BaseTestCase):
         by zero or more context lines not on the form "In ..." (e.g.,
         "previously declared here").
 
-        The _unittest_parse_messages() function contains a concrete example.
+        The unittest_parse_messages() function contains a concrete example.
 
         """
 
@@ -543,7 +543,7 @@ class DMLFileTestCase(BaseTestCase):
             self.expect_messages(
                 kind, actual_msgs.get(kind, []), expected_msgs.get(kind, []))
 
-def _unittest_parse_messages():
+def unittest_parse_messages():
     stderr = '''
 /tmp/f.dml:3:20: In template abc
 /tmp/g.dml:4:9: error EDPARAM: blah blah
@@ -554,7 +554,7 @@ def _unittest_parse_messages():
                  [('g.dml', 4, "/tmp/g.dml:4:9: error EDPARAM: blah blah"),
                   ('f.dml', 3, "/tmp/f.dml:3:20: In template abc"),
                   ('f.dml', 8, "/tmp/f.dml:8:12: conflicting definition")])])
-_unittest_parse_messages()
+unittest_parse_messages()
 
 class CTestCase(DMLFileTestCase):
     '''Compile a test DML file with the C backend and verify correct

--- a/test/tests.py
+++ b/test/tests.py
@@ -323,7 +323,7 @@ class DMLFileTestCase(BaseTestCase):
         by zero or more context lines not on the form "In ..." (e.g.,
         "previously declared here").
 
-        The unittest_parse_messages() function contains a concrete example.
+        The _unittest_parse_messages() function contains a concrete example.
 
         """
 
@@ -543,6 +543,19 @@ class DMLFileTestCase(BaseTestCase):
         for kind in set().union(actual_msgs, expected_msgs):
             self.expect_messages(
                 kind, actual_msgs.get(kind, []), expected_msgs.get(kind, []))
+
+def _unittest_parse_messages():
+    stderr = '''
+/tmp/f.dml:3:20: In template abc
+/tmp/g.dml:4:9: error EDPARAM: blah blah
+/tmp/f.dml:8:12: conflicting definition
+'''.splitlines()
+    assert (list(DMLFileTestCase.parse_messages(stderr))
+            == [('error', 'EDPARAM',
+                 [('g.dml', 4, "/tmp/g.dml:4:9: error EDPARAM: blah blah"),
+                  ('f.dml', 3, "/tmp/f.dml:3:20: In template abc"),
+                  ('f.dml', 8, "/tmp/f.dml:8:12: conflicting definition")])])
+_unittest_parse_messages()
 
 class CTestCase(DMLFileTestCase):
     '''Compile a test DML file with the C backend and verify correct
@@ -816,16 +829,6 @@ class DMLCProfileTestCase(CTestCase):
                 raise TestFail(f'cannot load profile data')
         else:
             raise TestFail(f'stats file not generated')
-
-def _unittest_parse_messages():
-    stderr = '''
-/tmp/f.dml:3:20: In template abc
-/tmp/g.dml:4:9: error EDPARAM: duplicate assignment to parameter 'f'
-/tmp/f.dml:8:12: conflicting definition
-'''.splitlines()
-    assert (list(DMLFileTestCase.parse_messages(stderr))
-            == [('error', 'EDPARAM',
-                 [('g.dml', 4), ('f.dml', 3), ('f.dml', 8)])])
 
 all_tests = []
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -120,9 +120,7 @@ os.environ['DMLC_DEBUG'] = 't'
 
 latest_api_version = "6"
 
-special_versions = {}
-for f in ["T_WREF.dml"]:
-    special_versions[f] = "5"
+special_versions = {"T_WREF.dml": "5"}
 
 def simics_api_version(filename):
     base = os.path.basename(filename)
@@ -199,7 +197,7 @@ class DMLFileTestCase(BaseTestCase):
         BaseTestCase.__init__(self, fullname)
         # Defaults
         self.filename = filename
-        self.api_version = None
+        self.api_version = latest_api_version
         self.includepath = None
         self.dmlc_extraargs = []
         self.cc_extraargs = []
@@ -851,15 +849,13 @@ all_tests.append(ErrorTest(
     errors=[(os.path.basename(os.devnull), 1, "EDEVICE")],
     warnings=[(os.path.basename(os.devnull), 1, "WNOVER")],
     includepath=()))
-all_tests.append(CTestCase(["minimal"], join(testdir, "minimal.dml"),
-                           api_version=latest_api_version))
+all_tests.append(CTestCase(["minimal"], join(testdir, "minimal.dml")))
 
 # Test that it fails with a good error message if it can't find
 # dml-builtins.dml etc.
 all_tests.append(ErrorTest(["noinclude"], join(testdir, "minimal.dml"),
                            errors=[("minimal.dml", 6, "EIMPORT")],
-                           includepath=(), api_version=latest_api_version,
-                           dmlc_extraargs=['--max-errors=1']))
+                           includepath=(), dmlc_extraargs=['--max-errors=1']))
 
 # Test DMLC_PROFILE
 all_tests.append(DMLCProfileTestCase(["dmlc_profile"],
@@ -876,12 +872,10 @@ all_tests.append(DMLCProfileTestCase(["dmlc_profile"],
 all_tests.append(CTestCase(
          ["debuggable-compile"],
          join(testdir, "1.2", "methods", "T_inline.dml"),
-         api_version=latest_api_version,
          dmlc_extraargs = ["-g"]))
 all_tests.append(CTestCase(
          ["debuggable-compile-connect"],
          join(testdir, "1.2", "structure", "T_connect_obj.dml"),
-         api_version=latest_api_version,
          dmlc_extraargs = ["-g"]))
 
 class SplitTestCase(CTestCase):
@@ -923,20 +917,17 @@ class SplitTestCase(CTestCase):
 all_tests.append(SplitTestCase(
          ["split"],
          join(testdir, "1.2", "misc", "T_split_output.dml"),
-         api_version=latest_api_version,
          dmlc_extraargs=["--split-c-file=1", "--state-change-dml12"]))
 
 all_tests.append(CTestCase(
          ["1.2", "misc", "test_dmlc_g"],
          join(testdir, "1.2", "misc", "test_dmlc_g.dml"),
-         api_version=latest_api_version,
          dmlc_extraargs = ["-g"]))
 
 # Test the --werror flag
 all_tests.append(CTestCase(
          ["werror"],
          join(testdir, "1.2", "werror", "T_WUNUSEDDEFAULT.dml"),
-         api_version=latest_api_version,
          status = 2,
          dmlc_extraargs = ["--werror"]))
 
@@ -1047,8 +1038,7 @@ class DmlDep(DmlDepBase):
 
 all_tests.append(DmlDep(['dmldep'],
                         join(testdir, '1.2', 'misc', 'T_import_rel_1.dml'),
-                        dmlc_extraargs = ['--dep', 'T_dmldep.dmldep'],
-                        api_version=latest_api_version))
+                        dmlc_extraargs = ['--dep', 'T_dmldep.dmldep']))
 
 class DmlDepArgs(DmlDepBase):
     '''Test optional arguments for dependency generation.'''
@@ -1064,8 +1054,7 @@ all_tests.append(
                dmlc_extraargs=[
                    '--dep=T_dmldepargs.dmldep', '--no-dep-phony',
                    '--dep-target=x.dml', '--dep-target=y.dml'
-               ],
-               api_version=latest_api_version))
+               ]))
 
 class PortingConvert(CTestCase):
     __slots__ = ('PORTING',)
@@ -1207,7 +1196,6 @@ class PortingConvertFail(PortingConvert):
 all_tests.append(PortingConvert(
     ["porting"],
     join(testdir, "1.2", "misc", "T_porting.dml"),
-    api_version=latest_api_version,
     PORTING=[("porting.dml", None, tag) for tag in [
         'PSHA1',
         'PVERSION',
@@ -1288,7 +1276,6 @@ all_tests.append(PortingConvert(
 all_tests.append(PortingConvertFail(
     ["porting_fail"],
     join(testdir, "1.2", "misc", "T_porting_fail.dml"),
-    api_version=latest_api_version,
     PORTING=[("T_porting_fail.dml", None, tag) for tag in [
         'PSHA1',
         'PVERSION',
@@ -1339,7 +1326,6 @@ all_tests.append(CompareIllegalAttrs('compare-illegal-attrs'))
 
 all_tests.append(CTestCase(["T_EIDXVAR_info"],
                            join(testdir, "1.2", "errors", "T_EIDXVAR.dml"),
-                           api_version=latest_api_version,
                            status=2, dmlc_extraargs = ["--info"]))
 
 class DevInfoCompare(BaseTestCase):
@@ -1518,7 +1504,6 @@ for version in ['1.2', '1.4']:
     generate = CTestCase(
         [testname],
         join(testdir, version, 'misc', 'devinfo.dml'),
-        api_version=latest_api_version,
         dmlc_extraargs=['--info'])
     all_tests.append(generate)
     all_tests.append(DevInfoCompare(
@@ -1529,37 +1514,31 @@ all_tests.append(
     XmlTestCase(
         ['1.2-register-view'],
         join(testdir, '1.2', 'misc', 'register_view.dml'),
-        api_version=latest_api_version,
         dmlc_extraargs=['--info']))
 all_tests.append(
     XmlTestCase(
         ['1.2-register-view-descriptions'],
         join(testdir, '1.2', 'misc', 'register_view_descriptions.dml'),
-        api_version=latest_api_version,
         dmlc_extraargs=['--info']))
 all_tests.append(
     XmlTestCase(
         ['1.2-register-view-bitorder-le'],
         join(testdir, '1.2', 'misc', 'register_view_bitorder_le.dml'),
-        api_version=latest_api_version,
         dmlc_extraargs=['--info']))
 all_tests.append(
     XmlTestCase(
         ['1.2-register-view-bitorder-be'],
         join(testdir, '1.2', 'misc', 'register_view_bitorder_be.dml'),
-        api_version=latest_api_version,
         dmlc_extraargs=['--info']))
 all_tests.append(
     XmlTestCase(
         ['1.2-register-view-inquiry'],
         join(testdir, '1.2', 'misc', 'register_view_inquiry.dml'),
-        api_version=latest_api_version,
         dmlc_extraargs=['--info']))
 all_tests.append(
     XmlTestCase(
         ['1.2-register-view-fields'],
         join(testdir, '1.2', 'misc', 'register_view_fields.dml'),
-        api_version=latest_api_version,
         dmlc_extraargs=['--info']))
 
 def walk(rootdir):


### PR DESCRIPTION
- Repair and run test
- Provide a sensible default for api_version
- Simplify profiling test case
- Add environment variable DMLC_DUMP_INPUT_FILES
