### PR TITLE
Don't declare a temporary struct instance as a local variable

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -440,4 +440,8 @@
       error on DMLC-generated code, caused by name clashes with
       the <tt>interface</tt> macro, defined by <tt>windows.h</tt>
       <bug number="15012582368"/>.</add-note></build-id>
+  <build-id value="next"><add-note>Fixed a bug in <tt>saved</tt>
+      variables that caused stack overflow during checkpoint restore
+      for huge (multi-megabyte) struct types
+      <bug number="18026246959"/>.</add-note></build-id>
 </rn>

--- a/test/1.4/serialize/T_large_struct.dml
+++ b/test/1.4/serialize/T_large_struct.dml
@@ -1,0 +1,46 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+import "simics/simulator/conf-object.dml";
+import "testing.dml";
+
+// A struct size large enough to make a local variable cause stack overflow.
+// This used to happen in serialization code, HSD-ES 18026246959
+
+constant size = 200_000;
+
+typedef struct {
+    uint8 data[size];
+} huge_t;
+saved huge_t x;
+
+
+header %{
+#ifndef _WIN32
+    #include <sys/resource.h>
+#endif
+    static void run_test(conf_object_t *obj, int stack_limit) {
+#ifndef _WIN32
+        // waste most of the stack. Pass O0 to avoid optimizing out alloca.
+        struct rlimit limit;
+        getrlimit(RLIMIT_STACK, &limit);
+/// CC-FLAG -O0
+        char *x = alloca(limit.rlim_cur - stack_limit);
+        x[0] = 1;
+        x[stack_limit - 1] = 1;
+#endif
+        attr_value_t a = SIM_get_attribute(obj, "x");
+        SIM_set_attribute(obj, "x", &a);
+        SIM_attr_free(&a);
+    }
+%}
+extern void run_test(conf_object_t *obj, int stack_limit);
+
+method test() throws {
+    run_test(dev.obj, 100000);
+}

--- a/test/1.4/structure/T_diamond_override.dml
+++ b/test/1.4/structure/T_diamond_override.dml
@@ -1,0 +1,20 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+import "testing.dml";
+
+template a { method m() -> (int) default { return 0; } }
+template b { method m() -> (int) default { return 1; } }
+template c is (a, b) { method m() -> (int) default { return 2; } }
+is c;
+group d is (a, b) { method m() -> (int) default { return 3; } }
+
+method test() throws {
+    assert m() == 2;
+    assert d.m() == 3;
+}

--- a/test/XFAIL
+++ b/test/XFAIL
@@ -58,9 +58,6 @@
 # SIMICS-9783
 1.2/structure/parameter_if
 
-# SIMICS-11346
-1.2/structure/trait
-
 # SIMICS-12233
 1.2/errors/ENAMECOLL_uint32
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -679,6 +679,8 @@ class CTestCase(DMLFileTestCase):
         sc.write("testname = %r\n" % self.shortname)
         sc.write("scratchdir = %r\n" % self.scratchdir)
         sc.write("basedir = %r\n" % join(os.path.dirname(self.filename)))
+        sc.write("SIM_add_module_dir(scratchdir)\n")
+        sc.write("SIM_module_list_refresh()\n")
         if auto_instantiate:
             sc.write("try:\n")
             sc.write(f"    SIM_load_module('dml-test-{self.shortname}')\n")
@@ -708,7 +710,6 @@ class CTestCase(DMLFileTestCase):
                 "-batch-mode", "-quiet", "-no-copyright", "-no-settings",
                 "-core", "-werror",
                 '-py3k-warnings',
-                "-L", self.scratchdir,
                 "-project", testparams.project_path(),
                 "-p", self.scriptname]
         env = os.environ.copy()


### PR DESCRIPTION
- remove obsolete XFAIL
- Add test that ambiguous inheritance can be resolved by override
- Avoid having to pass -L when re-running test manually
- Don't declare a temporary struct instance as a local variable
