### PR TITLE
Immediate After Statement -- SIMICS-20379

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -502,4 +502,11 @@
       variables or arguments of <tt>after</tt> statements) would lead
       to an internal compiler error
       <bug number="SIMICS-21424"/>.</add-note></build-id>
+  <build-id value="next"><add-note> Added a new form of the <tt>after</tt>
+      statement, called <em>immediate <tt>after</tt></em>. Syntax is
+      <tt>after: callback(1, false)</tt>. An immediate after will delay the call
+      to the specified method until all current entries into devices on the call
+      stack have been completed, and the simulation of the current
+      processor would otherwise be ready to move onto the next cycle
+      <bug number="SIMICS-20379"/>.</add-note></build-id>
 </rn>

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -899,6 +899,7 @@ method _get_attribute_attr(const _dml_attr_getset_info_t *_conf_info,
         no_items /= id_info.dimsizes[i];
     }
     local attr_value_t *items = new attr_value_t[no_items];
+    local attr_value_t *items_buf = new attr_value_t[no_items];
     for (local int i = 0; i < no_items; ++i) {
         local _traitref_t traitref = {conf_info.vtable,
                                       {id_info.id, i + flat_index_offset}};
@@ -908,20 +909,19 @@ method _get_attribute_attr(const _dml_attr_getset_info_t *_conf_info,
          --i) {
         local uint32 new_frag_size = id_info.dimsizes[i];
         local size_t new_no_items = no_items / new_frag_size;
-        local attr_value_t *new_items = new attr_value_t[new_no_items];
         for (local int j = 0; j < new_no_items; ++j) {
-            new_items[j] = SIM_alloc_attr_list(new_frag_size);
-            local attr_value_t *new_frag = SIM_attr_list(new_items[j]);
+            items_buf[j] = SIM_alloc_attr_list(new_frag_size);
+            local attr_value_t *new_frag = SIM_attr_list(items_buf[j]);
             for (local int k = 0; k < new_frag_size; ++k) {
                 new_frag[k] = items[j * new_frag_size + k];
             }
         }
-        delete items;
-        items = new_items;
+        (items, items_buf) = (items_buf, items);
         no_items = new_no_items;
     }
     local attr_value_t to_ret = *items;
     delete items;
+    delete items_buf;
     return to_ret;
 }
 
@@ -960,7 +960,8 @@ method _set_attribute_attr(const _dml_attr_getset_info_t *_conf_info,
         return cast(&traitref, _conf_attribute *)->set_attribute(*val);
     }
 
-    local attr_value_t *items = new attr_value_t;
+    local attr_value_t *items = new attr_value_t[conf_info.num];
+    local attr_value_t *items_buf = new attr_value_t[conf_info.num];
     *items = *val;
     local size_t no_items = 1;
     local bool allow_cutoff = conf_info.allow_cutoff;
