### PR TITLE
Pass -r flag to gcc directly

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -925,7 +925,7 @@ class SplitTestCase(CTestCase):
                 return result
         self.cc_stdout = join(self.scratchdir, self.shortname + '.cc_stdout')
         self.cc_stderr = join(self.scratchdir, self.shortname + '.cc_stderr')
-        ld = cc + ['-Wl,-r', '-nostdlib', '-o', self.cfilename + '.o'] + [
+        ld = cc + ['-r', '-nostdlib', '-o', self.cfilename + '.o'] + [
             fn[:-2] + '.o' for fn in files]
 
         result = subprocess.call(ld,


### PR DESCRIPTION
This fixes problems on Ubuntu 20.4, where gcc passes -pie to the linker
by default, which is incompatible with -r. Passing -r to gcc suppresses
this default, whereas -Wl,-r does not.