### PR TITLE
Add `init_val` param to standard attribute templates -- SIMICS-20108

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -405,4 +405,11 @@
       to the template type <tt>object</tt>, even if <tt>object</tt> is not an
       ancestor of the template <bug number="SIMICS-19950"/>.</add-note>
   </build-id>
+  <build-id value="next"><add-note>A new parameter <tt>init_val</tt> has been
+      introduced to the attribute templates <tt>bool_attr</tt>,
+      <tt>uint64_attr</tt>, <tt>int64_attr</tt> and <tt>double_attr</tt>. These
+      templates now also provide a default <tt>init()</tt> implementation
+      that leverages <tt>init_val</tt> in order to initialize the <tt>val</tt>
+      variable provided by the template <bug number="SIMICS-20108"/>.
+  </add-note></build-id>
 </rn>

--- a/doc/1.4/language.md
+++ b/doc/1.4/language.md
@@ -596,6 +596,9 @@ functions. The type of the value read and written through the get/set functions
 is controlled by the `type` parameter. More information about configuration
 object attributes can be found in *Simics Model Builder User's Guide*.
 
+The [`init`](dml-builtins.html#init) template and associated method is often
+useful together with `attribute` objects to initialize any associated state.
+
 Four standard templates are provided for attributes: `bool_attr`, `int64_attr`,
 `uint64_attr` and `double_attr`. They provide overridable `get` and `set`
 methods, and store the attribute's value in a session variable named `val`,
@@ -606,10 +609,17 @@ attribute `a`, then one can access it as follows:
 log info: "the value of attribute a is %d", dev.a.val;
 ```
 
-The [`init` template](dml-builtins.html#init) is often useful together with
-`attribute` objects &mdash; in particular in combination with these standard
-templates &mdash; in order to initialize the state associated with the
-`attribute` object.
+These templates also provide an overridable implementation of
+[`init()`](dml-builtins.html#init) that initializes the `val` session variable.
+The value that `val` is initialized to is controlled by the `init_val`
+parameter, whose default definition simply causes `val` to be zero-initialized.
+
+Defining `init_val` is typically the most convenient way of initializing any
+attribute instantiating any one of the these templates &mdash; however,
+overriding the default `init()` implementation with a custom one may still be
+desirable in certain cases. In particular, the definition of `init_val` must be
+constant, so a custom `init()` implementation is necessary if `val` should be
+initialized to a non-constant value.
 
 Note that using an attribute object purely to store and checkpoint simple
 internal device state is not recommended; prefer

--- a/lib/1.2/dml12-compatibility.dml
+++ b/lib/1.2/dml12-compatibility.dml
@@ -7,7 +7,18 @@ dml 1.4;
 
 import "simics/devs/signal.dml";
 
-template bool_attr is attribute {
+template _banned_init_val {
+    // The init template isn't available in 1.2, thus init_val support can't be
+    // implemented without some ad-hoc hacks in DMLC. Its use is banned
+    // instead.
+    param init_val default undefined;
+    #if (defined(init_val)) {
+        error "init_val for bool_attr, uint64_attr, int64_attr, and "
+            + "double_attr is not supported for DML 1.2 devices";
+    }
+}
+
+template bool_attr is (attribute, _banned_init_val) {
     param allocate_type = "bool";
     param val = this;
     // Since we are by definition backed by 1.2 builtins, get throws
@@ -15,14 +26,14 @@ template bool_attr is attribute {
     shared method set(attr_value_t val) throws;
 }
 
-template uint64_attr is attribute {
+template uint64_attr is (attribute, _banned_init_val) {
     param allocate_type = "uint64";
     param val = this;
     shared method get() -> (attr_value_t);
     shared method set(attr_value_t val) throws;
 }
 
-template int64_attr is attribute {
+template int64_attr is (attribute, _banned_init_val) {
     param allocate_type = "int64";
     param val = this;
     shared method get() -> (attr_value_t);
@@ -35,7 +46,7 @@ template int64_attr is attribute {
     }
 }
 
-template double_attr is attribute {
+template double_attr is (attribute, _banned_init_val) {
     param allocate_type = "double";
     param val = this;
     shared method get() -> (attr_value_t);

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -721,9 +721,11 @@ template attribute is _conf_attribute {
 ## Attribute templates
 
 Four templates are used to create a simple checkpointable attribute with
-standard types, storing the attribute value in a member `val`, and
-providing default implementations of methods `get` and `set`
-accordingly:
+standard types. Each store the attribute value in a member `val`,
+provide default implementations of methods `get` and `set` according to the
+type, and provide a default implementation of `init` that initializes
+`val` using the `init_val` parameter also provided by the template (whose
+default definition simply zero-initializes `val`.) These four templates are:
 
 <dl><dt>
 
@@ -784,9 +786,14 @@ Pseudo attribute that cannot be read. Method `set` is
 These templates are not compatible with the `bool_attr`, `uint64_attr`,
 `int64_attr`, or `float_attr` templates.
 */
-template bool_attr is attribute {
+template bool_attr is (attribute, init) {
     param type = "b";
+    param init_val : bool;
+    param init_val default false;
     session bool val;
+    shared method init() default {
+        val = init_val;
+    }
     shared method get() -> (attr_value_t) default {
         return SIM_make_attr_boolean(val);
     }
@@ -795,9 +802,14 @@ template bool_attr is attribute {
     }
 }
 
-template uint64_attr is attribute {
+template uint64_attr is (attribute, init) {
     param type = "i";
+    param init_val : uint64;
+    param init_val default 0;
     session uint64 val;
+    shared method init() default {
+        val = init_val;
+    }
     shared method get() -> (attr_value_t) default {
         return SIM_make_attr_uint64(val);
     }
@@ -811,9 +823,14 @@ template uint64_attr is attribute {
     }
 }
 
-template int64_attr is attribute {
+template int64_attr is (attribute, init) {
     param type = "i";
+    param init_val : int64;
+    param init_val default 0;
     session int64 val;
+    shared method init() default {
+        val = init_val;
+    }
     shared method get() -> (attr_value_t) default {
         return SIM_make_attr_int64(val);
     }
@@ -827,9 +844,14 @@ template int64_attr is attribute {
     }
 }
 
-template double_attr is attribute {
+template double_attr is (attribute, init) {
     param type = "f";
+    param init_val : double;
+    param init_val default 0.0;
     session double val;
+    shared method init() default {
+        val = init_val;
+    }
     shared method get() -> (attr_value_t) default {
         return SIM_make_attr_floating(val);
     }

--- a/test/1.4/lib/T_attributes.dml
+++ b/test/1.4/lib/T_attributes.dml
@@ -30,6 +30,27 @@ attribute f is (double_attr) {
 //    method set(attr_value_t value) throws default { default(value); }
 }
 
+attribute b2 is (bool_attr) {
+    param init_val = true;
+}
+
+attribute u2 is (uint64_attr) {
+    param init_val = 33;
+}
+
+attribute i2 is (int64_attr) {
+    param init_val = -33;
+}
+
+attribute f2 is (double_attr) {
+    param init_val = 3.3;
+}
+
+attribute overridden_init is (bool_attr) {
+    param init_val = true;
+    method init() { }
+}
+
 
 method test() throws {
     b.val = true;
@@ -69,4 +90,10 @@ method test() throws {
     local attr_value_t float_attr = SIM_make_attr_floating(1.414);
     SIM_set_attribute(dev.obj, "f", &float_attr);
     expect(f.val == 1.414, "set f");
+
+    expect(b2.val, "init_val b2");
+    expect(u2.val == 33, "init_val u2");
+    expect(i2.val == -33, "init_val i2");
+    expect(f2.val == 3.3, "init_val f2");
+    expect(!overridden_init.val, "init_val overridden_init");
 }


### PR DESCRIPTION
It's silly, but we're gonna have to test this against VP. The risk that there's some strange hierarchical conflict when it comes to the `init` definition or a user-rolled definition of `init_val` conflicting is just too high to ignore.