### PR TITLE
Don't rely on UB enum semantics for more than 32 log groups

### DIFF
--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1721,4 +1721,7 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
   <build-id value="6205"><add-note> Fixed a bug with how template types were
       handled by DMLC that could cause the compiler to still exhibit
       nondeterministic behaviour.</add-note></build-id>
+  <build-id value="next"><add-note> Added an error if a device declares
+      more than 63 log groups (including the two built-in log groups.)
+  </add-note></build-id>
 </rn>

--- a/doc/1.4/language.md
+++ b/doc/1.4/language.md
@@ -2360,6 +2360,9 @@ is similar to a `constant` declaration, but the value is
 allocated automatically so that all log groups are represented by
 distinct powers of 2 and can be combined with bitwise *or*.
 
+A maximum of 63 log groups may be declared per device (61 excluding the built-in
+`Register_Read` and `Register_Write` log groups.)
+
 ### Typedef Declarations
 
 <pre>

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -340,13 +340,11 @@ def generate_hfile(device, headers, filename):
     print_device_substruct(device)
 
     if dml.globals.log_groups:
-        out('typedef enum %s_log_group {\n' % crep.cname(device),
-            postindent = 1)
         i = 1
         for g in dml.globals.log_groups:
-            out('%s = %d,\n' % (crep.cloggroup(g), i))
+            out('static const uint64 %s UNUSED = %dULL;\n'
+                % (crep.cloggroup(g), i))
             i <<= 1
