### PR TITLE
Revert "Typed set/get variants for standard attribute templates -- SIMICS-17951"

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -448,15 +448,6 @@
       option to DMLC. When used, DMLC will generate Synopsys® Coverity® analysis
       annotations to suppress common false positives in generated C code created
       from DML 1.4 devices.</add-note></build-id>
-  <build-id value="next"><add-note>Two new overridable methods
-      <tt>get_val() -> (<em>type</em>)</tt> and
-      <tt>set_val(<em>type</em> val) throws</tt> have been introduced to the
-      attribute templates <tt>bool_attr</tt>, <tt>uint64_attr</tt>,
-      <tt>int64_attr</tt> and <tt>double_attr</tt>. These methods are used by
-      the default implementations of <tt>get</tt> and <tt>set</tt>, and
-      overriding them is an alternate way of specifying custom get/set logic for
-      attributes making use of these templates <bug number="SIMICS-17951"/>.
-  </add-note></build-id>
   <build-id value="next"><add-note> Fixed an ICE caused by constant inlined
       method parameters being used in constant equalities
       <bug number="16019548195"/>.</add-note></build-id>

--- a/lib/1.2/dml12-compatibility.dml
+++ b/lib/1.2/dml12-compatibility.dml
@@ -23,75 +23,26 @@ template bool_attr is (attribute, _banned_init_val) {
     param val = this;
     // Since we are by definition backed by 1.2 builtins, get throws
     shared method get() -> (attr_value_t);
-    method get() -> (attr_value_t) default {
-        return SIM_make_attr_boolean(get_val());
-    }
     shared method set(attr_value_t val) throws;
-    method set(attr_value_t val) throws default {
-        set_val(SIM_attr_boolean(val));
-    }
-    shared method get_val() -> (bool);
-    method get_val() -> (bool) default {
-        return this;
-    }
-    shared method set_val(bool val) throws;
-    method set_val(bool val) throws default {
-        this = val;
-    }
 }
 
 template uint64_attr is (attribute, _banned_init_val) {
     param allocate_type = "uint64";
     param val = this;
     shared method get() -> (attr_value_t);
-    method get() -> (attr_value_t) default {
-        return SIM_make_attr_uint64(get_val());
-    }
     shared method set(attr_value_t val) throws;
-    method set(attr_value_t val) throws default {
-        if (!SIM_attr_is_uint64(val)) {
-            SIM_c_attribute_error("negative integer value: %lld",
-                                  cast(SIM_attr_integer(val), int64));
-            throw;
-        }
-        set_val(SIM_attr_integer(val));
-    }
-    shared method set_val(uint64 val) throws;
-    method set_val(uint64 val) throws default {
-        this = val;
-    }
-    shared method get_val() -> (uint64);
-    method get_val() -> (uint64) default {
-        return this;
-    }
 }
 
 template int64_attr is (attribute, _banned_init_val) {
     param allocate_type = "int64";
     param val = this;
-    // Note: 1.4 attribute returns signed int but 1.2 does not,
-    // hence the override here is not only to make use of get_val(), but
-    // also to always return signed
     shared method get() -> (attr_value_t);
-    method get() -> (attr_value_t) default {
-        return SIM_make_attr_int64(get_val());
-    }
     shared method set(attr_value_t val) throws;
-    method set(attr_value_t val) throws default {
-        if (!SIM_attr_is_int64(val)) {
-            SIM_c_attribute_error("integer value too large: %llu",
-                                  cast(SIM_attr_integer(val), uint64));
-            throw;
-        }
-        set_val(SIM_attr_integer(val));
-    }
-    shared method get_val() -> (int64);
-    method get_val() -> (int64) default {
-        return this;
-    }
-    shared method set_val(int64 val) throws;
-    method set_val(int64 val) throws default {
-        this = val;
+    // 1.4 attribute returns signed int, but 1.2 does not,
+    // hence we need to override get here to always return
+    // signed
+    method get() -> (attr_value_t) default {
+        return SIM_make_attr_int64(val);
     }
 }
 
@@ -99,21 +50,7 @@ template double_attr is (attribute, _banned_init_val) {
     param allocate_type = "double";
     param val = this;
     shared method get() -> (attr_value_t);
-    method get() -> (attr_value_t) default {
-        return SIM_make_attr_floating(get_val());
-    }
     shared method set(attr_value_t val) throws;
-    method set(attr_value_t val) throws default {
-        set_val(SIM_attr_floating(val));
-    }
-    shared method get_val() -> (double);
-    method get_val() -> (double) default {
-        return this;
-    }
-    shared method set_val(double val) throws;
-    method set_val(double val) throws default {
-        this = val;
-    }
 }
 
 template pseudo_attr is attribute {

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -1040,14 +1040,7 @@ standard types. Each store the attribute value in a member `val`,
 provide default implementations of methods `get` and `set` according to the
 type, and provide a default implementation of `init` that initializes
 `val` using the `init_val` parameter also provided by the template (whose
-default definition simply zero-initializes `val`.)
-The default implementations of `get` and `set` make use of corresponding
-methods <tt>get_val() -> (<em>type</em>)</tt> and
-<tt>set_val(<em>type</em> val) throws</tt>, which can be overridden in order to
-provide custom get/set logic in a more ergonomic way compared to overriding
-`get`/`set` directly.
-
-The four templates are:
+default definition simply zero-initializes `val`.) These four templates are:
 
 <dl><dt>
 
@@ -1117,16 +1110,10 @@ template bool_attr is (attribute, init) {
         val = init_val;
     }
     shared method get() -> (attr_value_t) default {
-        return SIM_make_attr_boolean(get_val());
+        return SIM_make_attr_boolean(val);
     }
     shared method set(attr_value_t val) throws default {
-        set_val(SIM_attr_boolean(val));
-    }
-    shared method set_val(bool val) throws default {
-        this.val = val;
-    }
-    shared method get_val() -> (bool) default {
-        return this.val;
+        this.val = SIM_attr_boolean(val);
     }
 }
 
