### PR TITLE
Make DMLC output deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ PYFILES := dml/__init__.py			\
           dml/objects.py			\
           dml/output.py				\
 	  dml/reginfo.py			\
-          dml/serialize.py				\
+          dml/serialize.py			\
+          dml/set.py				\
           dml/slotsmeta.py			\
           dml/structure.py			\
           dml/symtab.py				\

--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1712,4 +1712,10 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
   <build-id value="next"><add-note> The DMLC implementation is now
       shipped as source code, as <tt>.py</tt> files instead
       of <tt>.pyc</tt>.</add-note></build-id>
+  <build-id value="next"><add-note> The C code emitted by DMLC is now
+      identical every time, when given the same DML files as
+      input. Previously, the compiler had nondeterministic behaviour
+      that affected things like in what order C functions are output.
+      Deterministic output allows more efficient use of tools like
+      <tt>ccache</tt>.</add-note></build-id>
 </rn>

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -25,6 +25,7 @@ from .expr_util import *
 from .symtab import *
 from .codegen import *
 from .types import *
+from .set import Set
 
 prototypes = []
 c_split_threshold = None
@@ -1851,7 +1852,7 @@ def generate_each_in_tables():
         by_trait.setdefault(trait, []).append((node, subobjs))
     for t in by_trait:
         generate_each_in_table(t, by_trait[t])
-    for t in set(dml.globals.traits.values()) - set(by_trait):
+    for t in Set(dml.globals.traits.values()).difference(by_trait):
         # Need by shared methods that belong to unused templates;
         # when dereferencing sequence params, these methods reference
         # the base array.
@@ -2476,7 +2477,7 @@ def generate_trait_trampoline(method, vtable_trait):
 def generate_trait_trampolines(node):
     '''Generate trampolines for all used trait methods overridden in an
     object, excluding subobjects'''
