### PR TITLE
Make release note headers abide to Intel standards

### DIFF
--- a/RELEASENOTES-1.2.docu
+++ b/RELEASENOTES-1.2.docu
@@ -4,7 +4,7 @@
 -->
 
 <rn id="dml-1.2">
-  <name>DML 1.2</name>
+  <name>Device Modeling Language (DML) 1.2</name>
   <build-id value="6012"><add-note> Fixed a bug that caused a crash on the
     expression
     <tt>1 &lt;&lt; 64</tt> <bug number="1306575446"/>. </add-note></build-id>

--- a/RELEASENOTES-1.2.docu
+++ b/RELEASENOTES-1.2.docu
@@ -17,7 +17,7 @@
     defined templates. </add-note></build-id>
   <build-id value="6019"><add-note> The <tt>get</tt> and <tt>set</tt> methods
     are now shared in attributes
-    inheriting from the dml 1.4 utility templates
+    inheriting from the DML 1.4 utility templates
     (<tt>bool_attr</tt> etc.). </add-note></build-id>
   <build-id value="6024"><add-note> The <tt>import</tt> statement has been
     changed: If the path

--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -4,7 +4,7 @@
 -->
 
 <rn id="dml-1.4">
-  <name>DML 1.4</name>
+  <name>Device Modeling Language (DML) 1.4</name>
   <build-id value="6012"><add-note> Initial release of DML version 1.4. The new
     language version is
     documented in the <em>DML 1.4 reference manual</em>

--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -34,9 +34,9 @@
     <tt>method extern</tt>. </add-note></build-id>
   <build-id value="6018"><add-note> The dml12-compatibility.dml library file is
     now available.
-    This file should be included from dml 1.4 files that
-    use or override templates defined in dml-builtins and
-    are meant to be backwards-compatible with dml
+    This file should be included from DML 1.4 files that
+    use or override templates defined in <tt>dml-builtins.dml</tt> and
+    are meant to be backwards-compatible with DML
     1.2 devices. </add-note></build-id>
   <build-id value="6018"><add-note> Templates can now override <tt>get</tt> or
     <tt>set</tt> method

--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -4,7 +4,7 @@
 -->
 
 <rn id="dml">
-  <name>DML</name>
+  <name>Device Modeling Language (DML)</name>
   <build-id value="1313"><add-note> A bug that caused bad C code to be
     generated when using 'switch'
     was fixed <bug number="4766"/> <bug number="4788"/>. </add-note></build-id>


### PR DESCRIPTION
- Spell DML in uppercase
- Make release note headers abide to Intel standards
