### PR TITLE
Repair IS_INT64 macro

### DIFF
--- a/py/dml/ctree-test.h
+++ b/py/dml/ctree-test.h
@@ -18,12 +18,9 @@ static void capture_assert_error(int line, const char *file,
 
 api_function_t SIM_get_api_function(const char *name) { return NULL; }
 
-#define IS_UINT32(x) (((x) | INT_MIN) > 0               \
-                      && (((x) | 1) << 16) << 16 == 0)
-#define IS_INT64(x) (((x) | LLONG_MIN) < 0              \
-                     && (((__int128)(x) | 1) << 16) << 16 != 0)
-#define IS_UINT64(x) (((x) | LLONG_MIN) > 0                             \
-                      && (((x) | ULLONG_MAX) << 1) < ULLONG_MAX)
+#define IS_UINT32(x) (sizeof(x) == 4 && ((x) | INT_MIN) > 0)
+#define IS_INT64(x)  (sizeof(x) == 8 && ((x) | LLONG_MIN) < 0)
+#define IS_UINT64(x) (sizeof(x) == 8 && ((x) | LLONG_MIN) > 0)
 #define IS_DOUBLE(x) (sizeof(x) == 8 && ((typeof(x))0.5 == 0.5))
 
 static bool failure = false;

--- a/py/dml/ctree_test.py
+++ b/py/dml/ctree_test.py
@@ -258,13 +258,22 @@ class ExprTests(GccTests):
     @subtest()
     def framework_assertions(self):
         '''validate helper macros used later in test'''
-        return (['int64 i = 0;',
+        return (['int32 i32 = 0;',
+                 'ASSERT(!IS_UINT32(i32));',
+                 'ASSERT(!IS_INT64(i32));',
+                 'ASSERT(!IS_UINT64(i32));',
+                 'uint32 u32 = 0;',
+                 'ASSERT(IS_UINT32(u32));',
+                 'ASSERT(!IS_INT64(u32));',
+                 'ASSERT(!IS_UINT64(u32));',
+                 'int64 i = 0;',
                  'ASSERT(!IS_UINT32(i));',
                  'ASSERT(IS_INT64(i));',
                  'ASSERT(!IS_UINT64(i));',
                  'ASSERT(IS_INT64(0x7fffffffffffffff));',
                  'ASSERT(!IS_INT64(0x8000000000000000));',
                  'uint64 u = 0;',
+                 'ASSERT(!IS_UINT32(u));',
                  'ASSERT(!IS_INT64(u));',
                  'ASSERT(IS_UINT64(u));',
                  'ASSERT(!IS_UINT64(0x7fffffffffffffff));',


### PR DESCRIPTION
It detected any 32-bit integer value as being int64
