### PR TITLE
Migrate from optparse to argparse

### DIFF
--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -539,6 +539,9 @@ template device {
     param _is_simics_object = true;
 
     param simics_api_version auto;
+    param _api_5_or_older = simics_api_version == "5"
+        || simics_api_version == "4.8";
+    param _api_6_or_older = simics_api_version == "6" || _api_5_or_older;
 
     // automatic parameters
     param obj                       auto;
@@ -551,8 +554,7 @@ template device {
     param be_bitorder             default _be_bitorder;
     param log_group                 = undefined;
 
-    param use_io_memory             default simics_api_version == "6"
-        || simics_api_version == "5" || simics_api_version == "4.8";
+    param use_io_memory             default _api_6_or_older;
     // this was available in DML 1.2; defensively reserved in 1.4
     param banks                     = undefined;
     // this carried semantics in DML 1.2; deprecated in 1.4
@@ -1441,8 +1443,7 @@ template port is object {
     param _is_simics_object = true;
     // limitations for ports are not recognized
     param limitations = undefined;
-    param obj = (simics_api_version == "5" || simics_api_version == "4.8")
-        #? dev.obj #: _port_obj();
+    param obj = dev._api_5_or_older #? dev.obj #: _port_obj();
 
     session conf_object_t *_cached_port_obj;
     shared method _port_obj() -> (conf_object_t *) {
@@ -1774,8 +1775,7 @@ template bank is (object, shown_desc) {
     // compatibility: referencing 'obj' in a bank method must evaluate to
     // dev.obj in code that can compile on both 5 and 6
     // TODO: we should probably make obj an immutable session variable
-    param obj = (simics_api_version == "5" || simics_api_version == "4.8")
-        #? dev.obj #: _bank_obj();
+    param obj = dev._api_5_or_older #? dev.obj #: _bank_obj();
     param partial : bool;
     param overlapping : bool;
     param _le_byte_order : bool;

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from . import objects, logging, crep, output, ctree, serialize, structure
 from . import traits
 import dml.globals
-from .structure import get_attr_name, port_class_ident, port_should_get_proxies
+from .structure import get_attr_name, port_class_ident, need_port_proxy_attrs
 from .logging import *
 from .messages import *
 from .output import *
@@ -510,7 +510,7 @@ def check_attribute(node, port, prefix):
             report(WNDOC(node, node.logname()))
     attrname = get_attr_name(prefix, node)
     register_attribute(node.site, port, attrname)
-    if port and port_should_get_proxies(port):
+    if port and need_port_proxy_attrs(port):
         register_attribute(node.site, None, "%s_%s" % (port.name, attrname))
 
 # dimsizes, loopvars, prefix are relative to port.

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -261,6 +261,27 @@ def flush_porting_log(tmpfile, porting_filename):
         # (so retrying compile will succeed)
         os.rmdir(lockfile)
 
+class HelpAction(argparse.Action):
+    def __init__(self, option_strings, dest, **kwargs):
+        super().__init__(option_strings, dest, nargs=0, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        self.print_help()
+        parser.exit()
+
+class WarnHelpAction(HelpAction):
+    def print_help(self):
+        print('''Tags accepted by --warn and --nowarn:''')
+        by_ignored = {True: [], False: []}
+        for tag in sorted(messages.warnings):
+            by_ignored[warning_is_ignored(tag)].append(tag)
+        print('  Enabled by default:')
+        for tag in by_ignored[False]:
+            print(f'    {tag}')
+        print('  Disabled by default:')
+        for tag in by_ignored[True]:
+            print(f'    {tag}')
+
 def main(argv):
     # DML files must be utf8, but are generally opened without specifying
     # the 'encoding' arg. This works only if utf8_mode is enabled.
@@ -357,6 +378,8 @@ def main(argv):
         default=[],
         help='disable warning TAG')
 
+    parser.add_argument('--help-warn', action=WarnHelpAction,
+                        help='List warning tags available for --warn/--nowarn')
     # <dt>--werror</dt>
     # <dd>Turn all warnings into errors.</dd>
     parser.add_argument('--werror', action='store_true',

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -403,12 +403,6 @@ def main(argv):
         '--info', dest = 'output_info', action = 'store_true',
         help = 'generate XML file describing register layout')
 
-    # <dt>--version</dt>
-    # <dd>Print version information.</dd>
-    optpar.add_option(
-        '--version', dest = 'handled_in_c', action = 'store_true',
-        help = 'print version information')
-
     # <dt>--simics-api=<i>version</i></dt>
     # <dd>Use Simics API version <i>version</i>.</dd>
     optpar.add_option(

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -440,17 +440,6 @@ def main(argv):
         help="""Append messages to file with tags for automatic porting
         to DML 1.4""")
 
-    def show_illegal_attributes(option, opt, value, parser):
-        for n in dml.globals.illegal_attributes:
-            print(n)
-        sys.exit(0)
-
-    # Not documented
-    optpar.add_option(
-        '--illegal-attributes', dest = 'illegal_attributes',
-        action = 'callback',
-        callback = show_illegal_attributes,
-        help = optparse.SUPPRESS_HELP)
     optpar.add_option(
         '--state-change-dml12', action='store_true',
         help=optparse.SUPPRESS_HELP)

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -2466,3 +2466,7 @@ class PINT1(PortingMessage):
     types, then the value of the variable becomes 1, whereas for
     `int1` in DML 1.4 the value is -1."""
     fmt = "Change int1 to uint1"
+
+warnings = {name: cls for (name, cls) in globals().items()
+            if isinstance(cls, type) and issubclass(cls, DMLWarning)
+            and cls is not DMLWarning}

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -2578,7 +2578,7 @@ class ConfAttrParentObjectClassParamExpr(objects.ParamExpr):
         self.cached = mkLit(self.site, lit, TPtr(TPtr(TNamed('conf_class_t'))))
         return self.cached
 
-def port_should_get_proxies(port):
+def need_port_proxy_attrs(port):
     assert port.objtype in {'port', 'bank', 'subdevice'}
     return (port.objtype in {'port', 'bank'}
             and port.dimensions <= 1
@@ -2602,7 +2602,7 @@ class ConfAttrParentObjectProxyInfoParamExpr(objects.ParamExpr):
             return self.cached
         object_parent = self.node.object_parent
         if (object_parent is not dml.globals.device
-            and port_should_get_proxies(object_parent)):
+            and need_port_proxy_attrs(object_parent)):
             is_bank = 'true' if object_parent.objtype == 'bank' else 'false'
             is_array = 'true' if object_parent.dimensions == 1 else 'false'
             indices = ((mkLit(self.site, '0', TInt(32, False)),)

--- a/test/tests.py
+++ b/test/tests.py
@@ -23,6 +23,13 @@ from depfile import parse_depfile
 import pstats
 import tarfile
 
+def project_host_path():
+    return join(testparams.project_path(),
+                        testparams.host_platform())
+
+sys.path.append(join(project_host_path(), 'bin', 'dml', 'python'))
+import dml.globals
+
 class TestFail(Exception):
     def __init__(self, reason):
         Exception.__init__(self)
@@ -33,10 +40,6 @@ import module_id
 
 def host_path():
     return join(testparams.simics_base_path(),
-                        testparams.host_platform())
-
-def project_host_path():
-    return join(testparams.project_path(),
                         testparams.host_platform())
 
 # Matches "/// (ANNOTATION) (details)", used for annotating error
@@ -1470,16 +1473,9 @@ class CompareIllegalAttrs(BaseTestCase):
                       capture_output=True,
                       encoding='utf-8').stdout.splitlines()
               if x.startswith('ATTR ')}
-        #self.pr("Automatic attributes: %r" % sl)
 
         # Extract list of illegal attributes from dmlc
-        dl = {x.strip()
-              for x in subprocess.run(
-                      [join(simics_base_path(), "bin", "dmlc" + bat_sfx),
-                       "--illegal-attributes"],
-                      capture_output=True,
-                      encoding='utf-8').stdout.splitlines()}
-        #self.pr("Illegal attributes: %r" % dl)
+        dl = dml.globals.illegal_attributes
 
         if dl != sl:
             for n in dl - sl:

--- a/test/tests.py
+++ b/test/tests.py
@@ -4,7 +4,6 @@
 import sys, time
 import os, os.path
 import re
-import functools
 import itertools
 import queue
 import threading
@@ -12,10 +11,9 @@ import random
 import subprocess
 import difflib
 from pathlib import Path
-from os.path import join, isdir, isfile, exists
+from os.path import join, isdir, exists
 import glob
 import json
-from fnmatch import fnmatch
 from simicsutils.host import host_type, is_windows, batch_suffix
 from simicsutils.internal import package_path, get_simics_major
 import testparams
@@ -205,7 +203,7 @@ class DMLFileTestCase(BaseTestCase):
         # Override defaults
         for k,v in info.items():
             setattr(self, k, v)
-        if self.includepath == None:
+        if self.includepath is None:
             assert self.api_version
             if self.api_version == "4.8":
                 libdir = "dml-old-4.8"
@@ -835,7 +833,7 @@ class CTestCase(DMLFileTestCase):
                         self.pr("Found %r" % s)
                         found.add(r)
             for s,r in rxs:
-                if not r in found:
+                if r not in found:
                     self.pr(self.simics_stdout + ":0: Didn't find %r" % s)
                     raise TestFail("grep miss")
 
@@ -863,9 +861,9 @@ class DMLCProfileTestCase(CTestCase):
                 # Check the validity of profiling data
                 pstats.Stats(stats_file_name)
             except:
-                raise TestFail(f'cannot load profile data')
+                raise TestFail('cannot load profile data')
         else:
-            raise TestFail(f'stats file not generated')
+            raise TestFail('stats file not generated')
 
 
 class SizeStatsTestCase(CTestCase):
@@ -1094,8 +1092,8 @@ class DebuggableCheck(BaseTestCase):
         lines = open(join(testparams.sandbox_path(), "scratch",
                           "debuggable-compile", "T_debuggable-compile.c"),
                      "r").readlines()
-        if not ("static bool _DML_M_mmm(test_t *_dev, int x, int *y)\n"
-                in lines):
+        if ("static bool _DML_M_mmm(test_t *_dev, int x, int *y)\n"
+            not in lines):
             raise TestFail("didn't find expected code")
     prereqs = ['debuggable-compile']
 
@@ -1459,7 +1457,7 @@ class CompareIllegalAttrs(BaseTestCase):
     __slots__ = ()
     prereqs = ['minimal']
     def test(self):
-       # Extract list of automatic attributes from Simics
+        # Extract list of automatic attributes from Simics
         sl = {x[5:].strip()
               for x in subprocess.run(
                       [join(simics_base_path(), "bin", "simics" + bat_sfx),
@@ -1561,11 +1559,11 @@ class CopyrightTestCase(BaseTestCase):
             return f'strange copyright year: {start}'
         return None
     def test(self):
-        mpl_lines = f'''\
+        mpl_lines = '''\
 © (2[0-9]*)(?:-(2[0-9]*))? Intel Corporation
 SPDX-License-Identifier: MPL-2.0
 '''.encode('utf-8').splitlines()
-        bsd0_copyright_re = re.compile(f'''/[*]
+        bsd0_copyright_re = re.compile('''/[*]
   © (2[0-9]*)(?:-(2[0-9]*))? Intel Corporation
   SPDX-License-Identifier: 0BSD
 [*]/'''.encode('utf-8'))


### PR DESCRIPTION
- Shut up linter
- Remove the --illegal-attrs flag
- Remove --illegal-attrs flag
- Remove --version, which was ignored
- Migrate from optparse to argparse