@@ -1139,7 +1126,7 @@ template uint64_attr is (attribute, init) {
         val = init_val;
     }
     shared method get() -> (attr_value_t) default {
-        return SIM_make_attr_uint64(get_val());
+        return SIM_make_attr_uint64(val);
     }
     shared method set(attr_value_t val) throws default {
         if (!SIM_attr_is_uint64(val)) {
@@ -1147,13 +1134,7 @@ template uint64_attr is (attribute, init) {
                                   cast(SIM_attr_integer(val), int64));
             throw;
         }
-        set_val(SIM_attr_integer(val));
-    }
-    shared method set_val(uint64 val) throws default {
-        this.val = val;
-    }
-    shared method get_val() -> (uint64) default {
-        return this.val;
+        this.val = SIM_attr_integer(val);
     }
 }
 
@@ -1166,7 +1147,7 @@ template int64_attr is (attribute, init) {
         val = init_val;
     }
     shared method get() -> (attr_value_t) default {
-        return SIM_make_attr_int64(get_val());
+        return SIM_make_attr_int64(val);
     }
     shared method set(attr_value_t val) throws default {
         if (!SIM_attr_is_int64(val)) {
@@ -1174,13 +1155,7 @@ template int64_attr is (attribute, init) {
                                   cast(SIM_attr_integer(val), uint64));
             throw;
         }
-        set_val(SIM_attr_integer(val));
-    }
-    shared method set_val(int64 val) throws default {
-        this.val = val;
-    }
-    shared method get_val() -> (int64) default {
-        return this.val;
+        this.val = SIM_attr_integer(val);
     }
 }
 
@@ -1193,16 +1168,10 @@ template double_attr is (attribute, init) {
         val = init_val;
     }
     shared method get() -> (attr_value_t) default {
-        return SIM_make_attr_floating(get_val());
+        return SIM_make_attr_floating(val);
     }
     shared method set(attr_value_t val) throws default {
-        set_val(SIM_attr_floating(val));
-    }
-    shared method set_val(double val) throws default {
-        this.val = val;
-    }
-    shared method get_val() -> (double) default {
-        return this.val;
+        this.val = SIM_attr_floating(val);
     }
 }
 

--- a/test/1.2/misc/dml14.dml
+++ b/test/1.2/misc/dml14.dml
@@ -358,44 +358,6 @@ attribute woa is (write_only_attr) {
     method set(attr_value_t val) throws {}
 }
 
-attribute ia2 is (int64_attr) {
-    method get_val() -> (int64) {
-        return this.val + 1;
-    }
-
-    method set_val(int64 val) throws {
-        this.val = val - 1;
-    }
-}
-
-attribute ua2 is (uint64_attr) {
-    method get_val() -> (uint64) {
-        return this.val + 1;
-    }
-
-    method set_val(uint64 val) throws {
-        this.val = val - 1;
-    }
-}
-attribute ba2 is (bool_attr) {
-    method get_val() -> (bool) {
-        return !this.val;
-    }
-
-    method set_val(bool val) throws {
-        this.val = !val;
-    }
-}
-attribute fa2 is (double_attr) {
-    method get_val() -> (double) {
-        return -this.val;
-    }
-
-    method set_val(double val) throws {
-        this.val = -val;
-    }
-}
-
 param global_sym = 14;
 
 /// WARNING WEXPERIMENTAL
