### PR TITLE
Miscellaneous changes from #144

### DIFF
--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -2120,12 +2120,16 @@ def stmt_after(stmt, location, scope):
     site = stmt.site
 
     if callexpr[0] == 'apply':
-        method = callexpr[2]
+        method_ast = callexpr[2]
         inargs = callexpr[3]
     else:
-        assert dml.globals.dml_version == (1, 2), repr(callexpr)
-        method = callexpr
-        inargs = []
+        if dml.globals.dml_version == (1, 2):
+            method_ast = callexpr
+            inargs = []
+        else:
+            raise ESYNTAX(site, None,
+                          'callback expression to after statement must be a '
+                          + 'function application')
 
     delay = codegen_expression(delay, location, scope)
     old_delay_type = delay.ctype()
@@ -2136,7 +2140,7 @@ def stmt_after(stmt, location, scope):
         api_unit = 'cycle'
         unit_type = TInt(64, True)
     else:
-        raise ICE(self.site, f"Unsupported unit of time: '{unit}'")
+        raise ICE(site, f"Unsupported unit of time: '{unit}'")
 
     try:
         delay = source_for_assignment(site, unit_type, delay)
@@ -2153,7 +2157,7 @@ def stmt_after(stmt, location, scope):
     else:
         domains = [TraitObjIdentity(site, lookup_var(site, scope, "this"))]
 
-    method = codegen_expression_maybe_nonvalue(method, location, scope)
+    method = codegen_expression_maybe_nonvalue(method_ast, location, scope)
 
     if not isinstance(method, NodeRef):
         raise ENMETH(site, method)

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -1533,7 +1533,7 @@ def stmt_session(stmt, location, scope):
         (struct_decls, etype) = eval_type(asttype, stmt.site, location,
                                           global_scope)
         etype = etype.resolve()
