### PR TITLE
Fix various issues relating to `after` on methods with const parameters

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -482,4 +482,7 @@
   <build-id value="next"><add-note>Fixed an error where const method parameters
       would cause an internal error if that method is used as the callback of
       an `after` statement.</add-note></build-id>
+  <build-id value="next"><add-note>Fixed an issue where having a const-qualified
+      layout type could lead to internal compiler errors in certain
+      scenarios.</add-note></build-id>
 </rn>

--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -477,4 +477,6 @@
   <build-id value="next"><add-note><tt>--coverity</tt> now suppresses a false
       positive that the <tt>COPY_PASTE_ERROR</tt> checker reports in
       <tt>dml-builtins.dml</tt>.</add-note></build-id>
+  <build-id value="next"><add-note>It's now allowed to cast an expression
+      of a struct type to that same struct type.</add-note></build-id>
 </rn>

--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -479,4 +479,7 @@
       <tt>dml-builtins.dml</tt>.</add-note></build-id>
   <build-id value="next"><add-note>It's now allowed to cast an expression
       of a struct type to that same struct type.</add-note></build-id>
+  <build-id value="next"><add-note>Fixed an error where const method parameters
+      would cause an internal error if that method is used as the callback of
+      an `after` statement.</add-note></build-id>
 </rn>

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -4058,16 +4058,22 @@ def mkCast(site, expr, new_type):
             return mkTraitUpcast(site, expr, real.trait)
     old_type = safe_realtype(expr.ctype())
     if (dml.globals.compat_dml12_int(site)
-        and (isinstance(old_type, (TStruct, TVector, TLayout))
-             or isinstance(real, (TStruct, TVector, TLayout)))):
+        and (isinstance(old_type, (TStruct, TVector))
+             or isinstance(real, (TStruct, TVector)))):
         # these casts are permitted by C only if old and new are
         # the same type, which is useless
         return Cast(site, expr, new_type)
-    if isinstance(real, (TVoid, TStruct, TArray, TVector, TTraitList,
-                         TLayout, TFunction)):
+    if isinstance(real, TStruct):
+        if isinstance(old_type, TStruct) and old_type.label == real.label:
+            return expr
         raise ECAST(site, expr, new_type)
-    if isinstance(old_type, (TVoid, TStruct, TVector, TTraitList, TLayout,
-                             TTrait)):
+    if isinstance(real, TExternStruct):
+        if isinstance(old_type, TExternStruct) and old_type.id == real.id:
+            return expr
+        raise ECAST(site, expr, new_type)
+    if isinstance(real, (TVoid, TArray, TVector, TTraitList, TFunction)):
+        raise ECAST(site, expr, new_type)
+    if isinstance(old_type, (TVoid, TStruct, TVector, TTraitList, TTrait)):
         raise ECAST(site, expr, new_type)
     if old_type.is_int and old_type.is_endian:
         expr = as_int(expr)

--- a/py/dml/serialize.py
+++ b/py/dml/serialize.py
@@ -221,7 +221,7 @@ def deserialize(real_type, current_expr, target_expr, error_out):
     def addressof_target_unconst():
         base = ctree.mkAddressOf(current_site, target_expr)
         if deep_const(real_type):
-            base = ctree.mkCast(current_site, target_expr, TPtr(void))
+            base = ctree.mkCast(current_site, base, TPtr(void))
         return base
 
     def construct_subcall(apply_expr):
@@ -564,7 +564,9 @@ def generate_deserialize(real_type):
             (tmp_out_decl, tmp_out_ref) = declare_variable(
                 site, "_tmp_out", TPtr(real_type),
                 ctree.mkNew(site, real_type))
