### PR TITLE
Avoid old style command line options (SIMICS-20622)

### DIFF
--- a/test/1.2/events/T_after_chk_dup.py
+++ b/test/1.2/events/T_after_chk_dup.py
@@ -13,9 +13,8 @@ SIM_write_configuration_to_file(testname + ".chkp", Sim_Save_Nobundle)
 
 subprocess.check_call(
     [f'{conf.sim.project}/bin/simics{batch_suffix()}'] +
-    ["-batch-mode", "-quiet", "-no-copyright", "-core", "-werror",
-     '-py3k-warnings',
-     '-project', conf.sim.project,
-     "-L", scratchdir,
-     "-c", testname + ".chkp",
-     "-p", join(basedir, "T_"+testname+".cont.py")])
+    ["--batch-mode", "--quiet", "--no-copyright", "--dump-core", "--werror",
+     '--project', conf.sim.project,
+     "--module-path", scratchdir,
+     "-e", f'read-configuration {testname + ".chkp"}',
+     join(basedir, "T_"+testname+".cont.py")])

--- a/test/1.2/events/T_dup.py
+++ b/test/1.2/events/T_dup.py
@@ -13,9 +13,8 @@ SIM_write_configuration_to_file("dup.chkp", Sim_Save_Nobundle)
 
 subprocess.check_call(
     [f'{conf.sim.project}/bin/simics{batch_suffix()}'] +
-    ["-batch-mode", "-quiet", "-no-copyright", "-core", "-werror",
-     '-py3k-warnings',
-     '-project', conf.sim.project,
-     "-L", scratchdir,
-     "-c", "dup.chkp",
-     "-p", join(basedir, "T_dup.cont.py")])
+    ["--batch-mode", "--quiet", "--no-copyright", "--dump-core", "--werror",
+     '--project', conf.sim.project,
+     "--module-path", scratchdir,
+     "-e", "read-configuration dup.chkp",
+     join(basedir, "T_dup.cont.py")])

--- a/test/1.4/events/T_after_chk.py
+++ b/test/1.4/events/T_after_chk.py
@@ -13,9 +13,8 @@ SIM_write_configuration_to_file("after_chk.chkp", Sim_Save_Nobundle)
 
 subprocess.check_call(
     [f'{conf.sim.project}/bin/simics{batch_suffix()}'] +
-    ["-batch-mode", "-quiet", "-no-copyright", "-core", "-werror",
-     '-py3k-warnings',
-     '-project', conf.sim.project,
-     "-L", scratchdir,
-     "-c", "after_chk.chkp",
-     "-p", join(basedir, "T_after_chk.cont.py")])
+    ["--batch-mode", "--quiet", "--no-copyright", "--dump-core", "--werror",
+     '--project', conf.sim.project,
+     "--module-path", scratchdir,
+     "-e", "read-configuration after_chk.chkp",
+     join(basedir, "T_after_chk.cont.py")])

--- a/test/tests.py
+++ b/test/tests.py
@@ -748,11 +748,10 @@ class CTestCase(DMLFileTestCase):
 
         self.pr("Running Simics")
         args = [join(simics_root_path(), "bin", "simics" + bat_sfx),
-                "-batch-mode", "-quiet", "-no-copyright", "-no-settings",
-                "-core", "-werror",
-                '-py3k-warnings',
-                "-project", testparams.project_path(),
-                "-p", self.scriptname]
+                "--batch-mode", "--quiet", "--no-copyright", "--no-settings",
+                "--dump-core", "--werror",
+                "--project", testparams.project_path(),
+                self.scriptname]
         env = os.environ.copy()
         env.update(self.extraenv)
         env['SIMICS_HOST'] = os.path.basename(host_path())
@@ -1448,10 +1447,10 @@ class CompareIllegalAttrs(BaseTestCase):
         sl = {x[5:].strip()
               for x in subprocess.run(
                       [join(simics_root_path(), "bin", "simics" + bat_sfx),
-                       "-batch-mode", "-quiet", "-no-copyright", "-no-settings",
-                       "-core", "-werror",
-                       "-L", join(testparams.sandbox_path(), "scratch",
-                                  "minimal"),
+                       "--batch-mode", "--quiet", "--no-copyright",
+                       "--no-settings", "--dump-core", "--werror",
+                       "--module-path", join(testparams.sandbox_path(),
+                                             "scratch", "minimal"),
                        "-e", "@SIM_create_object('test', 'o', [])",
                        "-e", "@for n in conf.o.attributes: print('ATTR', end=' '), print(n[0])"],
                       capture_output=True,


### PR DESCRIPTION
The new ones were introduced in 6 and old ones are removed or
deprecated in 7.
