### PR TITLE
Introduce `Site.linemarked` to suppress line directives for non-method C code

### DIFF
--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -3469,7 +3469,7 @@ def codegen_inline_byname(node, indices, meth_name, inargs, outargs,
     else:
         meth_node = node
 
-    return codegen_inline(meth_node.site, meth_node, indices,
+    return codegen_inline(site, meth_node, indices,
                           inargs, outargs, inhibit_copyin)
 
 intercepted_in_int_reg = {

--- a/py/dml/expr.py
+++ b/py/dml/expr.py
@@ -29,7 +29,7 @@ __all__ = (
 )
 
 def site_linemark_nocoverity(site, adjust=0):
-    if isinstance(site, SimpleSite):
+    if site is None or not site.linemarked:
         return
 
     filename = site.filename()
@@ -68,7 +68,7 @@ def coverity_markers(markers, site=None):
         if dml.globals.linemarks and isinstance(output.current(), FileOutput):
             out('#ifdef __COVERITY__\n')
             reset_line_directive()
-            if site_with_loc:
+            if site is not None and site.linemarked:
                 out('#else\n')
                 site_linemark_nocoverity(site,
                                          adjust=-(len(markers) + 1))
@@ -76,7 +76,7 @@ def coverity_markers(markers, site=None):
         for (event, classification) in markers:
             classification = f' : {classification}' if classification else ''
             out(f'/* coverity[{event}{classification}] */\n')
-    elif site is not None:
+    else:
         site_linemark_nocoverity(site)
 
 

--- a/py/dml/serialize.py
+++ b/py/dml/serialize.py
@@ -112,7 +112,7 @@ def call_c_fun(site, fun, args):
 # serialize current_expr, interpreted as real_type, and assign
 # to target_expr
 def serialize(real_type, current_expr, target_expr):
-    current_site = current_expr.site
+    current_site = unlinemarked_site(current_expr.site)
     def construct_assign_apply(funname, intype):
         apply_expr = apply_c_fun(current_site, funname,
                                  [current_expr], attr_value_t)
@@ -201,7 +201,7 @@ def serialize(real_type, current_expr, target_expr):
 # to target_expr. error_out constructs statements to fail deserialization
 # with a given set_error_t and message.
 def deserialize(real_type, current_expr, target_expr, error_out):
-    current_site = current_expr.site
+    current_site = unlinemarked_site(current_expr.site)
     def construct_assign_apply(attr_typ, intype):
         check_expr = apply_c_fun(current_site, 'SIM_attr_is_' + attr_typ,
                                  [current_expr], TBool())


### PR DESCRIPTION
This is still somewhat of a proof-of-concept -- I haven't looked too closely at where we want to apply this outside of c_backend.