### PR TITLE
Don't rely on use_io_memory default

### DIFF
--- a/RELEASENOTES-1.2.docu
+++ b/RELEASENOTES-1.2.docu
@@ -163,4 +163,9 @@
   <build-id value="6215"><add-note> Improve porting rules for method
       return values: In some simple cases, avoid storing the method's
       return value in an intermediate local variable.</add-note></build-id>
+  <build-id value="next"><add-note> If a bank declared with
+      <tt>use_io_memory=false</tt> in a DML 1.4 file is imported from
+      a DML 1.2 device, then the device will now honor overrides of
+      the <tt>transaction_access</tt> method. This simplifies future
+      transition to the Simics 7 API.</add-note></build-id>
 </rn>

--- a/RELEASENOTES-1.2.docu
+++ b/RELEASENOTES-1.2.docu
@@ -165,7 +165,11 @@
       return value in an intermediate local variable.</add-note></build-id>
   <build-id value="next"><add-note> If a bank declared with
       <tt>use_io_memory=false</tt> in a DML 1.4 file is imported from
-      a DML 1.2 device, then the device will now honor overrides of
-      the <tt>transaction_access</tt> method. This simplifies future
-      transition to the Simics 7 API.</add-note></build-id>
+      a DML 1.2 device, using the `dml12-compatibility.dml` library,
+      then a call to the <tt>transaction_access</tt> method will now
+      trigger a proper bank access. Also, if a bank uses the
+      `adml12_compat_io_memory_access` template, then overrides of
+      the <tt>transaction_access</tt> method will be honored. This
+      simplifies future transition to the Simics 7
+      API.</add-note></build-id>
 </rn>

--- a/RELEASENOTES-1.2.docu
+++ b/RELEASENOTES-1.2.docu
@@ -168,7 +168,7 @@
       a DML 1.2 device, using the `dml12-compatibility.dml` library,
       then a call to the <tt>transaction_access</tt> method will now
       trigger a proper bank access. Also, if a bank uses the
-      `adml12_compat_io_memory_access` template, then overrides of
+      <tt>dml12_compat_io_memory_access</tt> template, then overrides of
       the <tt>transaction_access</tt> method will be honored. This
       simplifies future transition to the Simics 7
       API.</add-note></build-id>