-        TStruct.late_global_struct_defs.extend(struct_decls)
+        add_late_global_struct_defs(struct_decls)
         if init:
             try:
                 init = eval_initializer(
@@ -1618,7 +1618,7 @@ def stmt_saved(stmt, location, scope):
     for (decl_ast, init) in zip(decls, inits):
         (name, asttype) = decl_ast.args
         (struct_decls, etype) = eval_type(asttype, stmt.site, location, scope)
-        TStruct.late_global_struct_defs.extend(struct_decls)
+        add_late_global_struct_defs(struct_decls)
         etype.resolve()
         if init:
             try:

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 
 from . import structure, logging, messages, ctree, ast, expr_util, toplevel
+from . import serialize
 from . import dmlparse
 from . import output
 
@@ -559,6 +560,7 @@ def main(argv):
     logtime("startup")
 
     try:
+        dml.globals.serialized_traits = serialize.SerializedTraits()
         (dml_version, devname, headers, footers, global_defs,
          top_tpl, imported) = toplevel.parse_main_file(
              inputfilename, options.import_path, options.strict)

--- a/py/dml/globals.py
+++ b/py/dml/globals.py
@@ -36,6 +36,10 @@ static_vars = []
 # A reference to the 'object' trait
 object_trait = None
 
+# Set of template types which get serialized
+# serialize.SerializedTraits
+serialized_traits = None
+
 # 1.4 style integer operations in 1.2, --strict-dml12-int
 strict_int_flag = None
 def compat_dml12_int(site):

--- a/py/dml/objects.py
+++ b/py/dml/objects.py
@@ -6,7 +6,7 @@ import abc
 
 from .logging import *
 from .messages import *
-from . import serialize
+from .set import Set
 import dml.globals
 
 __all__ = (
@@ -292,8 +292,8 @@ class CompositeObject(DMLObject):
         self.traits = traits
         for t in itertools.chain(*([t] + list(t.ancestors)
                                    for t in traits.ancestors)):
-            dml.globals.trait_instances.setdefault(t, []).append(self)
-            if t in serialize.serialized_traits.traits:
+            dml.globals.trait_instances.setdefault(t, Set()).add(self)
+            if t in dml.globals.serialized_traits.traits:
                 traits.mark_referenced(t)
 
 class Device(CompositeObject):

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -807,12 +807,13 @@ def mksaved(spec, parent):
     obj = objects.Saved(name, dtype, astinit, site, parent)
     if astinit:
         dml.globals.device.add_init_data(obj)
+    typ = crep.node_storage_type(obj)
     try:
-        typ = realtype(crep.node_storage_type(obj))
+        realtype(typ)
     except DMLUnknownType as e:
         raise ETYPE(obj, e.type)
-    else:
-        serialize.mark_for_serialization(site, typ)
+
+    serialize.mark_for_serialization(site, typ)
 
     return obj
 

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -785,7 +785,7 @@ def mkdata(spec, parent):
     (struct_defs, dtype) = eval_type(
         typ, site, parent_scope, global_scope)
     dtype = dtype.resolve()
-    TStruct.late_global_struct_defs.extend(struct_defs)
+    add_late_global_struct_defs(struct_defs)
     obj = objects.Session(name, dtype, astinit, site, parent)
     if astinit:
         dml.globals.device.add_init_data(obj)
@@ -800,7 +800,7 @@ def mksaved(spec, parent):
 
     parent_scope = Location(parent, static_indices(parent))
     (struct_defs, dtype) = eval_type(typ, site, parent_scope, global_scope)
-    TStruct.late_global_struct_defs.extend(struct_defs)
+    add_late_global_struct_defs(struct_defs)
     dtype.resolve()
     if deep_const(dtype):
         raise ESAVEDCONST(site, dtype)

--- a/py/dml/traits.py
+++ b/py/dml/traits.py
@@ -75,7 +75,7 @@ def process_trait(site, name, subasts, ancestors, template_symbols):
                     (sname, type_ast) = decl_ast.args
                     (struct_defs, stype) = eval_type(
                         type_ast, ast.site, None, global_scope)
-                    TStruct.late_global_struct_defs.extend(struct_defs)
+                    add_late_global_struct_defs(struct_defs)
                     check_namecoll(sname, ast.site)
                     sessions[sname] = (ast.site, stype)
             elif ast.kind == 'typedparam':

--- a/py/dml/traits_test.py
+++ b/py/dml/traits_test.py
@@ -12,6 +12,7 @@ import dml.ctree
 from dml import crep
 from dml import types
 from dml import traits
+from dml import serialize
 
 class Test_traits(unittest.TestCase):
     def setUp(self):
@@ -20,6 +21,7 @@ class Test_traits(unittest.TestCase):
         dev.name = 'dev'
         self.prev_device = dml.globals.device
         dml.globals.device = dev
+        dml.globals.serialized_traits = serialize.SerializedTraits()
         self.dev = dev
 
     def tearDown(self):

--- a/py/dml/types.py
+++ b/py/dml/types.py
@@ -11,6 +11,7 @@ __all__ = (
     'realtype',
     'safe_realtype_shallow',
     'safe_realtype',
+    'conv_const',
     'deep_const',
     'type_union',
     'compatible_types',

--- a/py/dml/types.py
+++ b/py/dml/types.py
@@ -18,6 +18,7 @@ __all__ = (
     'typedefs',
     'global_type_declaration_order',
     'global_anonymous_structs',
+    'add_late_global_struct_defs',
     'DMLType',
     'TVoid',
     'TUnknown',
@@ -898,8 +899,12 @@ class TExternStruct(StructType):
     def clone(self):
         return TExternStruct(self.members, self.id, self.typename, self.const)
 
+def add_late_global_struct_defs(decls):
+    TStruct.late_global_struct_defs.extend((site, t.resolve())
+                                           for (site, t) in decls)
+
 class TStruct(StructType):
-    __slots__ = ('label',)
+    __slots__ = ('label', 'anonymous',)
     # Anonymous struct types defined in global scope, but outside typedef
     # declarations, e.g. 'session struct { int x; } y;'.
     # These types can depend on typedefs, but typedefs cannot depend on them.
@@ -907,7 +912,8 @@ class TStruct(StructType):
     num_anon_structs = 0
     def __init__(self, members, label = None, const = False):
         assert members is None or members
-        if label is None:
+        self.anonymous = label is None
+        if self.anonymous:
             label = '_anon_struct_%d' % (TStruct.num_anon_structs,)
             TStruct.num_anon_structs += 1
         self.label = label

--- a/test/1.4/misc/T_dmllib.h
+++ b/test/1.4/misc/T_dmllib.h
@@ -192,13 +192,13 @@ void deserialize_simple_event_indices_tests(void) {
 }
 
 
-set_error_t stub_deserializer(attr_value_t *val, void *dest) {
-    ASSERT(SIM_attr_is_list(*val));
-    if (!(SIM_attr_list_size(*val) == 1
-          && SIM_attr_is_string(SIM_attr_list_item(*val, 0)))) {
+set_error_t stub_deserializer(attr_value_t val, void *dest) {
+    ASSERT(SIM_attr_is_list(val));
+    if (!(SIM_attr_list_size(val) == 1
+          && SIM_attr_is_string(SIM_attr_list_item(val, 0)))) {
         return Sim_Set_Illegal_Type;
     }
-    strncpy(dest, SIM_attr_string(SIM_attr_list_item(*val, 0)), 511);
+    strncpy(dest, SIM_attr_string(SIM_attr_list_item(val, 0)), 511);
     ((char *)dest)[511] = '\0';
     return Sim_Set_Ok;
 }
@@ -296,13 +296,13 @@ void deserialize_simple_event_domains_tests(void) {
     ht_delete_str_table(&ht, false);
 }
 
-void stub_serializer(const void *src, attr_value_t *dst) {
+attr_value_t stub_serializer(const void *src) {
     if (!src) {
-        *dst = SIM_make_attr_nil();
+        return SIM_make_attr_nil();
     } else {
         char buf[512] = {0};
         strncpy(buf, src, 511);
-        *dst = SIM_make_attr_list(1, SIM_make_attr_string(buf));
+        return SIM_make_attr_list(1, SIM_make_attr_string(buf));
     }
 }
 


### PR DESCRIPTION
This PR breaks out a couple of miscellaneous (non after-on-hook related) changes in #144 that were done in order to support the after-on-hook changes, in order to help them get approved faster, as they are also relevant for the work on RAII types.

Some of the changes have been tweaked compared to how they appear in #144. In particular, `deserialize_list_to_targets` no longer has the `pre` and `post` parameters, and its `error_out` parameter has become `error_out_at_index`, which also accepts the index of the target at which it is called. This will be relevant for the work on RAII types.