@@ -968,7 +969,6 @@ method _set_attribute_attr(const _dml_attr_getset_info_t *_conf_info,
     for (local int i = start_dim; i < cast(id_info.dimensions, int); ++i) {
         local uint32 frag_size = id_info.dimsizes[i];
         local size_t new_no_items = no_items * frag_size;
-        local attr_value_t *new_items = new attr_value_t[new_no_items];
         if (allow_cutoff) {
             for (local int j = 0; j < no_items; ++j) {
                 local uint32 subfrag_size = SIM_attr_is_list(items[j])
@@ -979,24 +979,24 @@ method _set_attribute_attr(const _dml_attr_getset_info_t *_conf_info,
                                              : NULL;
                 for (local int k = 0; k < subfrag_size; ++k) {
                     /*% COVERITY copy_paste_error FALSE %*/
-                    new_items[j * frag_size + k] = subfrags[k];
+                    items_buf[j * frag_size + k] = subfrags[k];
                 }
                 for (local int k = subfrag_size; k < frag_size; ++k) {
-                    new_items[j * frag_size + k] = SIM_make_attr_nil();
+                    items_buf[j * frag_size + k] = SIM_make_attr_nil();
                 }
             }
         } else {
             for (local int j = 0; j < no_items; ++j) {
                 local attr_value_t *subfrags = SIM_attr_list(items[j]);
                 for (local int k = 0; k < frag_size; ++k) {
-                    new_items[j * frag_size + k] = subfrags[k];
+                    items_buf[j * frag_size + k] = subfrags[k];
                 }
             }
         }
-        delete items;
-        items = new_items;
+        (items, items_buf) = (items_buf, items);
         no_items = new_no_items;
     }
+    delete items_buf;
     for (local int i = 0; i < no_items; ++i) {
         local _traitref_t traitref = {conf_info.vtable,
                                       {id_info.id, i + flat_index_offset}};

--- a/py/dml/ast.py
+++ b/py/dml/ast.py
@@ -32,6 +32,7 @@ class AST(object):
 astkinds = {
     'after',
     'afteronhook',
+    'immediateafter',
     'apply',
     'assert',
     'assign',

--- a/py/dml/dmlparse.py
+++ b/py/dml/dmlparse.py
@@ -2230,6 +2230,11 @@ def statement_delay_hook_no_msg_params(t):
     'statement_except_hashif : AFTER expression COLON expression SEMI'
     t[0] = ast.afteronhook(site(t), t[2], [], t[4])
 
+@prod_dml14
+def statement_delay_immediate(t):
+    'statement_except_hashif : AFTER COLON expression SEMI'
+    t[0] = ast.immediateafter(site(t), t[3])
+
 @prod_dml12
 def call(t):
     '''statement_except_hashif : CALL expression returnargs SEMI

--- a/py/dml/globals.py
+++ b/py/dml/globals.py
@@ -50,6 +50,10 @@ after_on_hook_infos = []
 # object -> codegen.AfterDelayInfo
 after_delay_infos = {}
 
+# A mapping from any immediate after key to its immediate after info
+# object -> codegen.ImmediateAfterInfo
+immediate_after_infos = {}
+
 # A mapping from a unique type sequence to its TypeSequenceInfo
 # types.TypeSequence -> codegen.TypeSequenceInfo
 type_sequence_infos = {}

--- a/test/1.4/errors/T_WHOOKSEND.dml
+++ b/test/1.4/errors/T_WHOOKSEND.dml
@@ -1,0 +1,90 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+/// COMPILE-ONLY
+typedef struct {
+    int *x;
+    int *y[2];
+    int *z[2][3];
+} substruct_t;
+
+typedef struct {
+    int *x;
+    int *y[2];
+    int *z[2][3];
+    substruct_t sub_a;
+    substruct_t sub_b[2];
+    substruct_t sub_c[2][3];
+} struct_t;
+
+hook(void *) h;
+
+method init() {
+    local int *x;
+    local int *y[2];
+    local int *z[2][3];
+    local struct_t s;
+
+    local int *(*arr)[2][3];
+    local int *(*arr_2)[3];
+
+    // no warning
+    h.send(x);
+    h.send(y[1]);
+    h.send(z[1][2]);
+    h.send(s.x);
+    h.send(s.y[1]);
+    h.send(s.z[1][2]);
+    h.send(s.sub_a.x);
+    h.send(s.sub_b[1].y[1]);
+    h.send(s.sub_b[1].y[1]);
+    h.send(arr);
+    h.send(*arr);
+    h.send((*arr)[1]);
+    h.send((*arr)[1][2]);
+
+    /// WARNING WHOOKSEND
+    h.send(&x);
+    /// WARNING WHOOKSEND
+    h.send(y);
+    /// WARNING WHOOKSEND
+    h.send(z[1]);
+    /// WARNING WHOOKSEND
+    h.send(&y[1]);
+    /// WARNING WHOOKSEND
+    h.send(&z[1][2]);
+    /// WARNING WHOOKSEND
+    h.send(&s.x);
+    /// WARNING WHOOKSEND
+    h.send(s.y);
+    /// WARNING WHOOKSEND
+    h.send(s.z[1]);
+    /// WARNING WHOOKSEND
+    h.send(&s.sub_a.x);
+    /// WARNING WHOOKSEND
+    h.send(s.sub_a.y);
+    /// WARNING WHOOKSEND
+    h.send(s.sub_a.z[1]);
+    /// WARNING WHOOKSEND
+    h.send(s.sub_b[1].y);
+    /// WARNING WHOOKSEND
+    h.send(s.sub_c[1][2].z[1]);
+
+    /// WARNING WHOOKSEND
+    h.send(*cast(z, typeof(arr_2)));
+
+    /// WARNING WHOOKSEND
+    h.send(cast(&*(1 + (&x - 1)), void *));
+
+    // no warning
+    h.send(cast(cast(&x, uintptr_t), void *));
+
+    local int **x_ptr = &x;
+    // no warning
+    h.send(x_ptr);
+}

--- a/test/1.4/errors/T_WIMMAFTER.dml
+++ b/test/1.4/errors/T_WIMMAFTER.dml
@@ -1,0 +1,90 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+/// COMPILE-ONLY
+typedef struct {
+    int *x;
+    int *y[2];
+    int *z[2][3];
+} substruct_t;
+
+typedef struct {
+    int *x;
+    int *y[2];
+    int *z[2][3];
+    substruct_t sub_a;
+    substruct_t sub_b[2];
+    substruct_t sub_c[2][3];
+} struct_t;
+
+method m(void *p) { }
+
+method init() {
+    local int *x;
+    local int *y[2];
+    local int *z[2][3];
+    local struct_t s;
+
+    local int *(*arr)[2][3];
+    local int *(*arr_2)[3];
+
+    // no warning
+    after: m(x);
+    after: m(y[1]);
+    after: m(z[1][2]);
+    after: m(s.x);
+    after: m(s.y[1]);
+    after: m(s.z[1][2]);
+    after: m(s.sub_a.x);
+    after: m(s.sub_b[1].y[1]);
+    after: m(s.sub_b[1].y[1]);
+    after: m(arr);
+    after: m(*arr);
+    after: m((*arr)[1]);
+    after: m((*arr)[1][2]);
+
+    /// WARNING WIMMAFTER
+    after: m(&x);
+    /// WARNING WIMMAFTER
+    after: m(y);
+    /// WARNING WIMMAFTER
+    after: m(z[1]);
+    /// WARNING WIMMAFTER
+    after: m(&y[1]);
+    /// WARNING WIMMAFTER
+    after: m(&z[1][2]);
+    /// WARNING WIMMAFTER
+    after: m(&s.x);
+    /// WARNING WIMMAFTER
+    after: m(s.y);
+    /// WARNING WIMMAFTER
+    after: m(s.z[1]);
+    /// WARNING WIMMAFTER
+    after: m(&s.sub_a.x);
+    /// WARNING WIMMAFTER
+    after: m(s.sub_a.y);
+    /// WARNING WIMMAFTER
+    after: m(s.sub_a.z[1]);
+    /// WARNING WIMMAFTER
+    after: m(s.sub_b[1].y);
+    /// WARNING WIMMAFTER
+    after: m(s.sub_c[1][2].z[1]);
+
+    /// WARNING WIMMAFTER
+    after: m(*cast(z, typeof(arr_2)));
+
+    /// WARNING WIMMAFTER
+    after: m(cast(&*(1 + (&x - 1)), void *));
+
+    // no warning
+    after: m(cast(cast(&x, uintptr_t), void *));
+
+    local int **x_ptr = &x;
+    // no warning
+    after: m(x_ptr);
+}

--- a/test/1.4/hooks/T_asynchronous_send.dml
+++ b/test/1.4/hooks/T_asynchronous_send.dml
@@ -1,0 +1,64 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+/// DMLC-FLAG --enable-features-for-internal-testing-dont-use-this
+
+hook() h1;
+/// WARNING WEXPERIMENTAL
+hook(int *, int) h2[3][5];
+
+session int count;
+session int storage;
+
+method inc() {
+    ++count;
+    after h1: inc();
+}
+
+method store(int *target, int x) {
+    *target = x;
+    after h2[1][2] -> (p, y): store(p, y);
+}
+
+method do_setup() {
+    // h.send(...) is equivalent to after: h.send_now(...),
+    // except it can't be cancelled
+    h1.send();
+    h2[1][2].send(&storage, 6);
+
+    after: h1.send_now();
+    after: h2[1][2].send_now(&storage, -4);
+
+    cancel_after();
+
+    after h1: inc();
+    after h2[1][2] -> (p, y): store(p, y);
+    assert count == 0 && storage == 0;
+}
+
+method do_test() {
+    assert count == 1 && storage == 6;
+    count = storage = 0;
+    cancel_after();
+}
+
+attribute setup is read_only_attr {
+    param type = "n";
+    method get() -> (attr_value_t) {
+        do_setup();
+        return SIM_make_attr_nil();
+    }
+}
+
+attribute test is read_only_attr {
+    param type = "n";
+    method get() -> (attr_value_t) {
+        do_test();
+        return SIM_make_attr_nil();
+    }
+}

--- a/test/1.4/hooks/T_asynchronous_send.py
+++ b/test/1.4/hooks/T_asynchronous_send.py
@@ -1,0 +1,25 @@
+# © 2023 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+cpu = SIM_create_object("clock", "clock", [["freq_mhz", 1]])
+obj.queue = cpu
+
+setup_ev = SIM_register_event("setup_ev", None, Sim_EC_Notsaved,
+                       lambda _o, _d: obj.setup, None, None, None, None)
+test_ev = SIM_register_event("test_ev", None, Sim_EC_Notsaved,
+                       lambda _o, _d: obj.test, None, None, None, None)
+
+# global context
+_ = obj.setup
+SIM_process_pending_work()
+_ = obj.test
+
+# execution context
+SIM_event_post_cycle(cpu, setup_ev, obj, 0, None)
+SIM_continue(1)
+_ = obj.test
+
+# global context into execution context
+SIM_event_post_cycle(cpu, test_ev, obj, 0, None)
+_ = obj.setup
+SIM_continue(1)

--- a/test/1.4/statements/T_immediate_after_basic.dml
+++ b/test/1.4/statements/T_immediate_after_basic.dml
@@ -1,0 +1,115 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+session int count;
+session int storage;
+session int array_storage[5][7];
+
+method inc() {
+    ++count;
+}
+
+method store(int x) {
+    storage = x;
+}
+
+session (int last_i, int last_j) = (-1, -1);
+
+group g[i < 5][j < 7]{
+    method set_lasts() {
+        (last_i, last_j) = (i, j);
+    }
+    method store_targeted(int (*arr)[5][7], int x) {
+        (*arr)[i][j] = x;
+    }
+}
+
+
+session int queue[6];
+session int *queue_ptr;
+
+method init() {
+    queue_ptr = queue;
+}
+
+method order_test_callback(int id) {
+    *queue_ptr++ = id;
+}
+
+method post_order_test_callback(int id) {
+    after: order_test_callback(id);
+}
+
+method subsequent_immediate_afters() {
+    after: order_test_callback(3);
+    (&post_order_test_callback)(dev.obj, 4);
+    after: order_test_callback(5);
+}
+
+
+method do_setup() {
+    after: inc();
+    after: store(4);
+    after: g[1][2].set_lasts();
+    after: g[3][4].store_targeted(&array_storage, 7);
+
+    // order test
+    after: subsequent_immediate_afters();
+    after: order_test_callback(0);
+    (&post_order_test_callback)(dev.obj, 1);
+    after: order_test_callback(2);
+    do_confirm_setup();
+}
+
+method do_confirm_setup() {
+    assert count == 0 && storage == 0 && last_i == -1 && last_j == -1
+        && array_storage[3][4] == 0;
+    assert queue_ptr == queue;
+}
+
+attribute confirm_setup is read_only_attr {
+    param type = "n";
+    method get() -> (attr_value_t) {
+        do_confirm_setup();
+        return SIM_make_attr_nil();
+    }
+}
+
+
+attribute setup is read_only_attr {
+    param type = "n";
+    method get() -> (attr_value_t) {
+        do_setup();
+        return SIM_make_attr_nil();
+    }
+}
+
+attribute test is read_only_attr {
+    param type = "n";
+    method get() -> (attr_value_t) {
+        assert count == 1 && storage == 4 && last_i == 1 && last_j == 2
+            && array_storage[3][4] == 7;
+        for (local int i = 0; i < array_storage.len; ++i) {
+            for (local int j = 0; j < array_storage[i].len; ++j) {
+                if (i != 3 && j != 4) {
+                    assert array_storage[i][j] == 0;
+                }
+            }
+        }
+        assert queue_ptr == queue + 6;
+        for (local int i = 0; i < queue.len; ++i) {
+            assert queue[i] == i;
+        }
+        memset(queue, 0, sizeof(queue));
+        memset(array_storage, 0, sizeof(array_storage));
+        queue_ptr = queue;
+        count = storage = 0;
+        last_i = last_j = -1;
+        return SIM_make_attr_nil();
+    }
+}

--- a/test/1.4/statements/T_immediate_after_basic.py
+++ b/test/1.4/statements/T_immediate_after_basic.py
@@ -1,0 +1,25 @@
+# © 2023 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+cpu = SIM_create_object("clock", "clock", [["freq_mhz", 1]])
+obj.queue = cpu
+
+setup_ev = SIM_register_event("setup_ev", None, Sim_EC_Notsaved,
+                       lambda _o, _d: obj.setup, None, None, None, None)
+test_ev = SIM_register_event("test_ev", None, Sim_EC_Notsaved,
+                       lambda _o, _d: obj.test, None, None, None, None)
+
+# global context
+_ = obj.setup
+SIM_process_pending_work()
+_ = obj.test
+
+# execution context
+SIM_event_post_cycle(cpu, setup_ev, obj, 0, None)
+SIM_continue(1)
+_ = obj.test
+
+# global context into execution context
+SIM_event_post_cycle(cpu, test_ev, obj, 0, None)
+_ = obj.setup
+SIM_continue(1)

--- a/test/1.4/statements/T_immediate_after_cancel.dml
+++ b/test/1.4/statements/T_immediate_after_cancel.dml
@@ -1,0 +1,59 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+attribute count is uint64_attr;
+
+method inc() {
+    ++count.val;
+}
+
+method post_inc() {
+    after: inc();
+}
+
+group g {
+    method post_inc() {
+        after: inc();
+    }
+
+    method cancel() {
+        after: inc(); // cancelled
+        cancel_after();
+    }
+
+    method do_setup() {
+        after: inc();       // cancelled
+        post_inc();         // cancelled
+        dev.post_inc();     // not cancelled
+        (&cancel)(dev.obj);
+        after: inc();       // not cancelled
+        after: post_inc();  // post_inc's after is cancelled
+        after: cancel();
+        after: inc();       // cancelled
+        assert count.val == 0;
+    }
+}
+
+attribute setup is read_only_attr {
+    param type = "n";
+
+    method get() -> (attr_value_t) {
+        g.do_setup();
+        return SIM_make_attr_nil();
+    }
+}
+
+attribute test is read_only_attr {
+    param type = "n";
+
+    method get() -> (attr_value_t) {
+        assert count.val == 2;
+        count.val = 0;
+        return SIM_make_attr_nil();
+    }
+}

--- a/test/1.4/statements/T_immediate_after_cancel.py
+++ b/test/1.4/statements/T_immediate_after_cancel.py
@@ -1,0 +1,25 @@
+# © 2023 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+cpu = SIM_create_object("clock", "clock", [["freq_mhz", 1]])
+obj.queue = cpu
+
+setup_ev = SIM_register_event("setup_ev", None, Sim_EC_Notsaved,
+                       lambda _o, _d: obj.setup, None, None, None, None)
+test_ev = SIM_register_event("test_ev", None, Sim_EC_Notsaved,
+                       lambda _o, _d: obj.test, None, None, None, None)
+
+# global context
+_ = obj.setup
+SIM_process_pending_work()
+_ = obj.test
+
+# execution context
+SIM_event_post_cycle(cpu, setup_ev, obj, 0, None)
+SIM_continue(1)
+_ = obj.test
+
+# global context into execution context
+SIM_event_post_cycle(cpu, test_ev, obj, 0, None)
+_ = obj.setup
+SIM_continue(1)

--- a/test/1.4/statements/T_immediate_after_entrances.dml
+++ b/test/1.4/statements/T_immediate_after_entrances.dml
@@ -1,0 +1,138 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+import "simics/devs/signal.dml";
+
+/// INSTANTIATE-MANUALLY
+
+// attributes set/get -- hardcoded
+
+attribute count is uint64_attr {
+    method post_inc() {
+        after: inc();
+    }
+    method inc() {
+        ++count.val;
+    }
+}
+
+method post_inc() {
+    // test the after call is actually delayed, and that repeated entrance
+    // doesn't muck things up.
+    local uint64 before = count.val;
+    (&count.post_inc)(dev.obj);
+    assert count.val == before;
+}
+
+export post_inc as "exported_post_inc";
+
+method init() {
+    assert count.val == 0;
+    post_inc();
+}
+
+
+method post_init() {
+    // assert count.val == 1;
+    post_inc();
+    after 0.1 s: post_inc();
+    ev.post(0.2, NULL);
+    // Will get destroyed
+    ev.post(0.3, NULL);
+}
+
+method destroy() {
+    assert count.val == 10;
+    after: after_destroy("dev");
+}
+
+event ev is custom_time_event {
+    method event(void *data) {
+        post_inc();
+    }
+    method get_event_info(void *data) -> (attr_value_t) {
+        return SIM_make_attr_nil();
+    }
+    method set_event_info(attr_value_t info) -> (void *) {
+        return NULL;
+    }
+    method destroy(void *data) {
+        after: after_destroy("event");
+    }
+}
+
+method after_destroy(const char *name) {
+    local attr_value_t args = SIM_make_attr_list(1,
+                                                 SIM_make_attr_string(name));
+    local attr_value_t val = VT_call_python_module_function(
+        "__main__", "destroyed", &args);
+    SIM_attr_free(&val);
+    SIM_attr_free(&args);
+}
+
+implement signal {
+    method signal_raise() {
+        post_inc();
+    }
+    method signal_lower() {}
+}
+
+connect out is init_as_subobj {
+    param classname = "signal-stub";
+    interface signal;
+}
+
+attribute simple_attr is write_only_attr {
+    param type = "n";
+    method set(attr_value_t val) throws {
+        local uint64 before = count.val;
+        out.signal.signal_raise();
+        assert before == count.val;
+    }
+}
+
+attribute recursive_entry_attr is write_only_attr {
+    param type = "n";
+    method set(attr_value_t val) throws {
+        local uint64 before = count.val;
+        out.signal.signal_raise();
+        assert before == count.val;
+    }
+}
+
+
+// Statically or externally exported methods called outside of DML methods
+header %{
+    extern void exported_post_inc(conf_object_t *);
+    void exported_on_notify(conf_object_t * obj, conf_object_t *_,
+                            lang_void *__) {
+        exported_post_inc(obj);
+    }
+%}
+
+extern void (*exported_on_notify)(conf_object_t *, conf_object_t *, void *);
+
+group notifiers[i < 2] is init {
+    session notifier_handle_t *handle;
+    independent startup memoized method notifier() -> (notifier_type_t) {
+        local notifier_type_t notifier = SIM_notifier_type(i == 0
+                                                           ? "static-export"
+                                                           : "extern-export");
+        SIM_register_notifier(SIM_get_class(dev.classname), notifier, NULL);
+        return notifier;
+    }
+    method init() {
+        handle = SIM_add_notifier(dev.obj, notifier(), dev.obj,
+                                  i == 0 ? &on_notify : exported_on_notify,
+                                  NULL);
+    }
+}
+
+method on_notify(conf_object_t *_notifier, void *_data) {
+    post_inc();
+}

--- a/test/1.4/statements/T_immediate_after_entrances.py
+++ b/test/1.4/statements/T_immediate_after_entrances.py
@@ -1,0 +1,68 @@
+# © 2023 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+import stest
+import dev_util
+import simics
+from simics import confclass
+
+class signal_stub:
+    cls = confclass('signal-stub')
+
+    @cls.iface.signal.signal_raise
+    def signal_raise(self):
+        return obj.iface.signal.signal_raise()
+
+cpu = SIM_create_object("clock", "clock", [["freq_mhz", 1]])
+
+destroyed_map = {}
+def destroyed(name):
+    destroyed_map[name] = destroyed_map.get(name, 0) + 1
+
+obj = simics.SIM_create_object('test', 'obj', queue=cpu)
+stest.expect_equal(obj.count, 0)
+SIM_process_pending_work()
+stest.expect_equal(obj.count, 2)
+
+obj.simple_attr = None
+stest.expect_equal(obj.count, 2)
+SIM_process_pending_work()
+stest.expect_equal(obj.count, 3)
+
+obj.iface.signal.signal_raise()
+stest.expect_equal(obj.count, 3)
+SIM_process_pending_work()
+stest.expect_equal(obj.count, 4)
+
+obj.recursive_entry_attr = None
+stest.expect_equal(obj.count, 4)
+SIM_process_pending_work()
+stest.expect_equal(obj.count, 5)
+
+SIM_notify(obj, SIM_notifier_type("static-export"))
+stest.expect_equal(obj.count, 5)
+SIM_process_pending_work()
+stest.expect_equal(obj.count, 6)
+
+SIM_notify(obj, SIM_notifier_type("extern-export"))
+stest.expect_equal(obj.count, 6)
+SIM_process_pending_work()
+stest.expect_equal(obj.count, 7)
+
+SIM_continue(99999)
+stest.expect_equal(obj.count, 7)
+SIM_continue(1)
+stest.expect_equal(obj.count, 8)
+SIM_continue(99999)
+stest.expect_equal(obj.count, 8)
+SIM_continue(1)
+stest.expect_equal(obj.count, 9)
+obj.simple_attr = None
+stest.expect_equal(obj.count, 9)
+# destroy() checks that the count has increased to 10
+SIM_delete_object(obj)
+stest.expect_equal(destroyed_map.get('dev', 0), 1)
+stest.expect_equal(destroyed_map.get('event', 0), 1)
+# Make sure that the delayed deallocation of immediate after state doesn't
+# error or segfault
+SIM_process_pending_work()


### PR DESCRIPTION
Depends on #144 . Reviewing that should take priority.

This was very quick and easy to do thanks to the architecture revamp that after-on-hooks does... but it just further highlights the copy-pasting necessary from what the architecture does not cover. 1400 insertions, ugh (though admittedly reducing the copy-pasting will just remove like ~350 loc if one is being _extremely_ optimistic, so perhaps it's not as bad as I think).