### PR TITLE
Add porting rule for converting int1 to uint1

### DIFF
--- a/RELEASENOTES-1.2.docu
+++ b/RELEASENOTES-1.2.docu
@@ -157,4 +157,7 @@
   <build-id value="6160"><add-note> Fixed issue where certain parameters defined
       in DML 1.4 modules couldn't be referenced within DML 1.2 modules without
       the use of <tt>$</tt>.</add-note></build-id>
+  <build-id value="next"><add-note> Add porting rule to convert the
+      <tt>int1</tt> type into <tt>uint1</tt> in DML 1.4, which better resembles
+      how the type works in 1.2.</add-note></build-id>
 </rn>

--- a/py/dml/dmlparse.py
+++ b/py/dml/dmlparse.py
@@ -1205,13 +1205,24 @@ def cdecl_const(t):
     info = [t[2], 'const'] + t[3][:-1]
     t[0] = ast.cdecl(site(t), name, info)
 
-@prod
+@prod_dml14
 def basetype(t):
     '''basetype : typeident
                 | struct
                 | layout
                 | bitfields
                 | typeof'''
+    t[0] = t[1]
+
+@prod_dml12
+def basetype(t):
+    '''basetype : typeident
+                | struct
+                | layout
+                | bitfields
+                | typeof'''
+    if logging.show_porting and t[1] == 'int1':
+        report(PINT1(site(t)))
     t[0] = t[1]
 
 @prod_dml14

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -2223,3 +2223,12 @@ class PUNDEFOFFS(PortingMessage):
     should be used instead.
     """
     fmt = "Use 'unmapped_offset' instead of 'undefined'"
+
+class PINT1(PortingMessage):
+    """Integer types have different semantics in DML 1.2 and DML 1.4;
+    the `int1` type in DML 1.2 is converted to `uint1` in DML 1.4
+    because that is a better match for some common operations. In
+    particular, if the value 1 is assigned to variables of these
+    types, then the value of the variable becomes 1, whereas for
+    `int1` in DML 1.4 the value is -1."""
+    fmt = "Change int1 to uint1"

--- a/py/port_dml.py
+++ b/py/port_dml.py
@@ -960,6 +960,7 @@ tags = {
     'PNO_WUNUSED': PNO_WUNUSED,
     'PRENAME_TEMPLATE': Replace,
     'PUNDEFOFFS': replace_const('undefined', 'unmapped_offset'),
+    'PINT1': replace_const('int1', 'uint1'),
 }
 
 def is_device_file(path):

--- a/spelling-passlist
+++ b/spelling-passlist
@@ -13,6 +13,7 @@ PATTRIBUTE      *
 PEVENT          *
 PVERSION        *
 PINVOKE         *
+PINT            *
 POVERRIDE       *
 PABSTRACT       *
 PCHANGE         *

--- a/test/1.2/misc/porting.dml
+++ b/test/1.2/misc/porting.dml
@@ -382,6 +382,8 @@ event ev2 is (evt) {
 }
 
 method init() {
+    local int1 i1;
+
     inline $c2.x(0);
     call $p();
     call $m();

--- a/test/1.4/misc/porting.dml
+++ b/test/1.4/misc/porting.dml
@@ -416,6 +416,8 @@ event ev2 is (custom_time_event, evt) {
 }
 
 method init() {
+    local uint1 i1;
+
     c2.x(0);
     p();
     m();

--- a/test/tests.py
+++ b/test/tests.py
@@ -1390,6 +1390,7 @@ all_tests.append(PortingConvert(
         'PNO_WUNUSED',
         'PRENAME_TEMPLATE',
         'PUNDEFOFFS',
+        'PINT1',
     ]]
     + [('dml-builtins.dml', None, 'PRETURNARGS'),
        ('porting-import.dml', None, 'PSHA1',),


### PR DESCRIPTION
Some users reported that after `int1 x = 1`, the expression `x == 1`
evaluates to `true` in 1.2 and `false` in 1.4; grepping around, this
pattern is fairly common; thus, the uint1 type seems to match better
what int1 means in practice in 1.2.
