### PR TITLE
Allow enabling line directives when running test suite

### DIFF
--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -2147,8 +2147,9 @@ class SingleParamValue(ParamValue):
     ptype: DMLType
     def tinit_arg(self):
         if deep_const(self.ptype):
-            k = (TArray(self.ptype, mkIntegerLiteral(logging.SimpleSite(""), 1))
-                 .declaration(""))
+            k = TArray(self.ptype,
+                       mkIntegerLiteral(logging.SimpleSite(
+                           "<SingleParamValue>"), 1)).declaration("")
             size = f'sizeof({self.ptype.declaration("")})'
             return f'memcpy(malloc({size}), ({k}) {{ {self.value} }}, {size})'
         else:

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -2080,7 +2080,7 @@ def stmt_log(stmt, location, scope):
                                         ExpressionInitializer(level_expr))]
         level = mkLocalVariable(site, LocalSymbol("_calculated_level",
                                                   "_calculated_level",
-                                                  TInt(64, False)))
+                                                  TInt(64, False), site=site))
 
     else:
         pre_statements = []
@@ -2231,14 +2231,14 @@ def foreach_each_in(site, itername, trait, each_in,
     scope = Symtab(scope)
     each_in_sym = scope.add_variable(
         '_each_in_expr', type=TTraitList(trait.name),
-        init=ExpressionInitializer(each_in), stmt = True)
+        init=ExpressionInitializer(each_in), stmt=True, site=site)
     ident = each_in_sym.value
     inner_scope = Symtab(scope)
     trait_type = TTrait(trait)
     trait_ptr = (f'(struct _{cident(trait.name)} *) _list.vtable')
     obj_ref = '(_identity_t) { .id = _list.id, .encoded_index = _inner_idx}'
     inner_scope.add_variable(
-        itername, type=trait_type,
+        itername, type=trait_type, site=site,
         init=ExpressionInitializer(
             mkLit(site,
                   ('((%s) {%s, %s})' % (trait_type.declaration(''),
@@ -3027,7 +3027,8 @@ def codegen_method(site, inp, outp, throws, independent, memoization, ast,
                 code = []
                 for ((varname, parmtype), init) in zip(outp, initializers):
                     sym = fnscope.add_variable(
-                        varname, type=parmtype, init=init, make_unique=True)
+                        varname, type=parmtype, init=init, make_unique=True,
+                        site=ast.site)
                     sym.incref()
                     code.append(sym_declaration(sym))
             else:

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -4391,6 +4391,7 @@ class Declaration(Statement):
     "A variable declaration"
     is_declaration = True
     def __init__(self, site, name, type, init = None, unused = False):
+        assert site
         self.site = site
         self.name = name
         self.type = type

--- a/py/dml/ctree_test.py
+++ b/py/dml/ctree_test.py
@@ -764,9 +764,9 @@ class ExprTests(GccTests):
         with endian_var_decl:
             var_declaration.toc()
         operation = op(site, ctree.mkLocalVariable(
-            site, symtab.LocalSymbol('x', 'x', endian_type)))
+            site, symtab.LocalSymbol('x', 'x', endian_type, site=site)))
         var_read = ctree.as_int(ctree.mkLocalVariable(
-            site, symtab.LocalSymbol('x', 'x', endian_type)))
+            site, symtab.LocalSymbol('x', 'x', endian_type, site=site)))
         expect_int64 = size != 8 or signed
         self.expect_int_type(operation.ctype(), expect_int64)
         return [

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -73,9 +73,9 @@ def process(devname, global_defs, top_tpl, extra_params):
         # inheriting the main file, thereby overriding any default
         # declarations from there
         param_tpl = '@<command-line>'
-        param_site = SimpleSite("<command-line>", 0,
+        param_site = SimpleSite("<command-line>:0",
                                 dml_version=dml.globals.dml_version)
-        top_site = SimpleSite(top_tpl[1:], 1,
+        top_site = SimpleSite(top_tpl[1:] + ':1',
                               dml_version=dml.globals.dml_version)
         global_defs.append(ast.template_dml12(
             top_site, param_tpl, [
@@ -112,7 +112,7 @@ def mytrace(frame, event, arg):
 
 def parse_define(arg):
     "Parse a parameter assignment given as a -D option"
-    define_site = SimpleSite('<command-line>', 0,
+    define_site = SimpleSite('<command-line>:0',
                              dml_version=dml.globals.dml_version)
     (lexer, _) = toplevel.get_parser((1, 4))
     lexer.filename = filename = "<command-line>"

--- a/py/dml/dmlparse.py
+++ b/py/dml/dmlparse.py
@@ -128,7 +128,7 @@ def end_site(site):
         # We still produce a well-formed site, to avoid confusing
         # port-dml's tag parser
         if os.path.isfile(site.filename() + 'ast'):
-            return SimpleSite(site.filename(), 1, 1)
+            return SimpleSite(site.filename() + ':1:1')
         # unknown...
         return None
     (_, end) = lexspan_map[site]

--- a/py/dml/expr.py
+++ b/py/dml/expr.py
@@ -31,7 +31,7 @@ class Code(object, metaclass=SlotsMeta):
                                     for name in self.init_args[2:]))
 
     def linemark(self):
-        if dml.globals.linemarks and self.site:
+        if dml.globals.linemarks and not isinstance(self.site, SimpleSite):
             # out("/* %s */\n" % repr(self))
             out('#line %d "%s"\n' % (self.site.lineno,
                                      quote_filename(self.site.filename())))

--- a/py/dml/int_register.py
+++ b/py/dml/int_register.py
@@ -88,9 +88,10 @@ def codegen_get_number(impl, indices, inargs, outargs, site):
     scope = Symtab(global_scope)
     regvar = mkLocalVariable(site, scope.add_variable(
         'reg',
-        type = regmap_table_type,
-        init = reg,
-        make_unique = True))
+        type=regmap_table_type,
+        init=reg,
+        make_unique=True,
+        site=site))
 
     return mkCompound(
         site,
@@ -129,11 +130,12 @@ def codegen_read(impl, indices, inargs, outargs, site):
     scope = Symtab(global_scope)
     regvar = mkLocalVariable(site, scope.add_variable(
         'reg',
-        type = regmap_table_type,
-        init = ExpressionInitializer(
+        type=regmap_table_type,
+        init=ExpressionInitializer(
             mkApply(site, find_regnum,
                     [regmap_table, regmap_table_len, num])),
-        make_unique = True))
+        make_unique=True,
+        site=site))
 
     devtype = node_storage_type(globals.device)
     read_reg = mkLit(None, '_DML_read_reg',
@@ -175,11 +177,12 @@ def codegen_write(impl, indices, inargs, outargs, site):
     scope = Symtab(global_scope)
     regvar = mkLocalVariable(site, scope.add_variable(
         'reg',
-        type = regmap_table_type,
-        init = ExpressionInitializer(
+        site=site,
+        type=regmap_table_type,
+        init=ExpressionInitializer(
             mkApply(site, find_regnum,
                     [regmap_table, regmap_table_len, num])),
-        make_unique = True))
+        make_unique=True))
 
     devtype = node_storage_type(globals.device)
     write_reg = mkLit(None, '_DML_write_reg',

--- a/py/dml/io_memory.py
+++ b/py/dml/io_memory.py
@@ -46,9 +46,9 @@ def unmapped_access(site, bank, idx, scope, isread, overlapping, bigendian,
     scope = Symtab(scope)
     code = []
     success = mkLocalVariable(site, scope.add_variable(
-        'success', type = TBool(),
-        init = ExpressionInitializer(mkBoolConstant(site, 0)),
-        make_unique = True))
+        'success', type=TBool(), site=site,
+        init=ExpressionInitializer(mkBoolConstant(site, 0)),
+        make_unique=True))
 
     if isread:
         code.append(codegen_call_byname(

--- a/py/dml/logging.py
+++ b/py/dml/logging.py
@@ -276,17 +276,14 @@ class Site(metaclass=abc.ABCMeta):
 class SimpleSite(Site):
     '''A variant of Site without line information. Useful for code
     that doesn't come from a real DML file'''
-    __slots__ = ('_name', '_line', '_dml_version')
-    def __init__(self, name, line=None, column=None, dml_version=(1, 4)):
+    __slots__ = ('_name', '_dml_version')
+    def __init__(self, name, dml_version=(1, 4)):
         self._name = name
         self._dml_version = dml_version
-        self._line = '' if line is None else f':{line}'
-        if column is not None:
-            self._line += f':{column}'
     def __repr__(self):
-        return f'<site {self.loc()}>'
+        return '<site %s>' % (self._name,)
     def loc(self):
-        return f'{self._name}{self._line}'
+        return self._name
     def filename(self):
         return self._name
     def dml_version(self):

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1690,7 +1690,7 @@ class WOLDAST(DMLWarning):
     """
     fmt = "Outdated AST file: %s"
     def __init__(self, dmlfile):
-        DMLWarning.__init__(self, SimpleSite(dmlfile, 0),
+        DMLWarning.__init__(self, SimpleSite(dmlfile + ":0"),
                             dmlfile + "ast")
 
 class WWRNSTMT(DMLWarning):

--- a/py/dml/output.py
+++ b/py/dml/output.py
@@ -73,7 +73,7 @@ class FileOutput(Output):
 
     def commit(self):
         if self.indent:
-            raise ICE(SimpleSite(self.filename, 0), 'Unbalanced indent')
+            raise ICE(SimpleSite("%s:0" % self.filename), 'Unbalanced indent')
         try:
             os.remove(self.filename)
         except OSError:

--- a/py/dml/serialize.py
+++ b/py/dml/serialize.py
@@ -66,7 +66,8 @@ def declare_variable(site, name, type, init_expr = None):
     else:
         init = None
     return (ctree.mkDeclaration(site, name, type, init = init),
-            ctree.mkLocalVariable(site, symtab.LocalSymbol(name, name, type)))
+            ctree.mkLocalVariable(
+                site, symtab.LocalSymbol(name, name, type, site=site)))
 
 def prepare_array_de_serialization(site, t):
     assert(isinstance(t, TArray))

--- a/py/dml/serialize.py
+++ b/py/dml/serialize.py
@@ -315,7 +315,7 @@ def type_signature(dmltype):
 
 def generate_serialize(real_type):
     site = logging.SimpleSite(
-        "generated serialization function for %s" % real_type)
+        f"<generated serialization function for {real_type}>")
     function_name = "DML_serialize_%s" % type_signature(real_type)
 
     in_arg_ty = TPtr(real_type)
@@ -374,7 +374,7 @@ def generate_serialize(real_type):
 
 def generate_deserialize(real_type):
     site = logging.SimpleSite(
-        "generated deserialization function for %s" % (real_type,))
+        "<generated deserialization function for {real_type}>")
     function_name = "DML_deserialize_%s" % type_signature(real_type)
 
     in_arg_ty = TPtr(attr_value_t)

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -1297,7 +1297,7 @@ def process_method_implementations(obj, name, implementations,
             continue
         defaults = default_map[impl]
         if len(defaults) == 0:
-            default = InvalidDefault(traits.NoDefaultSymbol())
+            default = InvalidDefault(traits.NoDefaultSymbol(impl.site))
         elif len(defaults) == 1:
             if defaults[0].shared:
                 [trait] = shared_impl_traits

--- a/py/dml/symtab.py
+++ b/py/dml/symtab.py
@@ -20,6 +20,7 @@ class Symbol(object):
     pseudo = True
     __slots__ = ('name', 'value', 'site', '_refcount')
     def __init__(self, name, value = None, site = None):
+        assert site
         self.name = name
         self.value = value
         self.site = site

--- a/py/dml/toplevel.py
+++ b/py/dml/toplevel.py
@@ -70,7 +70,7 @@ def determine_version(filestr, filename):
         column = ver_start - filestr.rfind('\n', 0, ver_start)
         m = check_version.match(filestr, pos=ver_start)
         if not m:
-            raise ESYNTAX(SimpleSite(filename, lineno, column),
+            raise ESYNTAX(SimpleSite("%s:%d:%d" % (filename, lineno, column)),
                           None, "malformed DML version tag")
         version = (int(m.group('major')), int(m.group('minor')))
         # Remove the language version tag, but preserve newlines.
@@ -80,24 +80,24 @@ def determine_version(filestr, filename):
         filestr = ' ' * ver_end + filestr[ver_end:]
     else:
         # TODO: make this an error
-        report(WNOVER(SimpleSite(filename, 1)))
+        report(WNOVER(SimpleSite("%s:1" % (filename,))))
         version = (1, 2)
         lineno = 1
         column = 1
 
     if version not in supported_versions:
-        raise ESYNTAX(SimpleSite(filename, lineno, column), None,
+        raise ESYNTAX(SimpleSite("%s:%d:%d" % (filename, lineno, column)), None,
                       "DML version %s not supported; allowed: %s"
                       % (fmt_version(version),
                          ", ".join(map(fmt_version, supported_versions))))
     if version == (1, 3):
         report(WDEPRECATED(
-            SimpleSite(filename, lineno, column),
+            SimpleSite("%s:%d:%d" % (filename, lineno, column)),
             "'dml 1.3' is a deprecated alias of dml 1.4"))
         version = (1, 4)
 
     if logging.show_porting and version == (1, 2):
-        report(PVERSION(SimpleSite(filename, lineno, column)))
+        report(PVERSION(SimpleSite("%s:%d:%d" % (filename, lineno, column))))
 
     return version, filestr
 
@@ -183,7 +183,7 @@ def parse_file(dml_filename):
         with open(dml_filename, 'r') as f:
             filestr = f.read()
     except IOError as msg:
-        raise EIMPORT(SimpleSite(dml_filename, 0),
+        raise EIMPORT(SimpleSite("%s:0" % (dml_filename,)),
                       "%s: %s" % (dml_filename, msg))
     except UnicodeDecodeError:
         with open(dml_filename, 'rb') as f:
@@ -192,7 +192,8 @@ def parse_file(dml_filename):
                     line.decode('utf-8')
                 except UnicodeDecodeError as e:
                     raise ESYNTAX(
-                        SimpleSite(dml_filename, lineno + 1, e.start + 1),
+                        SimpleSite("%s:%d:%d"
+                                   % (dml_filename, lineno + 1, e.start + 1)),
                         repr(line[e.start:e.end]),
                         'utf-8 decoding error: ' + e.reason)
         # should not happen
@@ -201,7 +202,7 @@ def parse_file(dml_filename):
     for m in bidi_re.finditer(filestr):
         lineno = filestr[:m.start()].count('\n') + 1
         col = m.start() - filestr.rfind('\n', 0, m.start())
-        report(ESYNTAX(SimpleSite(dml_filename, lineno, col),
+        report(ESYNTAX(SimpleSite(f"{dml_filename}:{lineno}:{col}"),
                        repr(m.group())[1:-1],
                        "Unicode BiDi character not allowed"))
     version, contents = determine_version(filestr, dml_filename)
@@ -209,7 +210,7 @@ def parse_file(dml_filename):
     if version == (1, 2) and logging.show_porting:
         with open(dml_filename, 'rb') as f:
             sha1 = hashlib.sha1(f.read()).hexdigest()  # nosec
-        report(PSHA1(SimpleSite(dml_filename, 1, 0), sha1))
+        report(PSHA1(SimpleSite('%s:1:0' % (dml_filename,)), sha1))
     ast = parse(contents, file_info, dml_filename, version)
     return ast
 
@@ -269,7 +270,7 @@ def import_file(importsite, path):
     version = site.dml_version()
     if (version != dml.globals.dml_version
         and (version, dml.globals.dml_version) != ((1, 4), (1, 2))):
-        raise EVERS(SimpleSite(path, 0),
+        raise EVERS(SimpleSite("%s:0" % (path,)),
                      importsite,
                      fmt_version(version),
                      fmt_version(importsite.dml_version()))
@@ -290,7 +291,7 @@ def exists(filename):
 
 def parse_main_file(inputfilename, explicit_import_path, strict):
     if not exists(inputfilename):
-        raise ENOFILE(SimpleSite(inputfilename, 0))
+        raise ENOFILE(SimpleSite("%s:0" % (inputfilename,)))
     (kind, site, name, stmts) = parse_dmlast_or_dml(inputfilename)
     # guaranteed by grammar
     assert kind == 'dml'

--- a/py/dml/traits.py
+++ b/py/dml/traits.py
@@ -99,8 +99,8 @@ class NoDefaultSymbol(Symbol):
     method. This is represented as an explicit symbol in order to
     report ENDEFAULT instead of the slightly less informative
     EIDENT."""
-    def __init__(self):
-        super(NoDefaultSymbol, self).__init__('default')
+    def __init__(self, site):
+        super(NoDefaultSymbol, self).__init__('default', site=site)
     def expr(self, site):
         raise ENDEFAULT(site)
 
@@ -110,7 +110,8 @@ class AmbiguousDefaultSymbol(Symbol):
     symbol in order to report EAMBDEFAULT instead of the slightly
     less informative EIDENT."""
     def __init__(self, default_method_sites):
-        super(AmbiguousDefaultSymbol, self).__init__('default')
+        super(AmbiguousDefaultSymbol, self).__init__(
+            'default', site=default_method_sites[0])
         self.default_method_sites = default_method_sites
     def expr(self, site):
         raise EAMBDEFAULT(site, self.default_method_sites)
@@ -214,7 +215,7 @@ class TraitMethod(TraitVTableItem):
                         default_method),
                     site)
             else:
-                default = NoDefaultSymbol()
+                default = NoDefaultSymbol(self.site)
                 # TODO: we should also have a clause for AmbiguousDefault here
 
             for (n, t) in self.outp:

--- a/test/tests.py
+++ b/test/tests.py
@@ -74,6 +74,8 @@ else:
     python = [join(simics_root_path(), host_type(), "bin", "py3",
                    "mini-python" + exe_sfx)]
 
+line_directives = bool(os.environ.get('DMLC_LINE_DIRECTIVES'))
+
 dmlc = python + [join(project_host_path(), "bin", "dml", "python")]
 
 if not is_windows():
@@ -256,7 +258,9 @@ class DMLFileTestCase(BaseTestCase):
         args =[]
         args += dmlc_reaper_args(exitcode_file,
                                  dmlc_timeout_multipliers.get(self.fullname, 1))
-        args += dmlc + ["-T", "--noline"]
+        args += dmlc + ["-T"]
+        if not line_directives:
+            args += ["--noline"]
         args += dmlc_extraargs
         if self.api_version:
             args += ["--simics-api=" + self.api_version]


### PR DESCRIPTION
- Revert previous SimpleSite change
- Polish site strings
- Don't generate #line directives for SimpleSite
- Add sites to all symbols
- Allow enabling line directives when running test suite
