### PR TITLE
Fix bug in naming when init_as_subobj is instantiated in a bank or port

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -311,4 +311,8 @@
       corresponding Simics object does not add a `port.` prefix. For
       instance, the object for `subdevice x;` is named `dev.x` instead
       of `dev.port.x`.</add-note></build-id>
+  <build-id value="next"><add-note> Fixed a bug that caused incorrect
+      Simics object names when the `init_as_subobj` template is
+      instantiated on a `connect` object inside a `bank` or `port`
+      object.</add-note></build-id>
 </rn>

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -1008,10 +1008,14 @@ template init_as_subobj is (connect, init, _qname) {
     param classname;
     param configuration default "none";
     method init() default {
-        local conf_object_t *o = SIM_object_descendant(dev.obj, this._qname());
+        local int portname_len = this._nongroup_parent.objtype == "device"
+            #? 0 #: strlen(this._nongroup_parent._qname()) + 1;
+        local conf_object_t *o = SIM_object_descendant(
+            this._nongroup_parent.obj, this._qname() + portname_len);
         if (o == NULL) {
             // should not happen
-            log critical: "subobject %s not found", this._qname();
+            log critical: "subobject %s not found",
+                this._qname() + portname_len;
         }
         local set_error_t err = this.set_attribute(SIM_make_attr_object(o));
         if (err != Sim_Set_Ok) {

--- a/test/1.4/lib/T_connect.dml
+++ b/test/1.4/lib/T_connect.dml
@@ -36,6 +36,29 @@ group sub[i < 2] {
     }
 }
 
+subdevice a[i < 2] {
+    param name = "a2";
+    bank b[j < 3] {
+        param name = "b2";
+        group c[k < 5] {
+            param name = "c2";
+            connect d[l < 7] is init_as_subobj {
+                param classname = "signal_stub";
+            }
+        }
+    }
+    subdevice e {
+        connect f is init_as_subobj {
+            param classname = "signal_stub";
+        }
+    }
+    port p {
+        connect q is init_as_subobj {
+            param classname = "signal_stub";
+        }
+    }
+}
+
 connect noconf is init_as_subobj {
     param classname = "signal_stub";
     interface signal;

--- a/test/1.4/lib/T_connect.py
+++ b/test/1.4/lib/T_connect.py
@@ -28,6 +28,11 @@ stest.expect_equal(obj.sub[1].classname, 'namespace')
 stest.expect_equal(obj.sub[1].renamed.classname, 'signal_stub')
 stest.expect_equal(obj.attr.sub_renamed, [obj.sub[0].renamed,
                                           obj.sub[1].renamed])
+
+stest.expect_true(SIM_object_descendant(obj, "a2[1].bank.b2[2].c2[4].d[6]"))
+stest.expect_true(SIM_object_descendant(obj, "a2[1].e.f"))
+stest.expect_true(SIM_object_descendant(obj, "a2[1].port.p.q"))
+
 # by default, init_as_subobj connects have configuration=none
 stest.expect_false(SIM_class_has_attribute('test', 'noconf'))
 


### PR DESCRIPTION
Reported on IM by Sven.