-    overridden = set(node.traits.method_overrides)
+    overridden = Set(node.traits.method_overrides)
     for trait in node.traits.referenced:
         for name in overridden.intersection(trait.vtable_methods):
             generate_trait_trampoline(

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -20,6 +20,7 @@ from .symtab import *
 from .messages import *
 from .output import out
 from .types import *
+from .set import Set
 import dml.globals
 
 __all__ = (
@@ -83,7 +84,7 @@ def gensym(prefix = '_gensym'):
 referenced_methods = {}
 method_queue = []
 exported_methods = {}
-statically_exported_methods = set()
+statically_exported_methods = Set()
 
 # Saved variables in methods, method->list of symbols
 saved_method_variables = {}

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -580,7 +580,7 @@ def main(argv):
                     sys.stderr.write(f'  {f}\n')
                 # this avoids an infinite make loop, at the cost of ruining
                 # dependencies
-                deplist = set(deplist) - set(future_timestamps)
+                deplist = [d for d in deplist if d not in future_timestamps]
             deps = ' '.join(path.replace(" ", "\\ ") for path in deplist)
             if options.dep_target:
                 targetlist = options.dep_target

--- a/py/dml/globals.py
+++ b/py/dml/globals.py
@@ -13,7 +13,7 @@ missing_templates = set()
 traits = None
 
 # A mapping from each trait to the set of objects instantiating that trait.
-# Trait -> {CompositeObject}
+# {Trait: [CompositeObject]}
 trait_instances = {}
 
 

--- a/py/dml/objects.py
+++ b/py/dml/objects.py
@@ -292,7 +292,7 @@ class CompositeObject(DMLObject):
         self.traits = traits
         for t in itertools.chain(*([t] + list(t.ancestors)
                                    for t in traits.ancestors)):
-            dml.globals.trait_instances.setdefault(t, set()).add(self)
+            dml.globals.trait_instances.setdefault(t, []).append(self)
             if t in serialize.serialized_traits.traits:
                 traits.mark_referenced(t)
 

--- a/py/dml/serialize.py
+++ b/py/dml/serialize.py
@@ -8,6 +8,7 @@ from . import ctree, expr, types, logging, symtab, messages, output, logging
 from .types import *
 from .logging import *
 from .expr_util import *
+from .set import Set
 import dml.globals
 
 __all__ = (
@@ -34,7 +35,7 @@ serialize_function_code = []
 
 class SerializedTraits:
     def __init__(self):
-        self.traits = set()
+        self.traits = Set()
 
     def add(self, trait):
         if trait not in self.traits:

--- a/py/dml/set.py
+++ b/py/dml/set.py
@@ -1,0 +1,66 @@
+# © 2023 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+from itertools import chain
+
+class Set:
+    '''Restricted clone of builtin.set where iteration preserves
+    insertion order
+
+    Performance is worse than that of builtins.set; for the slowest
+    operations the slowdown is about 20% worse using pypy, and about
+    100% using CPython
+
+    '''
+    __slots__ = ['_d', '__iter__', '__contains__', '__len__', 'remove']
+    def __init__(self, els=()):
+        d = {e: None for e in els}
+        self._d = d
+        self.__iter__ = self._d.__iter__
+        self.__contains__ = self._d.__contains__
+        self.__len__ = self._d.__len__
+        self.remove = self._d.__delitem__
+
+    def __repr__(self):
+        if self._d:
+            return f"Set([{', '.join(map(repr, self._d))}])"
+        else:
+            return 'Set()'
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __eq__(self, other):
+        if isinstance(other, Set):
+            return self._d.keys().__eq__(other._d.keys())
+        return self._d.keys().__eq__(other)
+
+    __hash__ = None
+
+    def add(self, x):
+        self._d[x] = None
+
+    def update(self, xs):
+        self._d.update((x, None) for x in xs)
+
+    def intersection(self, *others):
+        if not others:
+            return Set(self)
+        if len(others) == 1 and isinstance(others[0], (set, Set, dict)):
+            # __contains__ known to be fast
+            [i] = others
+        else:
+            i = set(others[0]).intersection(*others[1:])
+        return Set(x for x in self._d if x in i)
+
+    def difference(self, *others):
+        if len(self._d) == 0:
+            return Set()
+        if len(others) == 1 and isinstance(others[0], (set, Set, dict)):
+            [u] = others
+        else:
+            u = set().union(*others)
+        return Set(x for x in self._d if x not in u)
+
+    def union(self, *others):
+        return Set(chain(self._d, *others))

--- a/py/dml/set_test.py
+++ b/py/dml/set_test.py
@@ -1,0 +1,99 @@
+# © 2023 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+from dml.set import Set
+
+import unittest
+
+class TestSet(unittest.TestCase):
+    def test_contains(self):
+        (o1, o2) = (object(), object())
+        x = Set([0, 2, 'foo', o1])
+        self.assertTrue(0 in x)
+        self.assertFalse(1 in x)
+        self.assertTrue('foo' in x)
+        self.assertFalse('bar' in x)
+        self.assertTrue(o1 in x)
+        self.assertFalse(o2 in x)
+
+    def test_eq(self):
+        x = Set(range(10))
+        self.assertEqual(x, Set(range(10)))
+        self.assertNotEqual(x, Set(range(11)))
+        self.assertEqual(x, set(range(10)))
+        assert set(range(10)) == {e: e for e in range(10)}.keys()
+        self.assertEqual(x, {e: e for e in range(10)}.keys())
+
+    def test_str_repr(self):
+        for f in [str, repr]:
+            self.assertEqual(f(Set()), 'Set()')
+            self.assertEqual(f(Set([1, 'one'])), "Set([1, 'one'])")
+
+    def test_iter(self):
+        els = [object() for _ in range(100)]
+        x = Set(x for x in els)
+        self.assertEqual(list(x), els)
+
+    def test_len(self):
+        self.assertEqual(len(Set()), 0)
+        self.assertEqual(len(Set(range(10))), 10)
+        # the bool function relies on __len__
+        self.assertFalse(bool(Set()))
+        self.assertTrue(bool(Set([1])))
+
+    def test_add(self):
+        x = Set()
+        x.add(4)
+        x.add(10)
+        x.add(8)
+        self.assertTrue(4 in x)
+        self.assertTrue(8 in x)
+
+    def test_update(self):
+        x = Set([10, 4, 2])
+        x.update(x for x in [4, 8, 10])
+        self.assertEqual(list(x), [10, 4, 2, 8])
+
+    def test_remove(self):
+        x = Set(range(10))
+        x.remove(4)
+        x.remove(7)
+        self.assertEqual(list(x), [e for e in range(10) if e not in {4, 7}])
+        with self.assertRaises(KeyError):
+            x.remove(None)
+
+    def test_hash(self):
+        for s in [Set(), set()]:
+            with self.assertRaises(TypeError):
+                # fisketur[useless-builtin-call]
+                hash(s)
+
+    def test_intersection(self):
+        x = Set(range(10))
+        y = x.intersection()
+        self.assertIsNot(x, y)
+        self.assertEqual(list(y), list(range(10)))
+        self.assertEqual(
+            list(Set(range(10)).intersection({5, 3, 10})),
+            [3, 5])
+        self.assertEqual(
+            list(Set(range(10)).intersection({5: 1, 3: 7, 10: 3})),
+            [3, 5])
+        self.assertEqual(
+            list(Set(range(10)).intersection(range(0, 20, 2), range(0, 20, 3))),
+            [0, 6])
+
+    def test_difference(self):
+        self.assertEqual(list(Set([2, 1]).difference()), [2, 1])
+        for other in [{2, 4}, {2: None, 4: None}, Set([2, 4]), [2, 4]]:
+            self.assertEqual(list(Set([3, 2, 1]).difference(other)),
+                             [3, 1])
+        self.assertEqual(
+            list(Set(range(10)).difference(
+                range(0, 20, 2), range(0, 20, 3), range(0, 20, 5))),
+            [1, 7])
+
+    def test_union(self):
+        self.assertEqual(list(Set([1, 2]).union()), [1, 2])
+        self.assertEqual(list(Set([6, 1, 2]).union([5, 2], range(6, 0, -2))),
+                         [6, 1, 2, 5, 4])

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -1699,7 +1699,7 @@ def mkobj2(obj, obj_specs, params, each_stmts):
                                      subobj.name))
                     continue
                 # Prevent malicious users from having a top-level object
-                # be named "dev", as the device object's serialized identity
+                # named "dev", as the device object's serialized identity
                 # logname is "dev", and must be unique
                 elif subobj.name == 'dev' and obj.objtype == 'device':
                     report(ENAMECOLL(subobj.name_site, obj.site, 'dev'))

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -30,6 +30,7 @@ from . import template
 from .template import Rank, RankDesc, ObjectSpec
 from .reginfo import explode_registers
 from . import dmlparse
+from .set import Set
 
 __all__ = (
     'mkglobals', 'mkdev'
@@ -1564,7 +1565,7 @@ def mkobj2(obj, obj_specs, params, each_stmts):
                 report(EAUNKDIMSIZE(specs[0].site, i, idx))
                 arrayinfo[i] = (idx, ast.int(specs[0].site, 1))
 
-    explicit_traits = {t for (_, t) in obj_traits}
+    explicit_traits = Set(t for (_, t) in obj_traits)
     ancestors = explicit_traits.union(
         *(t.ancestors for t in explicit_traits))
 
@@ -1575,7 +1576,9 @@ def mkobj2(obj, obj_specs, params, each_stmts):
             new_trait = traits.mktrait(
                 obj.site, "__implicit_" + "__".join(sorted(
                     t.name for t in direct_parents)),
-                traitset, {}, {}, {}, {})
+                # traitset is a frozenset, with undefined iteration order;
+                # must sort it to keep compilation deterministic
+                Set(sorted(traitset)), {}, {}, {}, {})
             implicit_traits[traitset] = new_trait
             if new_trait.name in dml.globals.traits:
                 raise ICE(

--- a/py/dml/template.py
+++ b/py/dml/template.py
@@ -3,7 +3,6 @@
 
 # Process templates, from ASTs to Template objects
 
-import collections
 import os
 from . import ast, logging
 from .logging import *
@@ -332,8 +331,8 @@ def process_templates(template_decls):
 
     # The generation of struct definitions assumes the dictionary to
     # be topologically ordered on inheritance: if A inherits B, B
-    # occurs first in the dict.
-    traits = collections.OrderedDict()
+    # appears first in the dict.
+    traits = {}
 
     # name -> Template
     templates = {}

--- a/py/dml/template.py
+++ b/py/dml/template.py
@@ -8,6 +8,7 @@ import os
 from . import ast, logging
 from .logging import *
 from .messages import *
+from .set import Set
 import dml.globals
 import dml.traits
 
@@ -250,7 +251,7 @@ def rank_structure(asts):
     conditionally instantiate a template.
     '''
     inferior = {}
-    unconditional = set()
+    unconditional = Set()
     in_each_structure = {}
     queue = [(ast, False) for ast in asts]
     while queue:
@@ -296,7 +297,7 @@ def process_templates(template_decls):
     for (name, (_, asts, _)) in list(template_decls.items()):
         (references, uncond_refs, in_each_structure) = rank_structure(asts)
         template_rank_structure[name] = (references, in_each_structure)
-        referenced = set(references)
+        referenced = Set(references)
         required_templates[name] = referenced
         all_missing = referenced.difference(template_decls)
         if all_missing:
@@ -348,7 +349,8 @@ def process_templates(template_decls):
         else:
             trait = dml.traits.process_trait(
                 spec.site, name, trait_stmts,
-                set().union(*[tpl.traits() for (_, tpl) in spec.templates]),
+                Set().union(
+                    *[tpl.traits() for (_, tpl) in spec.templates]),
                 spec.defined_symbols())
             traits[name] = trait
         templates[name] = Template(name, trait, spec)

--- a/py/dml/traits.py
+++ b/py/dml/traits.py
@@ -4,7 +4,6 @@
 # Infrastructure for traits
 
 import itertools
-import collections
 import contextlib
 import abc
 import os
@@ -599,10 +598,9 @@ class ReservedSymbol(NonValue):
 class Trait(SubTrait):
     '''A trait, as defined by a top-level 'trait' statement'''
 
-    # set of traits that are actually used. Ordered set, represented
-    # as mapping Trait -> None. A trait should appear before all its
-    # subtraits in the ordering.
-    referenced = collections.OrderedDict()
+    # set of traits that are actually used. Each trait appears before
+    # all its subtraits.
+    referenced = Set()
 
     def __init__(self, site, name, ancestors, methods, params, sessions,
                  ancestor_vtables, ancestor_method_impls, reserved_symbols):
@@ -774,7 +772,7 @@ class Trait(SubTrait):
         if not self in Trait.referenced:
             for p in self.direct_parents:
                 p.mark_referenced()
-            Trait.referenced[self] = None
+            Trait.referenced.add(self)
 
     def implements(self, trait):
         return trait is self or trait in self.ancestors

--- a/py/dml/traits.py
+++ b/py/dml/traits.py
@@ -494,7 +494,7 @@ def sort_method_implementations(implementations):
 
     return (method_map, method_order)
 
-class SubTrait(object):
+class SubTrait:
     '''Logic shared between nodes and traits, which both can inherit
     other traits.'''
     def __init__(self, ancestors, ancestor_vtables):

--- a/test/1.2/misc/porting.dml
+++ b/test/1.2/misc/porting.dml
@@ -6,6 +6,7 @@
 /* column numbering works with unicode: ä */ dml 1.2;
 
 /// COMPILE-ONLY
+/// NO-CC
 // ignored
 //
 

--- a/test/1.2/registers/T_par_over_endian.dml
+++ b/test/1.2/registers/T_par_over_endian.dml
@@ -6,6 +6,9 @@ dml 1.2;
 
 device test;
 
+// reduce compile time
+/// CC-FLAG -O0
+
 template testfield {
     // These register fields simply return for each byte the lowest
     // byte in the offset

--- a/test/1.4/misc/porting.dml
+++ b/test/1.4/misc/porting.dml
@@ -6,6 +6,7 @@
 /* column numbering works with unicode: ä */ dml 1.4;
 
 /// COMPILE-ONLY
+/// NO-CC
 // ignored
 /// DMLC-FLAG -Ptags
 

--- a/test/1.4/statements/T_endian_int_aliasing.dml
+++ b/test/1.4/statements/T_endian_int_aliasing.dml
@@ -12,6 +12,7 @@ import "simics/simulator/sim-get-class.dml";
 
 // check that GCC actually performs the aliasing-based optimizations we think
 // for non-endian types
+/// CC-FLAG -O2
 method bad() {
     local uint8 buf[10];
     local uint32 *p1 = cast(buf, uint32 *);

--- a/test/tests.py
+++ b/test/tests.py
@@ -502,7 +502,8 @@ class DMLFileTestCase(BaseTestCase):
                      cc_flags=(),
                      dmlc_flags=(),
                      instantiate_manually=False,
-                     compile_only=False):
+                     compile_only=False,
+                     no_cc=False):
             self.exp_warnings = list(exp_warnings)
             self.exp_errors = list(exp_errors)
             self.exp_stdout = list(exp_stdout)
@@ -510,6 +511,7 @@ class DMLFileTestCase(BaseTestCase):
             self.dmlc_flags = list(dmlc_flags)
             self.instantiate_manually = instantiate_manually
             self.compile_only = compile_only
+            self.no_cc = no_cc
     def test_flags(self, filename=None, append_to=None):
         if filename is None:
             filename = self.filename
@@ -566,6 +568,8 @@ class DMLFileTestCase(BaseTestCase):
                 flags.instantiate_manually = True
             elif key == 'COMPILE-ONLY':
                 flags.compile_only = True
+            elif key == 'NO-CC':
+                flags.no_cc = True
             else:
                 raise TestFail('Unexpected key %s' % (key,))
         return flags
@@ -789,6 +793,10 @@ class CTestCase(DMLFileTestCase):
             self.print_logs('dmlc', self.dmlc_stdout, self.dmlc_stderr)
 
         if status != 0: # No use compiling if dmlc failed
+            return
+
+        if flags.no_cc:
+            assert flags.compile_only
             return
 
         # Run the C compiler

--- a/test/tests.py
+++ b/test/tests.py
@@ -74,6 +74,9 @@ line_directives = bool(os.environ.get('DMLC_LINE_DIRECTIVES'))
 
 dmlc = python + [join(project_host_path(), "bin", "dml", "python")]
 
+line_directives = {None: True, 'yes': True, 'no': False}[
+    os.environ.get('DMLC_LINE_DIRECTIVES')]
+
 if not is_windows():
     dmlc_lib_path = ":".join(
         [join(simics_root_path(), host_type(), p) for p in ('bin', 'sys/lib')]


### PR DESCRIPTION
- Adapt to rename of state-change notifier
- Enable line directives by default
- Allow disabling gcc optimizations
- Use dicts and lists instead of sets to avoid indeterministic output
- Sort sets before using, to avoid indeterministic output
- Validate that two runs with different pythons give the same C output
- fix minor typos
- Use ordinary dictionaries
