### PR TITLE
Avoid broken C code generation, SIMICS-21044

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -469,4 +469,9 @@
       This syntax can't be used for variadic arguments or any argument
       corresponding to a method parameter declared `inline`
       <bug number="SIMICS-20473"/>.</add-note></build-id>
+  <build-id value="next"><add-note>Fixed a bug where a top-level
+      object named the same as the device object could result in
+      invalid generated C when both objects are targets of <tt>each
+      .. in ..</tt> expressions
+      <bug number="SIMICS-21044"/>.</add-note></build-id>
 </rn>

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -2970,7 +2970,9 @@ class EachIn(Expression):
     @staticmethod
     def index_ident(node, trait):
         '''C identifier name for vtable_list_t instance'''
-        return f'_each__{trait.name}__in__{node.attrname() or node.name}'
+        # 'dev' is guaranteed not to clash with the name of another object
+        name = 'dev' if node is dml.globals.device else node.attrname()
+        return f'_each__{trait.name}__in__{name}'
 
     @staticmethod
     def array_ident(trait):

--- a/test/1.4/expressions/T_each_in.dml
+++ b/test/1.4/expressions/T_each_in.dml
@@ -26,6 +26,11 @@ bank a {
     }
 }
 
+template t2 { }
+group test is t2 {
+    group sub is t2;
+}
+
 method init() {
     local bool found = false;
     foreach obj in (each tr in (a.b[0].d)) {
@@ -64,4 +69,10 @@ method init() {
         if (i == 2) break;
     }
     assert i == 2;
+
+    // SIMICS-21044: 'each in' used to generate broken code for objects whose
+    // .qname == dev.name
+    assert test.name == dev.name;
+    assert (each t2 in (test)).len == 1;
+    assert (each t2 in (dev)).len == 1;
 }


### PR DESCRIPTION
If a top-level object's name equals dev.name, then they could yield
conflicting declarations of the `_each_X__in__NAME` variable.
