### PR TITLE
Log messages for unmapped accesses from unmapped_{read,write}

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -356,4 +356,14 @@
   <build-id value="6171"><add-note>The methods <tt>signal_raise</tt> and
     <tt>signal_lower</tt> are now overridable in HRESET port defined in template
     <tt>hreset</tt></add-note></build-id>
+  <build-id value="next"><add-note> When a transaction misses in a
+      bank, the error message is now logged by the <tt>unmapped_read</tt> and
+      <tt>unmapped_write</tt> methods of the bank, instead of
+      <tt>io_memory_access</tt> or <tt>transaction_access</tt>. This
+      makes it easier to override the default behaviour; however, if a
+      model suppresses logging by providing a local alternative
+      implementation of the <tt>*_access</tt> methods, and that
+      implementation still calls <tt>unmapped_read</tt>
+      or <tt>unmapped_write</tt>, then that model will no longer
+      suppress logging.</add-note></build-id>
 </rn>

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -1175,6 +1175,14 @@ method _mask(uint64 size) -> (uint64) {
 
 // TODO(enilsson): preferably, we'd be able to remove the need for
 // these methods by iterating over enabled_bytes in other methods
+
+// An access to 0x4 with bits 0x00ffff00 enabled can either be viewed as a
+// 2-byte access to 0x5, or a N-byte access to 0x4 for some N≥3. We choose to
+// present it as a 3-byte access to 0x4 for two reasons: first, misaligned
+// bitmask is an indication that HW requires even addresses so that's probably
+// natural; second, code that wants to capture accesses to an odd-addressed reg
+// but forgets to check addr=4 would break anyway on an (addr=4,
+// bits=0xffffffff) access.
 method _enabled_bytes_to_size(uint64 enabled_bytes) -> (uint64) {
     for (local int size = 8; size > 0; --size) {
         if ((enabled_bytes & (0xff << 56)) != 0) {

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -1284,7 +1284,7 @@ byte in the access. The *value* parameter contains the
 originally written value, including parts that are mapped to
 registers. Both *bits* and *value* are
 expressed in the host's endianness. The default behavior is to
-unconditionally throw an exception.
+log a `spec-viol` message on level 1, and throw an exception.
 </dd><dt>
 
 <small>read(uint64 offset, uint64 enabled\_bytes, void \*aux) ->
@@ -1603,11 +1603,20 @@ template bank is (object, shown_desc, _qname) {
 
     shared method unmapped_read(uint64 offset, uint64 bits, void *aux)
         -> (uint64) throws default {
+        log spec_viol, 1, Register_Read:
+            "%d byte read access at offset %#x in %s" +
+            " outside registers or misaligned access",
+            _enabled_bytes_to_size(bits), offset, this._qname();
         throw;
     }
 
-    shared method unmapped_write(uint64 offset, uint64 value, uint64 bits, void *aux)
+    shared method unmapped_write(uint64 offset, uint64 value, uint64 bits,
+                                 void *aux)
         throws default {
+        log spec_viol, 1, Register_Write:
+            "%d byte write access at offset %#x in %s" +
+            " outside registers or misaligned access",
+            _enabled_bytes_to_size(bits), offset, this._qname();
         throw;
     }
 
@@ -1834,19 +1843,6 @@ template bank is (object, shown_desc, _qname) {
         }
     }
 
-    shared method _log_miss(bool is_read, int size, uint64 offset) {
-        if (is_read)
-            log spec_viol, 1, Register_Read:
-                "%d byte read access at offset %#x in %s" +
-                " outside registers or misaligned access",
-                    size, offset, this._qname();
-        else
-            log spec_viol, 1, Register_Write:
-                "%d byte write access at offset %#x in %s" +
-                " outside registers or misaligned access",
-                    size, offset, this._qname();
-    }
-
     session conf_object_t *_cached_bank_obj;
     shared method _bank_obj() -> (conf_object_t *) {
         if (this._cached_bank_obj != NULL) {
@@ -1935,10 +1931,6 @@ template bank is (object, shown_desc, _qname) {
             _callback_after_write(this._bank_obj(), ini, &offset, size,
                                   &success, &_connections,
                                   &_after_write_callbacks);
-        }
-
-        if (!inquiry && !success) {
-            this._log_miss(SIM_mem_op_is_read(memop), size, offset);
         }
 
         if (inquiry_override) {
@@ -2060,9 +2052,6 @@ template bank is (object, shown_desc, _qname) {
                                   &_after_write_callbacks);
         }
 
-        if (!inquiry && !success) {
-            this._log_miss(is_read, size, offset);
-        }
         return success;
     }
 

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -1858,18 +1858,7 @@ template bank is (object, shown_desc, _qname) {
         default {
         local uint64 size = SIM_get_mem_op_size(memop);
         local bool inquiry = SIM_get_mem_op_inquiry(memop);
-        local bool inquiry_override = false;
         local conf_object_t *ini = SIM_get_mem_op_initiator(memop);
-        if (SIM_mem_op_is_read(memop) && !inquiry) {
-            _callback_before_read(this._bank_obj(), ini, &inquiry_override,
-                                  &offset, size,
-                                  &_connections, &_before_read_callbacks);
-            if (inquiry_override) {
-                // restored before return
-                SIM_set_mem_op_inquiry(memop, true);
-                inquiry = true;
-            }
-        }
 
         local bool success = true;
         if (inquiry) {
@@ -1879,12 +1868,6 @@ template bank is (object, shown_desc, _qname) {
                     value = this.get(offset, size);
                 } catch {
                     success = false;
-                }
-
-                if (inquiry_override) {
-                    _callback_after_read(this._bank_obj(), ini, &offset, size,
-                                         &value, &success, &_connections,
-                                         &_after_read_callbacks);
                 }
 
                 if (success) {
@@ -1897,12 +1880,19 @@ template bank is (object, shown_desc, _qname) {
         } else {
             if (SIM_mem_op_is_read(memop)) {
                 local uint64 value = 0;
+                local bool inquiry_override = false;
+                _callback_before_read(
+                    this._bank_obj(), ini, &inquiry_override,
+                    &offset, size, &_connections, &_before_read_callbacks);
                 try {
-                    value = this.read(offset, _mask(size), aux);
+                    if (inquiry_override) {
+                        value = this.get(offset, size);
+                    } else {
+                        value = this.read(offset, _mask(size), aux);
+                    }
                 } catch {
                     success = false;
                 }
-
                 _callback_after_read(this._bank_obj(), ini, &offset, size,
                                      &value, &success, &_connections,
                                      &_after_read_callbacks);
@@ -1924,18 +1914,12 @@ template bank is (object, shown_desc, _qname) {
                         success = false;
                     }
                 }
+                _callback_after_write(this._bank_obj(), ini, &offset, size,
+                                      &success, &_connections,
+                                      &_after_write_callbacks);
             }
         }
 
-        if (!SIM_mem_op_is_read(memop) && !inquiry) {
-            _callback_after_write(this._bank_obj(), ini, &offset, size,
-                                  &success, &_connections,
-                                  &_after_write_callbacks);
-        }
-
-        if (inquiry_override) {
-            SIM_set_mem_op_inquiry(memop, false);
-        }
         return success;
     }
 
@@ -1980,15 +1964,6 @@ template bank is (object, shown_desc, _qname) {
     shared method _transaction_access(
         conf_object_t *ini, bool is_read, bool inquiry,
         uint64 offset, uint64 size, uint8 *buf, void *aux) -> (bool) {
-        local bool inquiry_override = false;
-        if (is_read && !inquiry) {
-            _callback_before_read(this._bank_obj(), ini,
-                                  &inquiry_override, &offset,
-                                  size, &_connections, &_before_read_callbacks);
-            if (inquiry_override) {
-                inquiry = true;
-            }
-        }
 
         local bool success = true;
         if (inquiry) {
@@ -2000,12 +1975,6 @@ template bank is (object, shown_desc, _qname) {
                     success = false;
                 }
 
-                if (inquiry_override) {
-                    _callback_after_read(this._bank_obj(), ini, &offset, size,
-                                         &value, &success, &_connections,
-                                         &_after_read_callbacks);
-                }
-
                 if (success) {
                     this._set_read_value(size, buf, value);
                 }
@@ -2015,9 +1984,17 @@ template bank is (object, shown_desc, _qname) {
             }
         } else {
             if (is_read) {
+                local bool inquiry_override = false;
+                _callback_before_read(this._bank_obj(), ini,
+                                      &inquiry_override, &offset,
+                                      size, &_connections, &_before_read_callbacks);
                 local uint64 value = 0;
                 try {
-                    value = this.read(offset, _mask(size), aux);
+                    if (inquiry_override) {
+                        value = this.get(offset, size);
+                    } else {
+                        value = this.read(offset, _mask(size), aux);
+                    }
                 } catch {
                     success = false;
                 }
@@ -2043,13 +2020,10 @@ template bank is (object, shown_desc, _qname) {
                         success = false;
                     }
                 }
+                _callback_after_write(this._bank_obj(), ini, &offset, size,
+                                      &success, &_connections,
+                                      &_after_write_callbacks);
             }
-        }
-
-        if (!is_read && !inquiry) {
-            _callback_after_write(this._bank_obj(), ini, &offset, size,
-                                  &success, &_connections,
-                                  &_after_write_callbacks);
         }
 
         return success;

--- a/test/1.4/lib/T_io_memory.py
+++ b/test/1.4/lib/T_io_memory.py
@@ -24,8 +24,7 @@ r = dev_util.Register_LE(e, 3, size=4)
 miss = dev_util.Register_LE(e, 13, size=4)
 stest.expect_equal((r.read(), e.read_offset, e.read_mask, e.read_aux),
                    (4711, 3, 0xffffffff, 1234))
-with stest.expect_log_mgr(obj, 'spec-viol'), \
-     stest.expect_exception_mgr(dev_util.MemoryError):
+with stest.expect_exception_mgr(dev_util.MemoryError):
     miss.read()
 
 r.read_transaction.inquiry = True
@@ -37,8 +36,7 @@ with stest.expect_exception_mgr(dev_util.MemoryError):
 r.write(0xdeadbeef)
 stest.expect_equal((e.write_offset, e.write_value, e.write_mask, e.write_aux),
                    (3, 0xdeadbeef, 0xffffffff, 1234))
-with stest.expect_log_mgr(obj, 'spec-viol'), \
-     stest.expect_exception_mgr(dev_util.MemoryError):
+with stest.expect_exception_mgr(dev_util.MemoryError):
     miss.write(5)
 
 r.write_transaction.inquiry = True

--- a/test/1.4/lib/T_transaction.py
+++ b/test/1.4/lib/T_transaction.py
@@ -12,9 +12,8 @@ for b, endian in ((obj.bank.b, 'little'), (obj.bank.be, 'big')):
                         b.read_mask, b.read_aux),
                        (Sim_PE_No_Exception, 3, 4711, 0xffffffff, 1234),
                        trans.data)
-    with stest.expect_log_mgr(obj, 'spec-viol'):
-        stest.expect_equal(b.iface.transaction.issue(trans, 13),
-                           Sim_PE_IO_Not_Taken)
+    stest.expect_equal(b.iface.transaction.issue(trans, 13),
+                       Sim_PE_IO_Not_Taken)
 
     trans = transaction_t(read=True, inquiry=True, size=4)
     stest.expect_equal((b.iface.transaction.issue(trans, 3), b.get_offset,
@@ -29,9 +28,8 @@ for b, endian in ((obj.bank.b, 'little'), (obj.bank.be, 'big')):
                         b.write_offset, b.write_value, b.write_mask,
                         b.write_aux),
                        (Sim_PE_No_Exception, 5, 4712, 0xffffff, 1234))
-    with stest.expect_log_mgr(obj, 'spec-viol'):
-        stest.expect_equal(b.iface.transaction.issue(trans, 13),
-                           Sim_PE_IO_Not_Taken)
+    stest.expect_equal(b.iface.transaction.issue(trans, 13),
+                       Sim_PE_IO_Not_Taken)
 
     trans = transaction_t(
         write=True, inquiry=True, data=int.to_bytes(4712, 3, endian))

--- a/test/common/instrumentation_access_set_value.py
+++ b/test/common/instrumentation_access_set_value.py
@@ -17,7 +17,10 @@ def test(obj, provider):
     # An access miss is implicitly forgiven if the access value is set
     handle_2 = provider.register_after_read(
         None, 0xc, 4, set_value_callback(4711), None)
-    stest.expect_equal(dev_util.Register_LE(obj.bank.b1, 0xc, 4).read(), 4711)
+
+    # spec-viol is suppressed in 1.2 but not 1.4
+    with stest.allow_log_mgr(obj, 'spec-viol'):
+        stest.expect_equal(dev_util.Register_LE(obj.bank.b1, 0xc, 4).read(), 4711)
 
     provider.remove_callback(handle_1)
     provider.remove_callback(handle_2)


### PR DESCRIPTION
Apart from the effects mentioned in the release note, this also means
that the message can not be suppressed by bank_instrumentation.after_write