-        out('} %s_log_group_t;\n' % crep.cname(device), preindent = -1)
         out('\n')
 
     out('void hard_reset_'+crep.cname(device)

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1536,6 +1536,15 @@ class EIDENTSIZEOF(DMLError):
     def __init__(self, site, identifier):
         DMLError.__init__(self, site, identifier, identifier)
 
+class ELOGGROUPS(DMLError):
+    """
+    Too many log groups were declared. A device may have a maximum of 63
+    `loggroup` declarations (61 excluding the built-in `Register_Read` and
+    `Register_Write` loggroups).
+    """
+    fmt = ("Too many loggroup declarations. A maximum of 63 log groups (61 "
+           + "excluding builtins) may be declared per device.")
+
 #
 # WARNINGS (keep these as few as possible)
 #

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -185,9 +185,11 @@ def mkglobals(stmts):
                 new_typedefs.add(name)
             elif stmt[0] == 'loggroup':
                 _, site, name = stmt
+                if len(dml.globals.log_groups) >= 63:
+                    report(ELOGGROUPS(site))
                 dml.globals.log_groups.append(name)
                 new_symbols.append(LiteralSymbol(
-                    name, TNamed('int', const=True), site,
+                    name, TInt(64, False, const=True), site,
                     crep.cloggroup(name)))
             elif stmt.kind != 'constant': # handled above
                 raise ICE(stmt.site, 'bad AST kind: %s' % (stmt.kind,))

--- a/test/1.2/trivial/T_loggroup_1.dml
+++ b/test/1.2/trivial/T_loggroup_1.dml
@@ -5,12 +5,18 @@
 dml 1.2;
 device test;
 import "testing.dml";
+import "dml12-compatibility.dml";
+import "simics/simulator/conf-object.dml";
 
-loggroup lg1;
-loggroup lg2;
-loggroup lg3;
-loggroup lg4;
+loggroup lg1;  loggroup lg2;  loggroup lg3;  loggroup lg4;  loggroup lg5;
+loggroup lg6;  loggroup lg7;  loggroup lg8;  loggroup lg9;  loggroup lg10;
+loggroup lg11; loggroup lg12; loggroup lg13; loggroup lg14; loggroup lg15;
+loggroup lg16; loggroup lg17; loggroup lg18; loggroup lg19; loggroup lg20;
+loggroup lg21; loggroup lg22; loggroup lg23; loggroup lg24; loggroup lg25;
+loggroup lg26; loggroup lg27; loggroup lg28; loggroup lg29; loggroup lg30;
+loggroup lg31; loggroup lg32; loggroup lg33;
 
 method test -> (bool result) {
-    result = ((lg1 == 1) && (lg2 == 2) && (lg3 == 4) && (lg4 == 8));
+    result = ((lg1 == 1) && (lg2 == 2) && (lg3 == 4) && (lg4 == 8)
+              && (lg33 == cast(1 << 32, uint64)));
 }

--- a/test/1.4/errors/T_ELOGGROUPS.dml
+++ b/test/1.4/errors/T_ELOGGROUPS.dml
@@ -1,0 +1,24 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+
+/// ERROR ELOGGROUPS dml-builtins.dml
+
+loggroup lg1;  loggroup lg2;  loggroup lg3;  loggroup lg4;  loggroup lg5;
+loggroup lg6;  loggroup lg7;  loggroup lg8;  loggroup lg9;  loggroup lg10;
+loggroup lg11; loggroup lg12; loggroup lg13; loggroup lg14; loggroup lg15;
+loggroup lg16; loggroup lg17; loggroup lg18; loggroup lg19; loggroup lg20;
+loggroup lg21; loggroup lg22; loggroup lg23; loggroup lg24; loggroup lg25;
+loggroup lg26; loggroup lg27; loggroup lg28; loggroup lg29; loggroup lg30;
+loggroup lg31; loggroup lg32; loggroup lg33; loggroup lg34; loggroup lg35;
+loggroup lg36; loggroup lg37; loggroup lg38; loggroup lg39; loggroup lg40;
+loggroup lg41; loggroup lg42; loggroup lg43; loggroup lg44; loggroup lg45;
+loggroup lg46; loggroup lg47; loggroup lg48; loggroup lg49; loggroup lg50;
+loggroup lg51; loggroup lg52; loggroup lg53; loggroup lg54; loggroup lg55;
+loggroup lg56; loggroup lg57; loggroup lg58; loggroup lg59; loggroup lg60;
+loggroup lg61; loggroup lg62; loggroup lg63;
+/// ERROR ELOGGROUPS
+loggroup lg64;

--- a/test/1.4/statements/T_log.dml
+++ b/test/1.4/statements/T_log.dml
@@ -8,7 +8,19 @@ device test;
 
 import "simics/simulator/conf-object.dml";
 
-loggroup lg1;
+loggroup lg1;  loggroup lg2;  loggroup lg3;  loggroup lg4;  loggroup lg5;
+loggroup lg6;  loggroup lg7;  loggroup lg8;  loggroup lg9;  loggroup lg10;
+loggroup lg11; loggroup lg12; loggroup lg13; loggroup lg14; loggroup lg15;
+loggroup lg16; loggroup lg17; loggroup lg18; loggroup lg19; loggroup lg20;
+loggroup lg21; loggroup lg22; loggroup lg23; loggroup lg24; loggroup lg25;
+loggroup lg26; loggroup lg27; loggroup lg28; loggroup lg29; loggroup lg30;
+loggroup lg31; loggroup lg32; loggroup lg33; loggroup lg34; loggroup lg35;
+loggroup lg36; loggroup lg37; loggroup lg38; loggroup lg39; loggroup lg40;
+loggroup lg41; loggroup lg42; loggroup lg43; loggroup lg44; loggroup lg45;
+loggroup lg46; loggroup lg47; loggroup lg48; loggroup lg49; loggroup lg50;
+loggroup lg51; loggroup lg52; loggroup lg53; loggroup lg54; loggroup lg55;
+loggroup lg56; loggroup lg57; loggroup lg58; loggroup lg59; loggroup lg60;
+loggroup lg61;
 
 method init() {
     local uint64 i = 7;
@@ -34,9 +46,20 @@ method init() {
     // Somewhat unexpected: nothing is logged, but the side-effect does happen
     log error, 1, lg1: "not logged %d", ++side_effect;
     assert side_effect == 2;
-    a = SIM_make_attr_uint64(lg1);
+    a = SIM_make_attr_uint64(lg61);
+    assert cast(lg61, uint64) == 1 << 60;
     assert SIM_set_attribute(dev.obj, "log_group_mask", &a) == Sim_Set_Ok;
     /// GREP .*log on group, #3
-    log info, 1, lg1: "log on group, #%d", ++side_effect;
+    log info, 1, lg61: "log on group, #%d", ++side_effect;
     assert side_effect == 3;
+}
+
+attribute test_nolog is write_only_attr {
+    param type = "n";
+
+    method set(attr_value_t val) throws {
+        log info, 1, lg1: "log on unselected group";
+        log info, 1, lg60: "log on another unselected group";
+        log info: "log on no group";
+    }
 }

--- a/test/1.4/statements/T_log.py
+++ b/test/1.4/statements/T_log.py
@@ -1,0 +1,13 @@
+# © 2023 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+import stest
+
+try:
+    with stest.expect_log_mgr(obj, 'info'):
+        obj.test_nolog = None
+except stest.TestFailure as e:
+    if not str(e).startswith('Expected log'):
+        raise
+else:
+    stest.fail('Unexpected logging occurred')


### PR DESCRIPTION
(Edited: see https://github.com/intel/device-modeling-language/pull/186#issuecomment-1602099028)