-            cleanup.append(ctree.mkDelete(site, tmp_out_ref))
+            cleanup_ref = (tmp_out_ref if not deep_const(real_type)
+                           else ctree.mkCast(site, tmp_out_ref, TPtr(void)))
+            cleanup.append(ctree.mkDelete(site, cleanup_ref))
             tmp_out_decl.toc()
             targets = tuple((ctree.mkSubRef(site, tmp_out_ref, name, "->"),
                              conv_const(real_type.const, safe_realtype(typ)))

--- a/py/dml/types.py
+++ b/py/dml/types.py
@@ -1026,7 +1026,14 @@ class TLayout(TStruct):
         return self.size
 
     def clone(self):
-        return TLayout(self.endian, self.member_decls, self.label, self.const)
+        cloned = TLayout(self.endian, self.member_decls, self.label,
+                         self.const)
+        if self.members is not None:
+            cloned.members = self.members
+            cloned.size = self.size
+        return cloned
+
+
 
 class TFunction(DMLType):
     __slots__ = ('input_types', 'output_type', 'varargs')

--- a/test/1.4/errors/T_ECAST.dml
+++ b/test/1.4/errors/T_ECAST.dml
@@ -27,14 +27,18 @@ method init() {
     cast(s, uint32);
     /// ERROR ECAST
     cast(i, s_t);
-    /// ERROR ECAST
+    // no error
     cast(s, s_t);
+    /// ERROR ECAST
+    cast(s, l_t);
     /// ERROR ECAST
     cast(l, uint32);
     /// ERROR ECAST
     cast(i, l_t);
-    /// ERROR ECAST
+    // no error
     cast(l, l_t);
+    /// ERROR ECAST
+    cast(l, s_t);
     /// ERROR ECAST
     cast(v, uint32);
     /// ERROR ECAST

--- a/test/1.4/events/T_after.dml
+++ b/test/1.4/events/T_after.dml
@@ -44,3 +44,18 @@ template operator is (int64_attr) {
 
 attribute multi_operator[i < 2][j < 2] is (operator);
 attribute single_operator is (operator);
+
+// Test methods with const-qualified parameters
+
+attribute constig_res is uint64_attr;
+
+method constig(const uint64 i) {
+    constig_res.val = i;
+}
+
+attribute trigger_constig is (write_only_attr) {
+    param type = "n";
+    method set(attr_value_t val) throws {
+        after 0.1 s: constig(4);
+    }
+}

--- a/test/1.4/events/T_after.dml
+++ b/test/1.4/events/T_after.dml
@@ -47,15 +47,20 @@ attribute single_operator is (operator);
 
 // Test methods with const-qualified parameters
 
-attribute constig_res is uint64_attr;
+typedef layout "little-endian" {
+    const uint32 x[2];
+} l_t;
 
-method constig(const uint64 i) {
-    constig_res.val = i;
+attribute constig_res[i < 2] is uint64_attr;
+
+method constig(const uint64 i, const l_t l) {
+    constig_res[0].val = i;
+    constig_res[1].val = l.x[0] << 32 | l.x[1];
 }
 
 attribute trigger_constig is (write_only_attr) {
     param type = "n";
     method set(attr_value_t val) throws {
-        after 0.1 s: constig(4);
+        after 0.1 s: constig(4, {{7, 11}});
     }
 }

--- a/test/1.4/events/T_after.py
+++ b/test/1.4/events/T_after.py
@@ -27,6 +27,6 @@ stest.expect_equal(obj.single_operator, 3)
 
 obj.trigger_constig = None
 SIM_continue(99999)
-stest.expect_equal(obj.constig_res, 0)
+stest.expect_equal(obj.constig_res, [0, 0])
 SIM_continue(2)
-stest.expect_equal(obj.constig_res, 4)
+stest.expect_equal(obj.constig_res, [4, 7 << 32 | 11])

--- a/test/1.4/events/T_after.py
+++ b/test/1.4/events/T_after.py
@@ -24,3 +24,9 @@ SIM_continue(99998)
 stest.expect_equal(obj.single_operator, 5)
 SIM_continue(2)
 stest.expect_equal(obj.single_operator, 3)
+
+obj.trigger_constig = None
+SIM_continue(99999)
+stest.expect_equal(obj.constig_res, 0)
+SIM_continue(2)
+stest.expect_equal(obj.constig_res, 4)

--- a/test/1.4/expressions/T_cast.dml
+++ b/test/1.4/expressions/T_cast.dml
@@ -1,0 +1,32 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+
+header %{
+    typedef struct {
+        int x;
+    } ext_t;
+%}
+
+typedef struct {
+    int32 x;
+} s_t;
+
+typedef layout "little-endian" {
+    int32 x;
+} l_t;
+
+extern typedef struct {
+    int x;
+} ext_t;
+
+method init() {
+    local (s_t s, l_t l, ext_t ext) = ({1}, {1}, {1});
+    s = cast(s, s_t);
+    l = cast(l, l_t);
+    ext = cast(ext, ext_t);
+    assert s.x == 1 && l.x == 1 && ext.x == 1;
+}


### PR DESCRIPTION
Our unconstifying logic has always been suspect, but it turns out some pieces are not even tested -- deserialization in particular.

Four different issues, fixes for which have been packaged in three different commits. Check each commit for a brief comment on each.

The burden of maintaining deconstifying logic is a rather compelling argument to try to avoid its need in the first place -- by restricting the places where `const` may occur. We already have some restrictions in place, but only a few are codified in the language, while other are explicit limitations of the compiler, upheld by ICEs, and to be fixed at a later date. If we want to commit to "we don't want to bother with this idiocy" then we need to formalize it. For example, we could say "input parameters may not be (partially) const." This is likely to be breaking, but since the fix is rather damn easy (just remove the const qualifier) for every case but for partially const types and external const types -- both of which are rather niche -- we may be ok with codifying such restrictions. We're gonna need to discuss this.