### PR TITLE
Keep line numbers separately in SimpleSite

### DIFF
--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -73,9 +73,9 @@ def process(devname, global_defs, top_tpl, extra_params):
         # inheriting the main file, thereby overriding any default
         # declarations from there
         param_tpl = '@<command-line>'
-        param_site = SimpleSite("<command-line>:0",
+        param_site = SimpleSite("<command-line>", 0,
                                 dml_version=dml.globals.dml_version)
-        top_site = SimpleSite(top_tpl[1:] + ':1',
+        top_site = SimpleSite(top_tpl[1:], 1,
                               dml_version=dml.globals.dml_version)
         global_defs.append(ast.template_dml12(
             top_site, param_tpl, [
@@ -112,7 +112,7 @@ def mytrace(frame, event, arg):
 
 def parse_define(arg):
     "Parse a parameter assignment given as a -D option"
-    define_site = SimpleSite('<command-line>:0',
+    define_site = SimpleSite('<command-line>', 0,
                              dml_version=dml.globals.dml_version)
     (lexer, _) = toplevel.get_parser((1, 4))
     lexer.filename = filename = "<command-line>"

--- a/py/dml/dmlparse.py
+++ b/py/dml/dmlparse.py
@@ -128,7 +128,7 @@ def end_site(site):
         # We still produce a well-formed site, to avoid confusing
         # port-dml's tag parser
         if os.path.isfile(site.filename() + 'ast'):
-            return SimpleSite(site.filename() + ':1:1')
+            return SimpleSite(site.filename(), 1, 1)
         # unknown...
         return None
     (_, end) = lexspan_map[site]

--- a/py/dml/logging.py
+++ b/py/dml/logging.py
@@ -276,14 +276,17 @@ class Site(metaclass=abc.ABCMeta):
 class SimpleSite(Site):
     '''A variant of Site without line information. Useful for code
     that doesn't come from a real DML file'''
-    __slots__ = ('_name', '_dml_version')
-    def __init__(self, name, dml_version=(1, 4)):
+    __slots__ = ('_name', '_line', '_dml_version')
+    def __init__(self, name, line=None, column=None, dml_version=(1, 4)):
         self._name = name
         self._dml_version = dml_version
+        self._line = '' if line is None else f':{line}'
+        if column is not None:
+            self._line += f':{column}'
     def __repr__(self):
-        return '<site %s>' % (self._name,)
+        return f'<site {self.loc()}>'
     def loc(self):
-        return self._name
+        return f'{self._name}{self._line}'
     def filename(self):
         return self._name
     def dml_version(self):

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1690,7 +1690,7 @@ class WOLDAST(DMLWarning):
     """
     fmt = "Outdated AST file: %s"
     def __init__(self, dmlfile):
-        DMLWarning.__init__(self, SimpleSite(dmlfile + ":0"),
+        DMLWarning.__init__(self, SimpleSite(dmlfile, 0),
                             dmlfile + "ast")
 
 class WWRNSTMT(DMLWarning):

--- a/py/dml/output.py
+++ b/py/dml/output.py
@@ -73,7 +73,7 @@ class FileOutput(Output):
 
     def commit(self):
         if self.indent:
-            raise ICE(SimpleSite("%s:0" % self.filename), 'Unbalanced indent')
+            raise ICE(SimpleSite(self.filename, 0), 'Unbalanced indent')
         try:
             os.remove(self.filename)
         except OSError:


### PR DESCRIPTION
This avoids a weird :1 in some generated #line directives.
