### PR TITLE
Support function_mapped_bank on banks with use_io_memory=false

### DIFF
--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1226,12 +1226,34 @@ template function_io_memory {
 
     method operation(generic_transaction_t *mem_op,
                      map_info_t map_info) -> (exception_type_t) {
+        local uint64 offset = map_info.start - map_info.base;
         foreach b in (each function_mapped_bank in (dev)) {
             if (b.function == map_info.function) {
-                if (b.io_memory_access(mem_op,
-                                       (SIM_get_mem_op_physical_address(mem_op)
-                                        - map_info.base + map_info.start),
-                                       NULL)) {
+                if (!b.use_io_memory) {
+                    local map_target_t *mt = SIM_new_map_target(b._bank_obj(),
+                                                                 NULL, NULL);
+                    if (!mt) {
+                        local exception_type_t _exc = SIM_clear_exception();
+                        log error: "failed to create map target for %s: %s",
+                            SIM_object_name(b._bank_obj()), SIM_last_error();
+                        return Sim_PE_IO_Not_Taken;
+                    }
+                    // hack: VT_map_target_access doesn't accept a map_info
+                    // (even though the underlying implementation does).
+                    // Work around by temporarily patching the memop.
+                    local uint64 before = SIM_get_mem_op_physical_address(
+                        mem_op);
+                    SIM_set_mem_op_physical_address(mem_op, before + offset);
+                    local exception_type_t ret
+                        = VT_map_target_access(mt, mem_op);
+                    SIM_set_mem_op_physical_address(mem_op, before);
+                    SIM_free_map_target(mt);
+                    return ret;
+                }
+                if (b.io_memory_access(
+                        mem_op,
+                        SIM_get_mem_op_physical_address(mem_op) + offset,
+                        NULL)) {
                     return Sim_PE_No_Exception;
                 } else {
                     return Sim_PE_IO_Not_Taken;

--- a/test/1.4/lib/T_io_memory.dml
+++ b/test/1.4/lib/T_io_memory.dml
@@ -101,3 +101,14 @@ bank e {
             throw;
     }
 }
+
+bank f {
+    is function_mapped_bank;
+    param function = 0xf;
+    param use_io_memory = false;
+    method read(uint64 address, uint64 enabled_bytes, void *user)
+        -> (uint64) throws {
+        assert address == 0x100;
+        return 0xff;
+    }
+}

--- a/test/1.4/lib/T_io_memory.py
+++ b/test/1.4/lib/T_io_memory.py
@@ -13,6 +13,10 @@ stest.expect_equal(dev_util.Register_LE((obj, 0x10, 0), size=1).read(), 0x0)
 stest.expect_equal(dev_util.Register_LE((obj, 0x11, 0), size=1).read(), 0x1)
 stest.expect_equal(dev_util.Register_LE((obj, 0x12, 0), size=1).read(), 0x10)
 stest.expect_equal(dev_util.Register_LE((obj, 0x13, 0), size=1).read(), 0x11)
+stest.expect_equal(dev_util.Register_LE((obj, 0xf, 0x100), size=1).read(), 0xff)
+# accessing 0x10 hits address 0x100 in the bank
+ms = SIM_create_object('memory-space', 'ms', map=[[0x10, obj, 0xf, 0x100, 1]])
+ms.iface.memory_space.read(None, 0x10, 1, False)
 # .. and incorrect function numbers are handled somewhat gracefully
 with stest.expect_log_mgr(obj, 'error'), stest.expect_exception_mgr(
         dev_util.MemoryError):


### PR DESCRIPTION
The old PCI framework (pci-bus) depends on function_mapped_bank when
mapping pci_config, and it is natural for devices to transition to
transaction interface as an intermediate step before moving to the new
PCIe framework. Furthermore, the default of use_io_memory changes to
false in Simics 7.
