### PR TITLE
Trait trampolines: declare `_flat_index` as uint32

### DIFF
--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -2703,11 +2703,11 @@ def generate_trait_trampoline(method, vtable_trait):
         site = method.site
         obj = method.parent
         if obj.dimensions:
-            out(f'int _flat_index = {tname}.id.encoded_index;\n')
+            out(f'uint32 _flat_index = {tname}.id.encoded_index;\n')
         indices = [
             mkLit(site, '((_flat_index / %d) %% %d)' % (
                 reduce(operator.mul, obj.dimsizes[dim + 1:], 1),
-                obj.dimsizes[dim]), TInt(32, True))
+                obj.dimsizes[dim]), TInt(32, False))
             for dim in range(obj.dimensions)]
         args = [mkLit(site, n, t) for (n, t) in explicit_inargs]
         call_expr = mkcall_method(site, func, indices)(args)


### PR DESCRIPTION
This is to silence GCC when it decides to make warnings based on bad assumptions about the values that an argument may take.

Or at least, that is what I think is going on. Original issue was reported by @gwikland. I have not been able to create a minimal reproducer, which is why this lacks a test.

The seemingly stochastic nature of the issue _does_ terrify me -- making me doubt myself and wondering if the warning is actually based on a concrete usage rather than GCC assuming something to be possible. However, based on an inspection of the generated code, experimentation, and my previous experience of a similarly stupid error (see #204) I've thoroughly convinced myself that no, GCC really _is_ just deciding to be dumb.