### PR TITLE
1.4:utility.dml: template miss_pattern_bank: Allow method overrides

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -533,4 +533,8 @@
       for <tt>uint64_t</tt> and <tt>int64_t</tt> types from C. These
       types are needed for C interoperability, e.g., calling a function
       that takes an argument of type <tt>uint64_t *</tt>.</add-note></build-id>
+  <build-id _6="next" _7="next"><add-note> The <tt>miss_pattern_bank</tt>
+      template now allows for its implementations of <tt>unmapped_read</tt>,
+      <tt>unmapped_write</tt>, and <tt>unmapped_get</tt> to be
+      overridden. </add-note></build-id>
 </rn>

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1176,9 +1176,10 @@ template function_io_memory {
 
 #### Description
 
-Only valid in `bank` objects. Handles unmapped accesses by
-ignoring write accesses, and returning a given value for each unmapped
-byte.
+Only valid in `bank` objects. Handles unmapped accesses by ignoring write
+accesses, and returning a given value for each unmapped byte. If you want to
+customize this behaviour, overriding `unmapped_get` is sufficient to also
+customize `unmapped_read`.
 
 #### Parameters
 
@@ -1190,13 +1191,14 @@ template miss_pattern_bank is bank {
     param miss_pattern : uint8;
     shared method unmapped_read(uint64 offset, uint64 bits, void *aux)
         -> (uint64) throws default {
-        return this.get(offset, bits);
+        return this.unmapped_get(offset, bits);
     }
-    shared method unmapped_get(uint64 offset, uint64 bits) -> (uint64) throws default {
+    shared method unmapped_get(uint64 offset, uint64 bits)
+        -> (uint64) throws default {
         return miss_pattern * 0x0101010101010101;
     }
     shared method unmapped_write(uint64 offset, uint64 value, uint64 bits,
-                          void *aux) throws default {
+                                 void *aux) throws default {
     }
 }
 

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1189,14 +1189,14 @@ miss\_pattern: each missed byte in a miss read is set to this value
 template miss_pattern_bank is bank {
     param miss_pattern : uint8;
     shared method unmapped_read(uint64 offset, uint64 bits, void *aux)
-        -> (uint64) throws {
-        return miss_pattern * 0x0101010101010101;
+        -> (uint64) throws default {
+        return this.get(offset, bits);
     }
-    shared method unmapped_get(uint64 offset, uint64 bits) -> (uint64) throws {
+    shared method unmapped_get(uint64 offset, uint64 bits) -> (uint64) throws default {
         return miss_pattern * 0x0101010101010101;
     }
     shared method unmapped_write(uint64 offset, uint64 value, uint64 bits,
-                          void *aux) throws {
+                          void *aux) throws default {
     }
 }
 

--- a/test/1.4/lib/T_miss_pattern.dml
+++ b/test/1.4/lib/T_miss_pattern.dml
@@ -44,3 +44,22 @@ bank pb {
     is b;
     param partial = true;
 }
+
+bank override_get is miss_pattern_bank {
+    param miss_pattern = 0xff;
+    method unmapped_get(uint64 offset, uint64 bits) -> (uint64) throws {
+        return 0xdeadbeef & bits;
+    }
+}
+
+bank override_read_write is miss_pattern_bank {
+    param miss_pattern = 0xff;
+    method unmapped_read(uint64 offset, uint64 bits, void *aux)
+        -> (uint64) throws {
+        return 0xdeadbeef & bits;
+    }
+    method unmapped_write(uint64 offset, uint64 bits, uint64 val, void *aux)
+        throws {
+        throw;
+    }
+}


### PR DESCRIPTION
Allow method overrides so models could for instance print out info messages when an unmapped access occurs.