### PR TITLE
Warn if log groups are used as log level, or vice versa -- SIMICS-21138

### DIFF
--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1724,4 +1724,10 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
   <build-id value="6244"><add-note> Added an error if a device declares
       more than 63 log groups (including the two built-in log groups.)
   </add-note></build-id>
+  <build-id value="next"><add-note> Added a warning for if a specified log
+      level of a log statement is likely intended to instead specify the log
+      groups, and/or vice versa <bug number="22018374443"/>.
+      This warning is only enabled by default with Simics API version 7 or
+      above. With version 6 and below it must be explicitly enabled by passing
+      <tt>--warn=WLOGMIXUP</tt> to DMLC.</add-note></build-id>
 </rn>

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -68,7 +68,7 @@ __all__ = (
     'mkContinue',
     'mkAssignStatement',
     'mkCopyData',
-    'mkIfExpr',
+    'mkIfExpr', 'IfExpr',
     #'BinOp',
     #'Test',
     #'Flag',
@@ -84,7 +84,7 @@ __all__ = (
     'mkNotEquals',
     #'BitBinOp',
     'mkBitAnd',
-    'mkBitOr',
+    'mkBitOr', 'BitOr', 'BitOr_dml12',
     'mkBitXOr',
     'BitShift',
     'mkShL',
@@ -153,6 +153,7 @@ __all__ = (
     'InvalidSymbol',
     'mkQName', 'QName',
     'mkDeviceObject',
+    'LogGroup',
     'mkStructDefinition',
     'mkDeclaration',
     'mkCText',
@@ -202,6 +203,9 @@ class ExpressionSymbol(symtab.Symbol):
     """A symbol that corresponds to an expression."""
     def __init__(self, name, expr, site):
         super(ExpressionSymbol, self).__init__(name, value = expr, site = site)
+    @property
+    def type(self):
+        return self.value.ctype()
     def expr(self, site):
         expr = self.value.copy(site)
         expr.incref()
@@ -4709,6 +4713,19 @@ class DeviceObject(Expression):
         return "&_dev->obj"
 
 mkDeviceObject = DeviceObject
+
+class LogGroup(Expression):
+    type = TInt(64, False, const=True)
+    slots = ('name',)
+    priority = 1000
+    @auto_init
+    def __init__(self, site, name): pass
+
+    def __str__(self):
+        return self.name
+
+    def read(self):
+        return crep.cloggroup(self.name)
 
 class Initializer(object):
     """An initializer is either an expression, or a

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -481,6 +481,25 @@ def main(argv):
         else:
             defs[name] = value
 
+    if options.api_version not in api_versions():
+        prerr("dmlc: the version '%s' is not a valid API version" % (
+                options.api_version))
+        sys.exit(1)
+
+    if options.full_module and options.api_version not in ['4.8']:
+        prerr("dmlc: the -m option is only valid together with --api=4.8"
+              " or older")
+        sys.exit(1)
+
+    # This warning is disabled by default below Simics 7 due to sheer
+    # prominence of the issue it warns about in existing code.
+    # By only enabling the warning in Simics 7, we allow existing codebases
+    # to handle the bugs as part of migration, instead of suddenly
+    # overwhelming them with a truly massive amount of warnings in an
+    # intermediate release.
+    if options.api_version in {'4.8', '5', '6'}:
+        ignore_warning('WLOGMIXUP')
+
     for w in options.disabled_warnings:
         if not is_warning_tag(w):
             prerr("dmlc: the tag '%s' is not a valid warning tag" % w)
@@ -527,16 +546,6 @@ def main(argv):
               + "form. They are COMPLETELY UNSUPPORTED. "
               + "The DMLC developers WILL NOT respect their use. "
               + "NEVER enable this flag for any kind of production code!!!***")
-
-    if options.api_version not in api_versions():
-        prerr("dmlc: the version '%s' is not a valid API version" % (
-                options.api_version))
-        sys.exit(1)
-
-    if options.full_module and options.api_version not in ['4.8']:
-        prerr("dmlc: the -m option is only valid together with --api=4.8"
-              " or older")
-        sys.exit(1)
 
     dml.globals.api_version = options.api_version
 

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -191,9 +191,8 @@ def mkglobals(stmts):
                 if len(dml.globals.log_groups) >= 63:
                     report(ELOGGROUPS(site))
                 dml.globals.log_groups.append(name)
-                new_symbols.append(LiteralSymbol(
-                    name, TInt(64, False, const=True), site,
-                    crep.cloggroup(name)))
+                new_symbols.append(ExpressionSymbol(
+                    name, LogGroup(site, name), site))
             elif stmt.kind != 'constant': # handled above
                 raise ICE(stmt.site, 'bad AST kind: %s' % (stmt.kind,))
         except DMLError as e:

--- a/test/1.4/errors/WLOGMIXUP.dml
+++ b/test/1.4/errors/WLOGMIXUP.dml
@@ -1,0 +1,56 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+
+/// COMPILE-ONLY
+
+loggroup lg;
+
+session bool b;
+session int i;
+
+method init() {
+    /// WARNING WLOGMIXUP
+    log info, lg: "log";
+    /// WARNING WLOGMIXUP
+    log info, lg, i: "log";
+    /// WARNING WLOGMIXUP
+    log info, (lg | 0): "log";
+    /// WARNING WLOGMIXUP
+    log info, b ? (cast(lg | i, uint32) | i) : i: "log";
+    /// WARNING WLOGMIXUP
+    log info, b ? (cast(i | i, uint32) | i) : 0: "log";
+
+    // no warning
+    log info, b ? (cast(1 | i, uint32) | i) : i: "log";
+    log info, lg + 0: "log";
+    local uint64 lg_ = lg;
+    log info, lg_: "log";
+
+    /// WARNING WLOGMIXUP
+    log info, i, 1: "log";
+    /// WARNING WLOGMIXUP
+    log info, i, 5: "log";
+    /// WARNING WLOGMIXUP
+    log info, i, b ? cast(1, uint32) : i: "log";
+
+    // no warning
+    log info, i, lg: "log";
+    log info, i, 6: "log";
+    log info, i, b ? cast(1, uint32) : 0: "log";
+    log info, i, b ? cast(1, uint32) : lg: "log";
+    log info, i, b ? cast(i, uint32) : i: "log";
+    log info, i, 1 + i: "log";
+    local uint64 ll_ = 1;
+    log info, i, ll_: "log";
+
+    /// WARNING WLOGMIXUP
+    log info, 2, 3: "log";
+    /// WARNING WLOGMIXUP
+    log info, i then lg: "log";
+    /// WARNING WLOGMIXUP
+    log info, lg then 3: "log";
+}

--- a/test/tests.py
+++ b/test/tests.py
@@ -1070,14 +1070,22 @@ all_tests.append(CTestCase(
 
 if get_simics_major() == "6":
     all_tests.append(CTestCase(
-        ["1.2", "errors", "T_WREF"],
+        ["1.2", "errors", "WREF"],
         join(testdir, "1.2", "errors", "WREF.dml"),
         api_version="5"))
+    all_tests.append(CTestCase(
+        ["1.4", "errors", "WLOGMIXUP"],
+        join(testdir, "1.4", "errors", "WLOGMIXUP.dml"),
+        dmlc_extraargs = ["--warn=WLOGMIXUP"]))
 
 if get_simics_major() == "7":
     all_tests.append(CTestCase(
-        ["1.4", "errors", "T_ETYPE_integer_t"],
+        ["1.4", "errors", "ETYPE_integer_t"],
         join(testdir, "1.4", "errors", "ETYPE_integer_t.dml"),
+        api_version="7"))
+    all_tests.append(CTestCase(
+        ["1.4", "errors", "WLOGMIXUP"],
+        join(testdir, "1.4", "errors", "WLOGMIXUP.dml"),
         api_version="7"))
 
 class DebuggableCheck(BaseTestCase):


### PR DESCRIPTION
Depends on #186 

The verification of this is gonna be interesting. It will complain about what https://github.com/intel-innersource/applications.simulators.simics.simics-base/pull/4184 addresses, but what else?