@@ -470,34 +432,21 @@ method len_test() {
 // checks that typed attribute access works
 method attribute_test() throws {
     cast(ia, int64_attr).set(SIM_make_attr_int64(-16));
-    local attr_value_t ia_get = cast(ia, int64_attr).get();
-    assert SIM_attr_integer(ia_get) == -16;
+    local attr_value_t ia_get;
+    (ia_get) = cast(ia, int64_attr).get();
+    assert(SIM_attr_integer(ia_get) == -16);
     cast(ua, uint64_attr).set(SIM_make_attr_uint64(32));
-    local attr_value_t ua_get = cast(ua, uint64_attr).get();
-    assert SIM_attr_integer(ua_get) == 32;
+    local attr_value_t ua_get;
+    (ua_get) = cast(ua, uint64_attr).get();
+    assert(SIM_attr_integer(ua_get) == 32);
     cast(ba, bool_attr).set(SIM_make_attr_boolean(true));
-    local attr_value_t ba_get = cast(ba, bool_attr).get();
-    assert SIM_attr_boolean(ba_get);
+    local attr_value_t ba_get;
+    (ba_get) = cast(ba, bool_attr).get();
+    assert(SIM_attr_boolean(ba_get));
     cast(fa, double_attr).set(SIM_make_attr_floating(4.13));
-    local attr_value_t fa_get = cast(fa, double_attr).get();
-    assert SIM_attr_floating(fa_get) == 4.13;
-
-    cast(ia2, int64_attr).set(SIM_make_attr_int64(-16));
-    local attr_value_t ia2_get = cast(ia2, int64_attr).get();
-    assert SIM_attr_integer(ia2_get) == -16;
-    assert ia2.val == -17;
-    cast(ua2, uint64_attr).set(SIM_make_attr_uint64(32));
-    local attr_value_t ua2_get = cast(ua2, uint64_attr).get();
-    assert SIM_attr_integer(ua2_get) == 32;
-    assert ua2.val == 31;
-    cast(ba2, bool_attr).set(SIM_make_attr_boolean(true));
-    local attr_value_t ba2_get = cast(ba2, bool_attr).get();
-    assert SIM_attr_boolean(ba2_get);
-    assert !ba2.val;
-    cast(fa2, double_attr).set(SIM_make_attr_floating(4.13));
-    local attr_value_t fa2_get = cast(fa2, double_attr).get();
-    assert SIM_attr_floating(fa2_get) == 4.13;
-    assert fa2.val == -4.13;
+    local attr_value_t fa_get;
+    (fa_get) = cast(fa, double_attr).get();
+    assert(SIM_attr_floating(fa_get) == 4.13);
 }
 
 method pseudo_attr_test() throws {

--- a/test/1.4/lib/T_attributes.dml
+++ b/test/1.4/lib/T_attributes.dml
@@ -51,41 +51,6 @@ attribute overridden_init is (bool_attr) {
     method init() { }
 }
 
-attribute b3 is (bool_attr) {
-    method get_val() -> (bool) {
-        return !this.val;
-    }
-    method set_val(bool val) throws {
-        this.val = !val;
-    }
-}
-
-attribute u3 is (uint64_attr) {
-    method get_val() -> (uint64) {
-        return this.val + 1;
-    }
-    method set_val(uint64 val) throws {
-        this.val = val - 1;
-    }
-}
-
-attribute i3 is (int64_attr) {
-    method get_val() -> (int64) {
-        return this.val + 1;
-    }
-    method set_val(int64 val) throws {
-        this.val = val - 1;
-    }
-}
-
-attribute f3 is (double_attr) {
-    method get_val() -> (double) {
-        return -this.val;
-    }
-    method set_val(double val) throws {
-        this.val = -val;
-    }
-}
 
 method test() throws {
     b.val = true;
@@ -129,26 +94,4 @@ method test() throws {
     assert i2.val == -33;
     assert f2.val == 3.3;
     assert !overridden_init.val;
-
-    // local attr_value_t bool_attr = SIM_make_attr_boolean(false);
-    SIM_set_attribute(dev.obj, "b3", &bool_attr);
-    assert b3.val;
-    assert !SIM_attr_boolean(SIM_get_attribute(dev.obj, "b3"));
-
-    local attr_value_t uint_attr = SIM_make_attr_uint64(134);
-    SIM_set_attribute(dev.obj, "u3", &uint_attr);
-    assert u3.val == 133;
-    assert cast(SIM_attr_integer(SIM_get_attribute(dev.obj, "u3")), uint64)
-        == 134;
-
-    local attr_value_t int_attr = SIM_make_attr_int64(-134);
-    SIM_set_attribute(dev.obj, "i3", &int_attr);
-    assert i3.val == -135;
-    assert SIM_attr_integer(SIM_get_attribute(dev.obj, "i3")) == -134;
-
-    // local attr_value_t float_attr = SIM_make_attr_floating(1.414);
-    SIM_set_attribute(dev.obj, "f3", &float_attr);
-    assert f3.val == -1.414;
-    assert SIM_attr_floating(SIM_get_attribute(dev.obj, "f3"))
-        == 1.414;
 }


### PR DESCRIPTION
This reverts commit f6d442b6126ff46ea9ec5f1ff4d376018509bab6. Reverted due to breaking VP badly enough that resolution warrants thought and discussion.