### PR TITLE
Avoid wrapping constants in multiple layers of InlineParam

### DIFF
--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1742,4 +1742,10 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
       coverage tools. Generated C lines should now only ever be redirected to
       DML when the DML line in question can be reasonably considered to describe
       the operation of the C line. </add-note></build-id>
+  <build-id value="next"><add-note> Fixed an issue where attempting to use
+      inlined method parameters in constant equalities could lead to internal
+      compiler errors or invalid generated C, if the corresponding arguments
+      are themselves constant inlined method parameters (i.e. an inline method
+      call propagates an inline parameter to an inline method call of its own.)
+  </add-note></build-id>
 </rn>

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -4685,6 +4685,8 @@ class InlinedParam(RValue):
 def mkInlinedParam(site, expr, name, type):
     if not defined(expr):
         raise ICE(site, 'undefined parameter')
+    if isinstance(expr, InlinedParam):
+        expr = expr.expr
     if isinstance(expr, IntegerConstant):
         value = expr.value
         type = realtype(type)

--- a/test/1.4/expressions/T_inlined_param.dml
+++ b/test/1.4/expressions/T_inlined_param.dml
@@ -19,6 +19,10 @@ inline method m(inline x, void *y) {
     }
 }
 
+inline method m2(inline x, void *y) {
+    m(x, y);
+}
+
 method init() {
-    m(NULL, NULL);
+    m2(NULL, NULL);
 }


### PR DESCRIPTION
This sometimes triggered errors in the old PCI library
(`update_mapping("I/O")`)
