### PR TITLE
Warn about bad pointer-to-pointer casts -- SIMICS-20863

### DIFF
--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -4132,11 +4132,32 @@ def mkCast(site, expr, new_type):
         assert (not (real.is_int and real.is_endian)
                 and not (old_type.is_int and old_type.is_endian))
         return Cast(site, expr, new_type)
-    if ((isinstance(real, TPtr) or real.is_int or isinstance(real, TBool))
-        and (isinstance(old_type, (TPtr, TArray, TFunction))
-             or old_type.is_int or isinstance(old_type, TBool))):
+    if ((isinstance(real, (TBool, TPtr)) or real.is_int)
+        and (isinstance(old_type, (TBool, TPtr, TArray, TFunction))
+             or old_type.is_int)):
         assert (not (real.is_int and real.is_endian)
                 and not (old_type.is_int and old_type.is_endian))
+        if isinstance(old_type, (TPtr, TArray)) and isinstance(real, TPtr):
+            old_base = old_type.base
+            new_base = real.base
+            old_base_deep = old_base
+            while isinstance(old_base_deep, TArray):
+                old_base_deep = old_base_deep.base
+
+            if (not dml.globals.compat_dml12_int(site)
+                and isinstance(old_base_deep, (TLayout, TEndianInt))
+                and new_base.is_int and not new_base.is_endian
+                and not new_base.bits == 8
+                and not (old_base_deep.is_int and old_base_deep.bits == 8)):
+                byte_order = (old_base_deep.byte_order
+                              if old_base_deep.is_int
+                              else old_base_deep.endian)
+                likely_intended = TEndianInt(new_base.bits,
+                                             new_base.signed,
+                                             byte_order,
+                                             const=new_base.const)
+                report(WPCAST(site, old_base, new_base, likely_intended))
+
         return Cast(site, expr, new_type)
 
     # Allow unsafe casts from method references to function pointers in DML 1.2

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1799,6 +1799,29 @@ class WTTYPEC(DMLWarning):
     fmt = ("the time value of type '%s' is implicitly converted "
            + "to the type '%s' expected by the specified time unit '%s'.")
 
+class WPCAST(DMLWarning):
+    """
+    A pointer is cast to a base type which has incompatible representation
+    compared to the original. Accessing the pointed-to object via the new
+    pointer type will almost certainly constitute undefined behavior.
+
+    This warning is extremely limited in scope: don't rely on it to catch every
+    bad pointer cast.
+
+    To silence this warning, first cast the pointer to `void *`, then cast it
+    to the desired type.
+    """
+    fmt = ("very suspect pointer-to-pointer cast: the new base type has "
+           + "incompatible representation. This could lead to your code "
+           + "getting mangled by the C compiler, with unpredictable results.\n"
+           + "old base type: %s\n"
+           + "new base type: %s%s")
+    def __init__(self, site, old, new, maybe_intended):
+        suggestion = ('\nperhaps you meant the new base type to be '
+                      + maybe_intended.describe()
+                      if maybe_intended else '')
+        DMLWarning.__init__(self, site, old, new, suggestion)
+
 # TODO this should exist once pragmas are officially supported
 # class WPRAGMA(DMLWarning):
 #     """

--- a/test/1.4/errors/T_WPCAST.dml
+++ b/test/1.4/errors/T_WPCAST.dml
@@ -1,0 +1,107 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+/// COMPILE-ONLY
+
+typedef layout "little-endian" {
+    uint32 x;
+} layout_a_t;
+
+typedef layout "little-endian" {
+    uint8 x;
+    uint24 y;
+} layout_b_t;
+
+method init() {
+    local void *p;
+    local layout_a_t l;
+    /// WARNING WPCAST
+    p = cast(&l, uint32 *);
+    /// WARNING WPCAST
+    p = cast(&l, int32 *);
+    /// WARNING WPCAST
+    p = cast(&l, uint16 *);
+    /// WARNING WPCAST
+    p = cast(&l, int16 *);
+
+    // no warning
+    p = cast(cast(&l, void *), int16 *);
+    p = cast(&l, uint8 *);
+    p = cast(&l, int8 *);
+    p = cast(&l, uint32_le_t *);
+    p = cast(&l, int32_le_t *);
+    p = cast(&l, uint32_be_t *);
+    p = cast(&l, uint8_le_t *);
+    p = cast(&l, layout_b_t *);
+
+    local uint32_le_t i;
+    /// WARNING WPCAST
+    p = cast(&i, uint32 *);
+    /// WARNING WPCAST
+    p = cast(&i, int32 *);
+    /// WARNING WPCAST
+    p = cast(&i, uint16 *);
+    /// WARNING WPCAST
+    p = cast(&i, int16 *);
+
+    // no warning
+    p = cast(cast(&i, void *), int16 *);
+    p = cast(&i, uint8 *);
+    p = cast(&i, int8 *);
+    p = cast(&i, uint32_le_t *);
+    p = cast(&i, int32_le_t *);
+    p = cast(&i, uint32_be_t *);
+    p = cast(&i, uint8_le_t *);
+    p = cast(&i, layout_b_t *);
+
+    local layout_a_t larr[2][3][5];
+    /// WARNING WPCAST
+    p = cast(larr, uint32 *);
+    /// WARNING WPCAST
+    p = cast(larr, int32 *);
+    /// WARNING WPCAST
+    p = cast(larr, uint16 *);
+    /// WARNING WPCAST
+    p = cast(larr, int16 *);
+
+    // no warning
+    p = cast(cast(larr, void *), int16 *);
+    p = cast(larr, uint8 *);
+    p = cast(larr, int8 *);
+    p = cast(larr, uint32_le_t *);
+    p = cast(larr, int32_le_t *);
+    p = cast(larr, uint32_be_t *);
+    p = cast(larr, uint8_le_t *);
+    p = cast(larr, layout_b_t *);
+
+    local uint32_le_t iarr[2][3][5];
+    /// WARNING WPCAST
+    p = cast(iarr, uint32 *);
+    /// WARNING WPCAST
+    p = cast(iarr, int32 *);
+    /// WARNING WPCAST
+    p = cast(iarr, uint16 *);
+    /// WARNING WPCAST
+    p = cast(iarr, int16 *);
+
+    // no warning
+    p = cast(cast(iarr, void *), int16 *);
+    p = cast(iarr, uint8 *);
+    p = cast(iarr, int8 *);
+    p = cast(iarr, uint32_le_t *);
+    p = cast(iarr, int32_le_t *);
+    p = cast(iarr, uint32_be_t *);
+    p = cast(iarr, uint8_le_t *);
+    p = cast(iarr, layout_b_t *);
+
+    local uint8_le_t bmatrix[2][4];
+    // no warning
+    p = cast(bmatrix, uint32 *);
+    p = cast(bmatrix[0], uint32 *);
+    p = cast(&bmatrix[0][0], uint32 *);
+}


### PR DESCRIPTION
Currently limited to only catch when pointers to layouts/endian integers are cast to pointers where the basetype is a non-endian integer.