### PR TITLE
Improve DML_DUMP_INPUT_FILES

### DIFF
--- a/test/1.4/misc/rel/a/x.dml
+++ b/test/1.4/misc/rel/a/x.dml
@@ -10,3 +10,4 @@ import "./y.dml";
 import "../misc/rel/z.dml";
 // interpreted relative main file
 import "rel/z.dml";
+import "rel/a/y.dml";


### PR DESCRIPTION
In some SSM use cases, some files are imported both as
full/path/to/file.dml and file.dml, which somehow prohibits unification.
Here we fix this by unifying files identical basenames and content.