--- a/lib/1.2/dml12-compatibility.dml
+++ b/lib/1.2/dml12-compatibility.dml
@@ -68,10 +68,9 @@ template write_only_attr is pseudo_attr {
 // this template can be instantiated to make the override effective when
 // imported from a DML 1.2 device.
 template dml12_compat_io_memory_access is bank {
-    param _have_dml12_compat_io_memory_access = true;
-    method access(generic_transaction_t *mop, physical_address_t offset,
+    method access(generic_transaction_t *memop, physical_address_t offset,
                   physical_address_t size) throws {
-        if (!this.io_memory_access(mop, offset, NULL))
+        if (!this.io_memory_access(memop, offset, NULL))
             throw;
     }
 }
@@ -118,15 +117,8 @@ template dml12_compat_access_override {
             // still need to chain the transaction, to ensure
             // transaction_access will get the memop back untouched
             // through ATOM_get_transaction_memop
-            list = {
-                ATOM_memop(memop),
-                ATOM_list_end(0),
-                ATOM_list_end(0),
-                ATOM_list_end(0),
-                ATOM_list_end(0),
-                ATOM_list_end(0),
-                ATOM_list_end(0),
-            };
+            list[0] = ATOM_memop(memop);
+            list[1] = ATOM_list_end(0);
         }
         local transaction_t t = {
             .atoms = list, .prev = memop->transaction, ... };
@@ -145,6 +137,11 @@ template dml12_compat_access_override {
         local generic_transaction_t mop;
         local bool is_read = SIM_transaction_is_read(t);
         local uint64 size = SIM_transaction_size(t);
+        if (size > 8) {
+            log error: "Oversized access to %s", name;
+            return Sim_PE_IO_Not_Taken;
+        }
+
         local uint8 buf[size];
         local bool wrap = memop == NULL;
         if (wrap) {
@@ -163,10 +160,6 @@ template dml12_compat_access_override {
             memop = &mop;
         }
 
-        if (size > 8) {
-            log error: "Oversized access to %s", name;
-            return Sim_PE_IO_Not_Taken;
-        }
         try {
             if (is_read) {
                 this.read_access_memop(memop, offset, size);

--- a/lib/1.2/dml12-compatibility.dml
+++ b/lib/1.2/dml12-compatibility.dml
@@ -75,10 +75,19 @@ template dml12_compat_io_memory_access is bank {
     }
 }
 
-template dml12_compat_access_override {
-    // 'in each':ed in all banks to permit calls to the otherwise DML
-    // 1.4-specific functions io_memory_access and transaction_access.
-    // Can be instantiated explicitly to avoid rank ambiguities.
+in each bank {
+    // Permit calls to the otherwise DML 1.4-specific functions
+    // io_memory_access and transaction_access. Note how the API differs
+    // between 1.2 and 1.4: In 1.4 only one of these methods is valid, while in
+    // 1.2 they are chained. This is because 1.4 supports the transaction
+    // interface, and thus can honour the use_io_memory parameter; in 1.2, the
+    // bank ignores use_io_memory and always implements io_memory. To make this
+    // work with overrides from DML 1.4, io_memory_access actually calls
+    // transaction_access which in turn calls
+    // read_access_memop/write_access_memop. We rely on some undocumented
+    // features, like memop->transaction, to ensure the memop instance
+    // (potentially including PCI metadata etc) is retained over the
+    // transaction-based indirection.
     method io_memory_access(generic_transaction_t *memop, uint64 offset,
                             void *aux) -> (bool) default {
         log info, 4: "entering compatibility wrapper"
@@ -178,8 +187,6 @@ template dml12_compat_access_override {
         }
     }
 }
-
-in each bank { is dml12_compat_access_override; }
 
 template read_field {
     // Imitate the default behaviour of field.read_access()

--- a/lib/1.2/dml12-compatibility.dml
+++ b/lib/1.2/dml12-compatibility.dml
@@ -63,39 +63,130 @@ template write_only_attr is pseudo_attr {
     param readable = false;
 }
 
-// If a bank in a DML 1.4 file overrides io_memory_access, then
+// If a bank in a DML 1.4 file overrides io_memory_access
+// or transaction_access, then
 // this template can be instantiated to make the override effective when
 // imported from a DML 1.2 device.
 template dml12_compat_io_memory_access is bank {
-    method access(generic_transaction_t *memop, physical_address_t offset,
+    param _have_dml12_compat_io_memory_access = true;
+    method access(generic_transaction_t *mop, physical_address_t offset,
                   physical_address_t size) throws {
-        if (!this.io_memory_access(memop, offset, NULL))
+        if (!this.io_memory_access(mop, offset, NULL))
             throw;
     }
 }
 
-in each bank {
+template dml12_compat_access_override {
+    // 'in each':ed in all banks to permit calls to the otherwise DML
+    // 1.4-specific functions io_memory_access and transaction_access.
+    // Can be instantiated explicitly to avoid rank ambiguities.
     method io_memory_access(generic_transaction_t *memop, uint64 offset,
                             void *aux) -> (bool) default {
-        local uint64 size = SIM_get_mem_op_size(memop);
+        log info, 4: "entering compatibility wrapper"
+            + " for io_memory_access overrides";
+        local atom_t list[7];
+        if (memop->transaction == NULL) {
+            log info, 4: "io_memory_access: wrapping memop in transaction";
+            local mem_op_type_t type = memop->type;
+
+            local transaction_flags_t flags = 0
+                | ((type & Sim_Trn_Instr) == 0 ? 0 : Sim_Transaction_Fetch)
+                | ((type & Sim_Trn_Write) == 0 ? 0 : Sim_Transaction_Write)
+                | ((type & Sim_Trn_Control) == 0 ? 0
+                   : Sim_Transaction_Control)
+                | (memop->inquiry ? Sim_Transaction_Inquiry : 0)
+                | (memop->atomic ? Sim_Transaction_Atomic : 0)
+                | (memop->non_coherent ? Sim_Transaction_Incoherent : 0);
+
+            list = {
+                ATOM_completion(NULL),
+                ATOM_flags(flags),
+                ATOM_size(memop->size),
+                ATOM_data(memop->real_address),
+                ATOM_initiator(memop->ini_ptr),
+                ATOM_memop(memop),
+                ATOM_list_end(0),
+            };
+
+            if (memop->inverse_endian) {
+                // reverse endian is hard to fully translate outside core,
+                // but this should not be a problem in practice
+                log unimpl: "transaction support for inverse endian memops";
+            }
+        } else {
+            log info, 4: "Reusing memop's existing transaction";
+            // still need to chain the transaction, to ensure
+            // transaction_access will get the memop back untouched
+            // through ATOM_get_transaction_memop
+            list = {
+                ATOM_memop(memop),
+                ATOM_list_end(0),
+                ATOM_list_end(0),
+                ATOM_list_end(0),
+                ATOM_list_end(0),
+                ATOM_list_end(0),
+                ATOM_list_end(0),
+            };
+        }
+        local transaction_t t = {
+            .atoms = list, .prev = memop->transaction, ... };
+        memop->transaction = &t;
+        local bool ret = this.transaction_access(&t, offset, NULL)
+            == Sim_PE_No_Exception;
+        memop->transaction = t.prev;
+        return ret;
+    }
+
+    method transaction_access(transaction_t *t, uint64 offset,
+                              void *aux) -> (exception_type_t) default {
+        log info, 4: "entering compatibility wrapper"
+            + " for transaction_access overrides";
+        local generic_transaction_t *memop = ATOM_get_transaction_memop(t);
+        local generic_transaction_t mop;
+        local bool is_read = SIM_transaction_is_read(t);
+        local uint64 size = SIM_transaction_size(t);
+        local uint8 buf[size];
+        local bool wrap = memop == NULL;
+        if (wrap) {
+            log info, 4: "transaction_access: wrapping transaction in memop";
+            local bool inquiry = SIM_transaction_is_inquiry(t);
+            local conf_object_t *initiator = SIM_transaction_initiator(t);
+            if (is_read) {
+                mop = SIM_make_mem_op_read(
+                    offset, {.data=buf, .len=size}, inquiry, initiator);
+            } else {
+                SIM_get_transaction_bytes(t, {.data=buf, .len=size});
+                mop = SIM_make_mem_op_write(
+                    offset, {.data=buf, .len=size}, inquiry, initiator);
+            }
+            mop.transaction = t;
+            memop = &mop;
+        }
+
         if (size > 8) {
             log error: "Oversized access to %s", name;
-            return false;
+            return Sim_PE_IO_Not_Taken;
         }
         try {
-            if (SIM_mem_op_is_read(memop)) {
+            if (is_read) {
                 this.read_access_memop(memop, offset, size);
+                if (wrap) {
+                    SIM_set_transaction_bytes(
+                        t, {.data=memop->real_address, .len=size});
+                }
             } else {
                 local uint64 writeval;
                 writeval = this.get_write_value(memop);
                 this.write_access_memop(memop, offset, size, writeval);
             }
-            return true;
+            return Sim_PE_No_Exception;
         } catch {
-            return false;
+            return Sim_PE_IO_Not_Taken;
         }
     }
 }
+
+in each bank { is dml12_compat_access_override; }
 
 template read_field {
     // Imitate the default behaviour of field.read_access()

--- a/lib/1.4/dml12-compatibility.dml
+++ b/lib/1.4/dml12-compatibility.dml
@@ -8,7 +8,6 @@ dml 1.4;
 // NOOP if device is 1.4
 
 template dml12_compat_io_memory_access { }
-template dml12_compat_access_override { }
 template dml12_compat_read_register { }
 template dml12_compat_write_register { }
 template dml12_compat_read_field { }

--- a/lib/1.4/dml12-compatibility.dml
+++ b/lib/1.4/dml12-compatibility.dml
@@ -8,6 +8,7 @@ dml 1.4;
 // NOOP if device is 1.4
 
 template dml12_compat_io_memory_access { }
+template dml12_compat_access_override { }
 template dml12_compat_read_register { }
 template dml12_compat_write_register { }
 template dml12_compat_read_field { }

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -2748,6 +2748,7 @@ def port_builtin_method_overrides(name, site, inp_ast, parent_obj):
     trampolines = {
         'bank': {
             'access': ('''\
+param use_io_memory = true;
 method io_memory_access(generic_transaction_t *memop, uint64 offset, void *aux) -> (bool) {
     // TODO: further conversion likely needed; probably move
     // old_access implementation into this method
@@ -2836,6 +2837,7 @@ method read_access(generic_transaction_t *memop, physical_address_t offset,
     }
 }'''),
             'read_access_memop': ('''\
+param use_io_memory = true;
 method io_memory_access(generic_transaction_t *memop, uint64 offset, void *aux) -> (bool) {
     // TODO: further conversion likely needed; probably move
     // old_read_access_memop implementation into this method
@@ -2864,6 +2866,7 @@ method write_access(generic_transaction_t *memop, physical_address_t offset,
     }
 }'''),
             'write_access_memop': ('''\
+param use_io_memory = true;
 method io_memory_access(generic_transaction_t *memop, uint64 offset, void *aux) -> (bool) {
     // TODO: further conversion likely needed; probably move
     // old_write_access_memop implementation into this method

--- a/test/1.2/misc/T_import_dml14.dml
+++ b/test/1.2/misc/T_import_dml14.dml
@@ -158,6 +158,9 @@ method test() -> (bool ok) {
     call $pseudo_attr_test();
     call $field_regs.test();
     call $io_memory_access_bank.test();
+    call $transaction_access_bank_compat.test();
+    call $io_memory_access_bank.test();
+    call $transaction_access_bank_compat.test();
     local conf_object_t *bo;
     call $test_bank_obj_get();
     call $len_test();

--- a/test/1.2/misc/T_utility_14_api.py
+++ b/test/1.2/misc/T_utility_14_api.py
@@ -21,7 +21,7 @@ import contextlib
  undocumented0,
  undocumented1,
 ] = [
-    dev_util.Register_LE((obj, 'b', offs), size=4)
+    dev_util.Register_LE(obj.bank.b, offs, size=4)
     for offs in [4, 8, 12, 16, 52, 56, 60, 64, 68, 72, 76, 80, 84, 88]]
 
 # TODO: Currently DML 1.2 logs on bank objects and DML 1.4 logs on conf_objects
@@ -159,7 +159,7 @@ stest.expect_equal(obj.b_fields0, 0xf)
 
 # In 1.4, write_1_clears supports partial access, but not in 1.2
 [write_1_clears, clear_on_read, write_1_only, write_0_only] = [
-     dev_util.Register_LE((obj, 'b', offs), size=4)
+     dev_util.Register_LE(obj.bank.b, offs, size=4)
      for offs in [20, 24, 28, 32]]
 
 obj.b_write_1_clears = 0x12345678
@@ -205,7 +205,7 @@ stest.expect_equal(fields1.read(), 0x55)
 # clear_on_read field cleared!
 stest.expect_equal(fields1.read(), 0x51)
 
-write_only = dev_util.Register_LE((obj, 'b', 100), size=4)
+write_only = dev_util.Register_LE(obj.bank.b, 100, size=4)
 write_only.write(0xdeadbeef)
 stest.expect_equal(obj.b_write_only, 0xdeadbeef)
 

--- a/test/1.2/misc/dml14.dml
+++ b/test/1.2/misc/dml14.dml
@@ -145,7 +145,6 @@ bank regs {
 }
 
 bank field_regs {
-    param use_io_memory = true;
     param partial = true;
     register r4 size 4 @ 16 is (read_field) {
         is dml12_compat_read_field;
@@ -226,23 +225,147 @@ bank field_regs {
     }
 }
 
-bank io_memory_access_bank {
+template io_memory_access_bank is bank {
     param use_io_memory = true;
+    #if (dml_1_2) {
+        method miss_access(generic_transaction_t *memop,
+                           physical_address_t offset,
+                           physical_address_t size) throws {
+            throw; // suppress spec-viol
+        }
+    }
     method io_memory_access(generic_transaction_t *memop, uint64 offset,
                             void *aux) -> (bool) {
-        SIM_set_mem_op_value_le(memop, 0xdeadbeef);
-        return true;
+        if (offset == 13) {
+            SIM_set_mem_op_value_le(memop, 0xdeadbeef);
+            return true;
+        } else {
+            return default(memop, offset, aux);
+        }
     }
-    method test() {
-        local uint32 value;
+    register r size 4 @ 4 { param init_val = 0xc0ffee; }
+    method test() default {
+        local uint32_le_t value;
         local buffer_t buf;
         buf.len = 4;
         buf.data = cast(&value, uint8 *);
         local generic_transaction_t read_memop = SIM_make_mem_op_read(
             0, buf, false, NULL);
-        io_memory_access(&read_memop, 13, NULL);
-        // assuming little-endian host
+        assert io_memory_access(&read_memop, 13, NULL);
         assert value == 0xdeadbeef;
+        assert io_memory_access(&read_memop, 4, NULL);
+        assert value == 0xc0ffee;
+        assert !io_memory_access(&read_memop, 3, NULL);
+    }
+}
+
+bank io_memory_access_bank is io_memory_access_bank;
+
+bank io_memory_access_bank_compat is (
+    io_memory_access_bank, dml12_compat_io_memory_access) {
+    method test() {
+        default();
+        local uint32_le_t value;
+        local buffer_t buf;
+        buf.len = 4;
+        buf.data = cast(&value, uint8 *);
+        local generic_transaction_t read_memop = SIM_make_mem_op_read(
+            4, buf, false, NULL);
+        local exception_type_t exc
+            = io_memory.operation(&read_memop, {.base=0, ...});
+        assert exc == Sim_PE_No_Exception;
+        assert value == 0xc0ffee;
+        SIM_set_mem_op_physical_address(&read_memop, 13);
+        exc = io_memory.operation(&read_memop, {.base=0, ...});
+        assert exc == Sim_PE_No_Exception;
+        assert value == 0xdeadbeef;
+        SIM_set_mem_op_physical_address(&read_memop, 3);
+        exc = io_memory.operation(&read_memop, {.base=0, ...});
+        assert exc == Sim_PE_IO_Not_Taken;
+    }
+}
+
+template transaction_access_bank is bank {
+    param use_io_memory = false;
+    #if (dml_1_2) {
+        method miss_access(generic_transaction_t *memop,
+                           physical_address_t offset,
+                           physical_address_t size) throws {
+            throw; // suppress spec-viol
+        }
+    }
+    method transaction_access(transaction_t *t, uint64 offset,
+                            void *aux) -> (exception_type_t) {
+        if (offset == 13) {
+            SIM_set_transaction_value_le(t, 0xdeadbeef);
+            return Sim_PE_No_Exception;
+        } else {
+            return default(t, offset, aux);
+        }
+    }
+    register r size 4 @ 4 { param init_val = 0xc0ffee; }
+    method test() default {
+        local uint8 val[4];
+        local atom_t atoms[3] = {
+            ATOM_data(val),
+            ATOM_size(4),
+            ATOM_list_end(0)
+        };
+        // the override is honored if sending a transaction to the bank.
+        local transaction_t t;
+        t.atoms = atoms;
+        assert transaction_access(&t, 13, NULL) == Sim_PE_No_Exception;
+        assert SIM_get_transaction_value_le(&t) == 0xdeadbeef;
+        assert transaction_access(&t, 4, NULL) == Sim_PE_No_Exception;
+        assert SIM_get_transaction_value_le(&t) == r.init_val;
+        assert transaction_access(&t, 3, NULL) == Sim_PE_IO_Not_Taken;
+    }
+}
+
+bank transaction_access_bank is transaction_access_bank;
+bank transaction_access_bank_compat is (
+    transaction_access_bank, dml12_compat_io_memory_access)  {
+    method test() {
+        default();
+        local uint8 val[4];
+        local atom_t atoms[3] = {
+            ATOM_data(val),
+            ATOM_size(4),
+            ATOM_list_end(0)
+        };
+        local transaction_t t;
+        t.atoms = atoms;
+        local map_target_t *map_target = SIM_new_map_target(
+            SIM_object_descendant(
+                dev.obj, "bank.transaction_access_bank_compat"),
+            NULL, NULL);
+        assert SIM_issue_transaction(map_target, &t, 13) == Sim_PE_No_Exception;
+        assert SIM_get_transaction_value_le(&t) == 0xdeadbeef;
+        assert SIM_issue_transaction(map_target, &t, 4) == Sim_PE_No_Exception;
+        assert SIM_get_transaction_value_le(&t) == r.init_val;
+        assert SIM_issue_transaction(map_target, &t, 3) == Sim_PE_IO_Not_Taken;
+        SIM_free_map_target(map_target);
+        #if (dml_1_2) {
+            // a DML 1.2 bank with use_io_memory=false still implements
+            // io_memory
+            local uint32_le_t value;
+            local buffer_t buf;
+            buf.len = 4;
+            buf.data = cast(&value, uint8 *);
+            local generic_transaction_t read_memop = SIM_make_mem_op_read(
+                4, buf, false, NULL);
+            local exception_type_t exc
+                = io_memory.operation(&read_memop, {.base=0, ...});
+            assert exc == Sim_PE_No_Exception;
+            assert value == 0xc0ffee;
+            SIM_set_mem_op_physical_address(&read_memop, 13);
+            exc = io_memory.operation(&read_memop, {.base=0, ...});
+            assert exc == Sim_PE_No_Exception;
+            assert value == 0xdeadbeef;
+            SIM_set_mem_op_physical_address(&read_memop, 3);
+            exc = io_memory.operation(&read_memop, {.base=0, ...});
+            assert exc == Sim_PE_IO_Not_Taken;
+        }
     }
 }
 
@@ -276,7 +399,6 @@ template function_shared is function_mapped_bank {
 }
 
 bank testbank is (miss_pattern_bank, function_mapped_bank) {
-    param use_io_memory = true;
     param function = 14;
     param overlapping = true;
     param miss_pattern = 0xee;

--- a/test/1.2/misc/dml14.dml
+++ b/test/1.2/misc/dml14.dml
@@ -145,6 +145,7 @@ bank regs {
 }
 
 bank field_regs {
+    param use_io_memory = true;
     param partial = true;
     register r4 size 4 @ 16 is (read_field) {
         is dml12_compat_read_field;
@@ -226,6 +227,7 @@ bank field_regs {
 }
 
 bank io_memory_access_bank {
+    param use_io_memory = true;
     method io_memory_access(generic_transaction_t *memop, uint64 offset,
                             void *aux) -> (bool) {
         SIM_set_mem_op_value_le(memop, 0xdeadbeef);
@@ -274,6 +276,7 @@ template function_shared is function_mapped_bank {
 }
 
 bank testbank is (miss_pattern_bank, function_mapped_bank) {
+    param use_io_memory = true;
     param function = 14;
     param overlapping = true;
     param miss_pattern = 0xee;

--- a/test/1.2/misc/dml14.dml
+++ b/test/1.2/misc/dml14.dml
@@ -192,9 +192,7 @@ bank field_regs {
 
     method test() {
         local uint16 value;
-        local buffer_t buf;
-        buf.len = 2;
-        buf.data = cast(&value, uint8 *);
+        local buffer_t buf = {.len=2, .data=cast(&value, uint8 *)};
         local generic_transaction_t read_memop = SIM_make_mem_op_read(
             0, buf, false, NULL);
         local generic_transaction_t write_memop = SIM_make_mem_op_write(
@@ -246,9 +244,7 @@ template io_memory_access_bank is bank {
     register r size 4 @ 4 { param init_val = 0xc0ffee; }
     method test() default {
         local uint32_le_t value;
-        local buffer_t buf;
-        buf.len = 4;
-        buf.data = cast(&value, uint8 *);
+        local buffer_t buf = {.len=4, .data=cast(&value, uint8 *)};
         local generic_transaction_t read_memop = SIM_make_mem_op_read(
             0, buf, false, NULL);
         assert io_memory_access(&read_memop, 13, NULL);
@@ -266,9 +262,7 @@ bank io_memory_access_bank_compat is (
     method test() {
         default();
         local uint32_le_t value;
-        local buffer_t buf;
-        buf.len = 4;
-        buf.data = cast(&value, uint8 *);
+        local buffer_t buf = {.len=4, .data=cast(&value, uint8 *)};
         local generic_transaction_t read_memop = SIM_make_mem_op_read(
             4, buf, false, NULL);
         local exception_type_t exc
@@ -349,9 +343,7 @@ bank transaction_access_bank_compat is (
             // a DML 1.2 bank with use_io_memory=false still implements
             // io_memory
             local uint32_le_t value;
-            local buffer_t buf;
-            buf.len = 4;
-            buf.data = cast(&value, uint8 *);
+            local buffer_t buf = {.len=4, .data=cast(&value, uint8 *)};
             local generic_transaction_t read_memop = SIM_make_mem_op_read(
                 4, buf, false, NULL);
             local exception_type_t exc
@@ -418,9 +410,7 @@ bank overridden_bank is (unified_hard_reset, unified_soft_reset);
 
 method memop_test() {
     local uint8 value;
-    local buffer_t buf;
-    buf.len = 1;
-    buf.data = &value;
+    local buffer_t buf = {.len=1, .data = &value};
     local generic_transaction_t memop = SIM_make_mem_op_read(
         0, buf, false, NULL);
     local map_info_t info;

--- a/test/1.2/registers/T_largearray.py
+++ b/test/1.2/registers/T_largearray.py
@@ -3,9 +3,9 @@
 
 import dev_util
 
-a = dev_util.Register_LE((obj, 'b',  50000))
-b = dev_util.Register_LE((obj, 'b', 90000))
-c = dev_util.Register_LE((obj, 'b', 150000))
+a = dev_util.Register_LE(obj.bank.b,  50000)
+b = dev_util.Register_LE(obj.bank.b, 90000)
+c = dev_util.Register_LE(obj.bank.b, 150000)
 
 a.read()
 b.read()

--- a/test/1.4/lib/T_io_memory.dml
+++ b/test/1.4/lib/T_io_memory.dml
@@ -22,6 +22,7 @@ port bare {
 }
 
 bank a {
+    param use_io_memory = true; // needed by the redirect from `bare`
     param mappable = false;
     method read(uint64 address, uint64 enabled_bytes, void *user)
         -> (uint64) throws {
@@ -54,9 +55,10 @@ bank d[i < 2][j < 2] {
 }
 
 bank e {
-    method io_memory_access(generic_transaction_t *memop, uint64 offset,
-                            void *aux) -> (bool) {
-        return default(memop, offset, cast(1234, void *));
+    param use_io_memory = false;
+    method transaction_access(transaction_t *t, uint64 offset,
+                              void *aux) -> (exception_type_t) {
+        return default(t, offset, cast(1234, void *));
     }
     method get(uint64 offset_, uint64 size_) -> (uint64) throws {
         saved uint64 offset;

--- a/test/1.4/lib/T_io_memory.py
+++ b/test/1.4/lib/T_io_memory.py
@@ -5,7 +5,7 @@ import stest
 import dev_util
 
 # bank_io_memory works
-stest.expect_equal(dev_util.Register_LE((obj, 'bare', 0), size=1).read(), 0xaa)
+stest.expect_equal(dev_util.Register_LE(obj.port.bare, 0, size=1).read(), 0xaa)
 # function_io_memory works ..
 stest.expect_equal(dev_util.Register_LE((obj, 0xb, 0), size=1).read(), 0xbb)
 stest.expect_equal(dev_util.Register_LE((obj, 0xc, 0), size=1).read(), 0xcc)

--- a/test/1.4/lib/T_miss_pattern.py
+++ b/test/1.4/lib/T_miss_pattern.py
@@ -10,35 +10,35 @@ mkR = dev_util.Register_LE
 def test_overlap():
     def mkRegs(b):
         return (
-            (mkR((obj, b, 0x00), size = 2),     0xFFFF),
-            (mkR((obj, b, 0x00), size = 4), 0x0203FFFF),
-            (mkR((obj, b, 0x02), size = 4), 0xFFFF0203),
-            (mkR((obj, b, 0x04), size = 4), 0x0607FFFF),
-            (mkR((obj, b, 0x06), size = 4), 0x08090607),
-            (mkR((obj, b, 0x08), size = 4), 0xFFFF0809),
-            (mkR((obj, b, 0x0a), size = 4), 0x0c0dFFFF),
-            (mkR((obj, b, 0x00), size = 8), 0x0607FFFF0203FFFF),
-            (mkR((obj, b, 0x08), size = 8), 0xFFFF0c0dFFFF0809),
-            (mkR((obj, b, 0x10), size = 2),     0xFFFF),
-            (mkR((obj, b, 0x10), size = 4), 0x1213FFFF),
-            (mkR((obj, b, 0x12), size = 4), 0xFFFF1213),
-            (mkR((obj, b, 0x14), size = 4), 0x1617FFFF),
-            (mkR((obj, b, 0x16), size = 4), 0x18191617),
-            (mkR((obj, b, 0x18), size = 4), 0xFFFF1819),
-            (mkR((obj, b, 0x1a), size = 4), 0x1c1dFFFF),
-            (mkR((obj, b, 0x10), size = 8), 0x1617FFFF1213FFFF),
-            (mkR((obj, b, 0x18), size = 8), 0xFFFF1c1dFFFF1819),
+            (mkR(b, 0x00, size=2),     0xFFFF),
+            (mkR(b, 0x00, size=4), 0x0203FFFF),
+            (mkR(b, 0x02, size=4), 0xFFFF0203),
+            (mkR(b, 0x04, size=4), 0x0607FFFF),
+            (mkR(b, 0x06, size=4), 0x08090607),
+            (mkR(b, 0x08, size=4), 0xFFFF0809),
+            (mkR(b, 0x0a, size=4), 0x0c0dFFFF),
+            (mkR(b, 0x00, size=8), 0x0607FFFF0203FFFF),
+            (mkR(b, 0x08, size=8), 0xFFFF0c0dFFFF0809),
+            (mkR(b, 0x10, size=2),     0xFFFF),
+            (mkR(b, 0x10, size=4), 0x1213FFFF),
+            (mkR(b, 0x12, size=4), 0xFFFF1213),
+            (mkR(b, 0x14, size=4), 0x1617FFFF),
+            (mkR(b, 0x16, size=4), 0x18191617),
+            (mkR(b, 0x18, size=4), 0xFFFF1819),
+            (mkR(b, 0x1a, size=4), 0x1c1dFFFF),
+            (mkR(b, 0x10, size=8), 0x1617FFFF1213FFFF),
+            (mkR(b, 0x18, size=8), 0xFFFF1c1dFFFF1819),
 
-            (mkR((obj, b, 0x20), size = 4), 0xFF2122FF),
-            (mkR((obj, b, 0x21), size = 4), 0xFFFF2122),
-            (mkR((obj, b, 0x20), size = 8), 0xFF2526FFFF2122FF),
-            (mkR((obj, b, 0x30), size = 4), 0xFF3132FF),
-            (mkR((obj, b, 0x31), size = 4), 0xFFFF3132),
-            (mkR((obj, b, 0x30), size = 8), 0xFF3536FFFF3132FF),
+            (mkR(b, 0x20, size=4), 0xFF2122FF),
+            (mkR(b, 0x21, size=4), 0xFFFF2122),
+            (mkR(b, 0x20, size=8), 0xFF2526FFFF2122FF),
+            (mkR(b, 0x30, size=4), 0xFF3132FF),
+            (mkR(b, 0x31, size=4), 0xFFFF3132),
+            (mkR(b, 0x30, size=8), 0xFF3536FFFF3132FF),
             )
 
-    for b in ('ob', 'pb'):
-        for r, val in mkRegs(b):
+    for b in [obj.bank.ob, obj.bank.pb]:
+        for (r, val) in mkRegs(b):
             expect_equal(r.read(), val)
 
 def expect_error():
@@ -51,12 +51,12 @@ def test_partial():
     # logic is simpler in 1.4, and much is covered elsewhere, so we
     # could probably remove most test cases.
 
-    r1 = mkR((obj, 'ob', 0x01), size = 2)
-    r2 = mkR((obj, 'ob', 0x02), size = 2)
-    r3 = mkR((obj, 'ob', 0x03), size = 2)
-    ru = mkR((obj, 'ob', 0x21), size = 2)
-    r4 = mkR((obj, 'ob', 0x20), size = 2)
-    r5 = mkR((obj, 'ob', 0x22), size = 2)
+    r1 = mkR(obj.bank.ob, 0x01, size=2)
+    r2 = mkR(obj.bank.ob, 0x02, size=2)
+    r3 = mkR(obj.bank.ob, 0x03, size=2)
+    ru = mkR(obj.bank.ob, 0x21, size=2)
+    r4 = mkR(obj.bank.ob, 0x20, size=2)
+    r5 = mkR(obj.bank.ob, 0x22, size=2)
     expect_equal(r1.read(), 0xffff)
     expect_equal(r3.read(), 0xffff)
     expect_equal(r4.read(), 0xffff)
@@ -70,12 +70,12 @@ def test_partial():
     r5.write(0xabcd)
     expect_equal(ru.read(), 0x2122)
 
-    r1 = mkR((obj, 'ob', 0x11), size = 2)
-    r2 = mkR((obj, 'ob', 0x12), size = 2)
-    r3 = mkR((obj, 'ob', 0x13), size = 2)
-    ru = mkR((obj, 'ob', 0x31), size = 2)
-    r4 = mkR((obj, 'ob', 0x30), size = 2)
-    r5 = mkR((obj, 'ob', 0x32), size = 2)
+    r1 = mkR(obj.bank.ob, 0x11, size=2)
+    r2 = mkR(obj.bank.ob, 0x12, size=2)
+    r3 = mkR(obj.bank.ob, 0x13, size=2)
+    ru = mkR(obj.bank.ob, 0x31, size=2)
+    r4 = mkR(obj.bank.ob, 0x30, size=2)
+    r5 = mkR(obj.bank.ob, 0x32, size=2)
     expect_equal(r1.read(), 0xffff)
     expect_equal(r3.read(), 0xffff)
     r1.write(0xabcd)
@@ -87,12 +87,12 @@ def test_partial():
     r5.write(0xabcd)
     expect_equal(ru.read(), 0x3132)
 
-    r1 = mkR((obj, 'pb', 0x01), size = 2)
-    r2 = mkR((obj, 'pb', 0x02), size = 2)
-    r3 = mkR((obj, 'pb', 0x03), size = 2)
-    ru = mkR((obj, 'pb', 0x21), size = 2)
-    r4 = mkR((obj, 'pb', 0x20), size = 2)
-    r5 = mkR((obj, 'pb', 0x22), size = 2)
+    r1 = mkR(obj.bank.pb, 0x01, size=2)
+    r2 = mkR(obj.bank.pb, 0x02, size=2)
+    r3 = mkR(obj.bank.pb, 0x03, size=2)
+    ru = mkR(obj.bank.pb, 0x21, size=2)
+    r4 = mkR(obj.bank.pb, 0x20, size=2)
+    r5 = mkR(obj.bank.pb, 0x22, size=2)
     expect_equal(r1.read(), 0x03FF)
     expect_equal(r3.read(), 0xFF02)
     r1.write(0xabcd)
@@ -104,12 +104,12 @@ def test_partial():
     r5.write(0xabcd)
     expect_equal(ru.read(), 0xcdab)
 
-    r1 = mkR((obj, 'pb', 0x11), size = 2)
-    r2 = mkR((obj, 'pb', 0x12), size = 2)
-    r3 = mkR((obj, 'pb', 0x13), size = 2)
-    ru = mkR((obj, 'pb', 0x31), size = 2)
-    r4 = mkR((obj, 'pb', 0x30), size = 2)
-    r5 = mkR((obj, 'pb', 0x32), size = 2)
+    r1 = mkR(obj.bank.pb, 0x11, size=2)
+    r2 = mkR(obj.bank.pb, 0x12, size=2)
+    r3 = mkR(obj.bank.pb, 0x13, size=2)
+    ru = mkR(obj.bank.pb, 0x31, size=2)
+    r4 = mkR(obj.bank.pb, 0x30, size=2)
+    r5 = mkR(obj.bank.pb, 0x32, size=2)
     expect_equal(r1.read(), 0x13FF)
     expect_equal(r3.read(), 0xFF12)
     r1.write(0xabcd)

--- a/test/1.4/lib/T_utility.py
+++ b/test/1.4/lib/T_utility.py
@@ -23,7 +23,7 @@ import contextlib
  read_constant,
  read_constant_field,
 ] = [
-    dev_util.Register_LE((obj, 'b', offs), size=4)
+    dev_util.Register_LE(obj.bank.b, offs, size=4)
     for offs in [4, 8, 12, 16, 52, 56, 60, 64, 68, 72, 76, 80, 84, 88,
                  92, 96]]
 
@@ -72,7 +72,7 @@ obj.b_read_only = 0xdeadbeef
 obj.log_level = 1
 stest.expect_equal(read_only.read(), 0xdeadbeef)
 # partial access, second byte of register
-read_only_1 = dev_util.Register_LE((obj, 'b', 17), size=1)
+read_only_1 = dev_util.Register_LE(obj.bank.b, 17, size=1)
 with LogCapture() as capture, stest.allow_log_mgr(obj, 'spec-viol'):
     read_only.write(0xdeadbeef)
     # remaining on log-level 2
@@ -113,7 +113,7 @@ with LogCapture() as capture, stest.allow_log_mgr(obj, 'spec-viol'):
 obj.log_level = 1
 
 fields0 = dev_util.Register_LE(
-    (obj, 'b', 0), size=1, bitfield=dev_util.Bitfield_LE({
+    obj.bank.b, 0, size=1, bitfield=dev_util.Bitfield_LE({
         'read_write': 0,
         'ignore_write': 1,
         'read_zero': 2,
@@ -159,7 +159,7 @@ obj.b_fields0 = 0xf
 stest.expect_equal(obj.b_fields0, 0xf)
 
 [write_1_clears, clear_on_read, write_1_only, write_0_only] = [
-     dev_util.Register_LE((obj, 'b', offs + 1), size=2)
+     dev_util.Register_LE(obj.bank.b, offs + 1, size=2)
      for offs in [20, 24, 28, 32]]
 
 obj.b_write_1_clears = 0x12345678
@@ -195,7 +195,7 @@ stest.expect_equal(read_constant.read(), 0x44)
 stest.expect_equal(read_constant_field.read(), 0x44)
 
 fields1 = dev_util.Register_LE(
-    (obj, 'b', 1), size=1, bitfield=dev_util.Bitfield_LE({
+    obj.bank.b, 1, size=1, bitfield=dev_util.Bitfield_LE({
         'write_0_only': (7, 6),
         'write_1_only': (5, 4),
         'clear_on_read': (3, 2),
@@ -214,7 +214,7 @@ stest.expect_equal(fields1.read(), 0x55)
 # clear_on_read field cleared!
 stest.expect_equal(fields1.read(), 0x51)
 
-write_only = dev_util.Register_LE((obj, 'b', 100), size=4)
+write_only = dev_util.Register_LE(obj.bank.b, 100, size=4)
 write_only.write(0xdeadbeef)
 stest.expect_equal(obj.b_write_only, 0xdeadbeef)
 
@@ -233,7 +233,7 @@ obj.log_level = 1
 
 # Access outside fields
 (fields3_0, fields3_2_0, fields3_2_1) = (dev_util.Register_LE(
-    (obj, 'b', offset), size=1, bitfield=dev_util.Bitfield_LE({
+    obj.bank.b, offset, size=1, bitfield=dev_util.Bitfield_LE({
         'f76': (7, 6), 'y': 5, 'f43': (4, 3), 'x': 2, 'f10': (1, 0)}))
                                      for offset in (3, 128, 129))
 with LogCapture() as capture, stest.allow_log_mgr(obj, 'spec-viol'):
@@ -266,10 +266,10 @@ with LogCapture() as capture, stest.allow_log_mgr(obj, 'spec-viol'):
              for (bits, val) in [("7:6", "10"), ("1:0", "01")]])])
 
 [unimpl, read_unimpl, write_unimpl, silent_unimpl] = [
-     dev_util.Register_LE((obj, 'b', offs), size=4)
+     dev_util.Register_LE(obj.bank.b, offs, size=4)
      for offs in [36, 40, 44, 48]]
 fields = dev_util.Register_LE(
-    (obj, 'b', 2), size=1, bitfield=dev_util.Bitfield_LE({
+    obj.bank.b, 2, size=1, bitfield=dev_util.Bitfield_LE({
         'unimpl': 0, 'read_unimpl': 1, 'write_unimpl': 2, 'silent_unimpl': 3}))
 with LogCapture('unimpl') as capture:
     unimpl.write(5)
@@ -330,12 +330,12 @@ with LogCapture('unimpl') as capture:
     del capture.messages[:]
 
 fields4 = dev_util.Register_LE(
-    (obj, 'b', 104), size=1, bitfield=dev_util.Bitfield_LE({
+    obj.bank.b, 104, size=1, bitfield=dev_util.Bitfield_LE({
         'constant0': 0,
         'constant1': (2, 1)}))
 
 fields5 = dev_util.Register_LE(
-    (obj, 'b', 108), size=1, bitfield=dev_util.Bitfield_LE({
+    obj.bank.b, 108, size=1, bitfield=dev_util.Bitfield_LE({
         'constant0': 0,
         'constant1': (2, 1)}))
 
@@ -439,7 +439,7 @@ with LogCapture() as capture, stest.allow_log_mgr(obj, "spec-viol"):
     del capture.messages[:]
 
 fields6 = dev_util.Register_LE(
-    (obj, 'b', 112), size=1, bitfield=dev_util.Bitfield_LE({
+    obj.bank.b, 112, size=1, bitfield=dev_util.Bitfield_LE({
         'zeros': 0,
         'ones': 1,
         'many_ones' : (5, 2)}))
@@ -473,7 +473,7 @@ with LogCapture() as capture, stest.allow_log_mgr(obj, "spec-viol"):
     del capture.messages[:]
 
 fields7 = dev_util.Register_LE(
-    (obj, 'b', 116), size=1, bitfield=dev_util.Bitfield_LE({
+    obj.bank.b, 116, size=1, bitfield=dev_util.Bitfield_LE({
         'ignore': 0}))
 
 # No logs from ignore
@@ -495,7 +495,7 @@ with LogCapture() as capture:
     stest.expect_equal(capture.messages, [])
 
 fields8 = dev_util.Register_LE(
-    (obj, 'b', 120), size=1, bitfield=dev_util.Bitfield_LE({
+    obj.bank.b, 120, size=1, bitfield=dev_util.Bitfield_LE({
         'undocumented': 0}))
 
 with LogCapture() as capture, stest.allow_log_mgr(obj, "spec-viol"):

--- a/test/1.4/misc/T_import_dml14.dml
+++ b/test/1.4/misc/T_import_dml14.dml
@@ -31,6 +31,9 @@ method init() {
     pseudo_attr_test();
     field_regs.test();
     io_memory_access_bank.test();
+    transaction_access_bank_compat.test();
+    io_memory_access_bank.test();
+    transaction_access_bank_compat.test();
     test_bank_obj_get();
     len_test();
     /// GREP .*Once logging

--- a/test/1.4/misc/porting-common-compat.dml
+++ b/test/1.4/misc/porting-common-compat.dml
@@ -107,6 +107,7 @@ bank b2 {
 }
 
 bank access {
+    param use_io_memory = true;
     method io_memory_access(generic_transaction_t *memop, uint64 offset, void *aux) -> (bool) {
         // TODO: further conversion likely needed; probably move
         // old_access implementation into this method
@@ -179,6 +180,7 @@ bank miss {
 }
 
 bank read_access_memop {
+    param use_io_memory = true;
     method io_memory_access(generic_transaction_t *memop, uint64 offset, void *aux) -> (bool) {
         // TODO: further conversion likely needed; probably move
         // old_read_access_memop implementation into this method
@@ -198,6 +200,7 @@ bank read_access_memop {
 }
 
 bank write_access_memop {
+    param use_io_memory = true;
     method io_memory_access(generic_transaction_t *memop, uint64 offset, void *aux) -> (bool) {
         // TODO: further conversion likely needed; probably move
         // old_write_access_memop implementation into this method

--- a/test/1.4/misc/porting-common.dml
+++ b/test/1.4/misc/porting-common.dml
@@ -86,6 +86,7 @@ bank b2 {
 }
 
 bank access {
+    param use_io_memory = true;
     method io_memory_access(generic_transaction_t *memop, uint64 offset, void *aux) -> (bool) {
         // TODO: further conversion likely needed; probably move
         // old_access implementation into this method
@@ -133,6 +134,7 @@ bank miss {
 }
 
 bank read_access_memop {
+    param use_io_memory = true;
     method io_memory_access(generic_transaction_t *memop, uint64 offset, void *aux) -> (bool) {
         // TODO: further conversion likely needed; probably move
         // old_read_access_memop implementation into this method
@@ -150,6 +152,7 @@ bank read_access_memop {
 }
 
 bank write_access_memop {
+    param use_io_memory = true;
     method io_memory_access(generic_transaction_t *memop, uint64 offset, void *aux) -> (bool) {
         // TODO: further conversion likely needed; probably move
         // old_write_access_memop implementation into this method

--- a/test/1.4/registers/T_inquiry.py
+++ b/test/1.4/registers/T_inquiry.py
@@ -29,7 +29,7 @@ def expect_attributes(write_val = 0, read_called = False, write_called = False,
 
 for offs in range(8):
     for size in range(1, 8 - offs + 1):
-        r = Register_LE((obj, 'b', offs), size=size)
+        r = Register_LE(obj.bank.b, offs, size=size)
         r.read_transaction.inquiry = True
         r.write_transaction.inquiry = True
         val = 0x8877665544332211 & ((1 << size * 8) - 1)

--- a/test/common/test_register_view.py
+++ b/test/common/test_register_view.py
@@ -3,8 +3,7 @@
 
 import dev_util
 
-from simics import *
-from stest import expect_equal, expect_true
+from stest import expect_equal
 
 def test_description(b, expected_desc):
     expect_equal(b.description(), expected_desc)
@@ -94,8 +93,8 @@ def test(obj):
     test_array_names(obj.bank.bg.iface.register_view)
 
     test_register_value(obj.bank.le.iface.register_view,
-                        dev_util.Register_LE((obj, 'le', 0x0), 4))
+                        dev_util.Register_LE(obj.bank.le, 0x0, 4))
     test_register_value(obj.bank.be.iface.register_view,
-                        dev_util.Register_BE((obj, 'be', 0x0), 4))
+                        dev_util.Register_BE(obj.bank.be, 0x0, 4))
     expect_equal(obj.bank.le.iface.register_view.register_info(0)[5], False)
     expect_equal(obj.bank.be.iface.register_view.register_info(0)[5], True)


### PR DESCRIPTION
- Avoid legacy Register_LE form
- Enable `use_io_memory` for generated io_memory_access overrides
- Make explicit assumptions on use_io_memory
- Use io_memory explicitly in shared 1.2/1.4 banks
