### PR TITLE
Need to run ctree_test.py without decorated ccache

### DIFF
--- a/py/dml/ctree_test.py
+++ b/py/dml/ctree_test.py
@@ -7,6 +7,7 @@ import os
 import sys
 import subprocess
 import math
+import shlex
 from pathlib import Path
 
 from dml import ctree, types, logging, messages, output, symtab
@@ -200,12 +201,12 @@ class GccTests(unittest.TestCase):
         if is_windows():
             exe += '.exe'
         here = Path(__file__).parent
-        gcc_cmd = [os.environ['CC'],
-                   '-I%s' % (os.path.join(base, 'src', 'include')),
-                   f'-I{here}',
-                   f'-I{here.parent.parent / "include"}',
-                   '-O', '-std=gnu11', '-Wall', '-Werror',
-                   '-Wno-int-in-bool-context',  '-o', exe, cfile]
+        gcc_cmd = shlex.split(os.environ['CC'], posix=not is_windows()) + [
+            '-I%s' % (os.path.join(base, 'src', 'include')),
+            f'-I{here}',
+            f'-I{here.parent.parent / "include"}',
+            '-O', '-std=gnu11', '-Wall', '-Werror',
+            '-Wno-int-in-bool-context',  '-o', exe, cfile]
         if is_windows():
             gcc_cmd += [
                 "-DUSE_MODULE_HOST_CONFIG", "-D__USE_MINGW_ANSI_STDIO=1"]


### PR DESCRIPTION
Without this change, PR https://github.com/intel-innersource/applications.simulators.simics.simics-base/pull/4984 ends up with:
```
[Step 8/14] FileNotFoundError: [Errno 2] No such file or directory: ' /disk2/conan_build_deps/6.53/gcc-13.1.0/bin/gcc'
```

Notice the extra space. If CCACHE is set to ccache it's equally bad as ctree_test.py does not split CC into multiple arguments passed to subprocess. The assumption is that CC is an undecorated compiler, and this PR does that by using special CC_NO_CCACHE variable.