### PR TITLE
Fix bug in DMLC_DUMP_INPUT_FILES

### DIFF
--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -201,7 +201,8 @@ def dump_input_files(outputbase, imported):
                 tf.add(hfile, h_path_in_tar)
             for path in paths:
                 symlink = os.path.normpath(os.path.join(prefix, path))
-                if os.path.dirname(symlink) == os.path.normpath(prefix):
+                if (os.path.normpath(os.path.dirname(symlink))
+                    == os.path.normpath(prefix)):
                     # import path resolves to file already present in tarfile
                     continue
                 # file imported through relative path, create symlink where


### PR DESCRIPTION
If a device has no relative imports with `..`, then we created
self-referencing symlinks because we couldn't distinguish between
directories `''` and `'.'`. `normpath` solves the problem.
