### PR TITLE
Add porting rule for `assert 0;`

### DIFF
--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -984,10 +984,15 @@ def as_bool(e):
     if isinstance(t, TBool):
         return e
     elif t.is_int and t.bits == 1:
-        if logging.show_porting and (isinstance(e, NodeRef)
-                                     or isinstance(e, LocalVariable)):
-            report(PBITNEQ(dmlparse.start_site(e.site),
-                           dmlparse.end_site(e.site)))
+        if logging.show_porting:
+            if e.constant:
+                report(PZEROCOND(dmlparse.start_site(e.site),
+                                 dmlparse.end_site(e.site),
+                                 'true' if e.value else 'false'))
+            elif (isinstance(e, NodeRef)
+                  or isinstance(e, LocalVariable)):
+                report(PBITNEQ(dmlparse.start_site(e.site),
+                               dmlparse.end_site(e.site)))
         return mkFlag(e.site, e)
     elif isinstance(t, TPtr):
         return mkNotEquals(e.site, e,

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -2346,6 +2346,11 @@ class PBITNEQ(PortingMessage):
     field values are 64 bit, and thus require an explicit `!= 0`"""
     fmt = ""
 
+class PZEROCOND(PortingMessage):
+    """DML 1.2 permits using the literals `0` and `1` as booleans. In DML 1.4,
+    this should be replaced with `false` and `true`, respectively"""
+    fmt = ""
+
 class PVAL(PortingMessage):
     """The value of a `register`, `field` or `attribute`
     object, and the interface struct of a `interface` object, is now

--- a/test/1.2/misc/porting.dml
+++ b/test/1.2/misc/porting.dml
@@ -393,6 +393,8 @@ event ev2 is (evt) {
     parameter timebase = "seconds";
 }
 
+parameter zero = 0;
+
 method init() {
     local int1 i1;
 
@@ -427,5 +429,10 @@ method init() {
         if (!$c.signal.signal_lower) {
             $c.signal.signal_raise();
         }
+    }
+    if (1) {
+        assert $zero;
+    } else {
+        assert 0;
     }
 }

--- a/test/1.4/misc/porting.dml
+++ b/test/1.4/misc/porting.dml
@@ -418,6 +418,8 @@ template evt is event {
 event ev2 is (custom_time_event, evt) {
 }
 
+param zero = 0;
+
 method init() {
     local uint1 i1;
 
@@ -454,5 +456,10 @@ method init() {
         if (!c.signal.signal_lower) {
             c.signal.signal_raise();
         }
+    }
+    if (true) {
+        assert zero != 0;
+    } else {
+        assert false;
     }
 }

--- a/test/tests.py
+++ b/test/tests.py
@@ -1388,6 +1388,7 @@ all_tests.append(PortingConvert(
         'PABSTRACT_TEMPLATE',
         'PCHANGE_INARGS',
         'PBITNEQ',
+        'PZEROCOND',
         'PVAL',
         'PNODOLLAR',
         'PDOLLAR_QUALIFY',


### PR DESCRIPTION
This tends to be fairly common in DML 1.2 code
