### PR TITLE
Make releasenotes display consistently

### DIFF
--- a/RELEASENOTES-1.2.docu
+++ b/RELEASENOTES-1.2.docu
@@ -6,8 +6,8 @@
 <rn id="dml-1.2">
   <name>Device Modeling Language (DML) 1.2</name>
   <build-id value="6012"><add-note> Fixed a bug that caused a crash on the
-    expression
-    <tt>1 &lt;&lt; 64</tt> <bug number="1306575446"/>. </add-note></build-id>
+    expression <tt>1 &lt;&lt; 64</tt>
+    <bug number="HSD-1306575446"/>.</add-note></build-id>
   <build-id value="6018"><add-note> The <tt>read</tt> and <tt>write</tt>
     templates have been moved from
     utility.dml to always be included into 1.2 DML files. Additionally
@@ -23,7 +23,7 @@
     changed: If the path
     starts with <tt>./</tt>, the path is now interpreted relative to
     the directory of the importing file
-    <bug number="2209506845"/>. </add-note></build-id>
+    <bug number="HSD-2209506845"/>. </add-note></build-id>
   <build-id value="6024"><add-note> Fixed a bug that caused a bad warning and
     incorrect code when
     the operand to <tt>sizeof</tt> is an identifier that can be
@@ -49,7 +49,7 @@
   <build-id value="6031"><add-note> Fixed a bug in nested <tt>foreach</tt>
     loops when traversing
     register arrays inside bank arrays
-    <bug number="1809370911"/>. </add-note></build-id>
+    <bug number="HSD-1809370911"/>. </add-note></build-id>
   <build-id value="6036"><add-note> It is now permitted to use the
     <tt>nothrow</tt> annotation on a
     method override even if the overridden method does not. This is
@@ -96,30 +96,31 @@
   <build-id value="6054"><add-note>Fixed a crash on methods marked
     <tt>nothrow</tt> and
     multiple return arguments, returning a typed template or struct type
-    <bug number="18012036595"/>. </add-note></build-id>
+    <bug number="HSD-18012036595"/>. </add-note></build-id>
   <build-id value="6054"><add-note>The file <tt>dml12-compatibility.dml</tt>
     now adds a
     parameter <tt>val</tt> to <tt>field</tt> objects. </add-note></build-id>
   <build-id value="6059"><add-note>Unmapped registers names are now properly
     anonymized according
     to _confidentiality
-    <bug number="1508117636"/>. </add-note></build-id>
+    <bug number="HSD-1508117636"/>. </add-note></build-id>
   <build-id value="6066"><add-note> Fixed a regression in use cases where
     <tt>if</tt> has a
     constant condition, and the taken branch consists of a variable
     declaration. I.e., if the code <tt>if (true) local int x;</tt>
     appears in a scope, then the variable <tt>x</tt> is now added to
-    that scope <bug number="18013028128"/>. </add-note></build-id>
+    that scope <bug number="HSD-18013028128"/>. </add-note></build-id>
   <build-id value="6079"><add-note> If a <tt>static</tt> variable is
     declared within a method declared under an object array, it will
     now result in a separate instance of the variable for each
-    instance of the containing object.
+    instance of the containing object
     <bug number="SIMICS-13738"/>. </add-note></build-id>
   <build-id value="6082"><add-note> It is no longer possible to
       override the <tt>loggroup</tt> parameter inside a <tt>group</tt>
       object. </add-note></build-id>
   <build-id value="6082"><add-note> Added documentation of the <tt>nothrow</tt>
-      annotation for methods <bug number="18012035545"/>. </add-note></build-id>
+      annotation for methods
+      <bug number="HSD-18012035545"/>. </add-note></build-id>
   <build-id value="6096"><add-note> Fixed a compile error when a DML
       1.2 device imports a DML 1.4 file that declares a <tt>saved</tt>
       variable inside a register or field
@@ -129,7 +130,7 @@
       <bug number="SIMICS-17308"/>. </add-note></build-id>
   <build-id value="6122"><add-note> Added the <tt>--state-change-dml12</tt>
       flag, allowing the use of an incomplete version of state change notifiers
-      in DML 1.2 devices<bug number="SIMICS-17952"/>.</add-note></build-id>
+      in DML 1.2 devices <bug number="SIMICS-17952"/>.</add-note></build-id>
   <build-id value="6124"><add-note> Fixed an issue when using the
       <tt>--state-change-dml12</tt> flag together with the
       <tt>--split-c-file</tt> flag

--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -50,7 +50,7 @@
     changed: If the path
     starts with <tt>./</tt> or <tt>../</tt>, the path is now
     interpreted relative to the directory of the importing file
-    <bug number="2209506845"/>. </add-note></build-id>
+    <bug number="HSD-2209506845"/>. </add-note></build-id>
   <build-id value="6024"><add-note> Fixed a problem where parameters defined in
     global scope in DML
     1.4 (typically auto-converted from a DML 1.2 <tt>constant</tt>)
@@ -89,7 +89,7 @@
   <build-id value="6046"><add-note> In <tt>switch</tt> statements,
     <tt>case</tt> labels are now
     permitted inside <tt>#if</tt> blocks
-    <bug number="14011267833"/>. </add-note></build-id>
+    <bug number="HSD-14011267833"/>. </add-note></build-id>
   <build-id value="6046"><add-note> Fixed an issue where the <tt>++</tt> and
     <tt>--</tt> operators could not
     be applied to pointers. </add-note></build-id>
@@ -163,17 +163,17 @@
   <build-id value="6079"><add-note> <tt>saved</tt> variable
     declarations are now available. These can be used to declare
     variables that behave similarly to <tt>session</tt> variables,
-    but that are automatically checkpointed.
+    but that are automatically checkpointed
     <bug number="SIMICS-7031"/>. </add-note></build-id>
   <build-id value="6079"><add-note> If a <tt>static</tt> variable is
     declared within a method declared under an object array, it will
     now result in a separate instance of the variable for each
-    instance of the containing object.
+    instance of the containing object
     <bug number="SIMICS-13738"/>. </add-note></build-id>
   <build-id value="6079"><add-note> Fixed a bug that caused a crash
       in <tt>print-device-regs</tt> and related commands, when
       inspecting a function-mapped bank array in a DML 1.4 device
-      <bug number="1508646546"/>.</add-note></build-id>
+      <bug number="HSD-1508646546"/>.</add-note></build-id>
   <build-id value="6080"><add-note> If a method argument has mismatching
       type in an override, then an error will now be
       reported <bug number="SIMICS-9337"/>.</add-note></build-id>
@@ -282,7 +282,7 @@
       </pre></add-note></build-id>
   <build-id value="6143"><add-note>Added an optimization that
       reduces the compile time for devices with huge register arrays
-      <bug number="SIMICS-7038"/> </add-note></build-id>
+      <bug number="SIMICS-7038"/>.</add-note></build-id>
   <build-id value="6143"><add-note> Added support for cancelling events posted
       via <tt>after</tt> statement through the use of the
       <tt>cancel_after()</tt> method, provided as part of the <tt>object</tt>
@@ -294,7 +294,7 @@
   <build-id value="6147"><add-note> When declaring an object array, any
       dimension size specification may now be omitted if already defined through
       a different declaration of the same object array
-      <bug number="22014423596"/>. Omission is done by specifying <tt>...</tt>
+      <bug number="HSD-22014423596"/>. Omission is done by specifying <tt>...</tt>
       instead of the dimension size; for example, the following is now
       supported:
       <pre>
@@ -368,7 +368,7 @@
       suppress logging.</add-note></build-id>
   <build-id value="6177"><add-note>Removed the generation of some
       broken <tt>#line</tt> directives that caused problems in code
-      coverage reports <bug number="18024044100"/>.</add-note></build-id>
+      coverage reports <bug number="HSD-18024044100"/>.</add-note></build-id>
   <build-id value="6177"><add-note>When using designated initializers, partial
       initialization is now possible through trailing <tt>...</tt> syntax
       <bug number="SIMICS-18705"/>. Members not explicitly initialized are
@@ -439,18 +439,18 @@
   <build-id value="6195"><add-note>Fixed Windows-specific gcc compile
       error on DMLC-generated code, caused by name clashes with
       the <tt>interface</tt> macro, defined by <tt>windows.h</tt>
-      <bug number="15012582368"/>.</add-note></build-id>
+      <bug number="HSD-15012582368"/>.</add-note></build-id>
   <build-id value="6200"><add-note>Fixed a bug in <tt>saved</tt>
       variables that caused stack overflow during checkpoint restore
       for huge (multi-megabyte) struct types
-      <bug number="18026246959"/>.</add-note></build-id>
+      <bug number="HSD-18026246959"/>.</add-note></build-id>
   <build-id value="6205"><add-note> <tt>--coverity</tt> has been added as an
       option to DMLC. When used, DMLC will generate Synopsys® Coverity® analysis
       annotations to suppress common false positives in generated C code created
       from DML 1.4 devices.</add-note></build-id>
   <build-id value="6205"><add-note> Fixed an ICE caused by constant inlined
       method parameters being used in constant equalities
-      <bug number="16019548195"/>.</add-note></build-id>
+      <bug number="HSD-16019548195"/>.</add-note></build-id>
   <build-id value="6205"><add-note> Fixed an issue with debuggable compilation
       (<tt>-g</tt>) that caused <tt>inline</tt> method calls to inline constant
       arguments even for parameters not declared <tt>inline</tt>

--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -454,7 +454,7 @@
   <build-id value="6205"><add-note> Fixed an issue with debuggable compilation
       (<tt>-g</tt>) that caused <tt>inline</tt> method calls to inline constant
       arguments even for parameters not declared <tt>inline</tt>
-      <bug number="16019548195"/>.</add-note></build-id>
+      <bug number="HSD-16019548195"/>.</add-note></build-id>
   <build-id value="6213"><add-note> Compound initializer syntax can now be used
       to construct arguments of a method or function call, e.g:
       <pre>

--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1453,7 +1453,7 @@
   <build-id value="6008"><add-note> In the <file>io-memory.dml</file> standard
     library file,
     the <fun>operation</fun> method is now marked <tt>default</tt>
-    <bug number="1507149841"/>. </add-note></build-id>
+    <bug number="HSD-1507149841"/>. </add-note></build-id>
   <build-id value="6008"><add-note> A new parameter <tt>dml_1_2</tt> has been
     added to device
     scope. The parameter is true, but will be false in future
@@ -1472,7 +1472,7 @@
     attribute <tt><v>bank</v>_<v>attr</v></tt> in the device upon
     object creation. Previously, required attributes had to be set
     directly on the bank object
-    <bug number="2207518293"/>. </add-note></build-id>
+    <bug number="HSD-2207518293"/>. </add-note></build-id>
   <build-id value="6012"><add-note> Initial release of DML version 1.4. The new
     language version is
     documented in the <em>DML 1.4 reference manual</em>
@@ -1522,7 +1522,7 @@
   <build-id value="6028"><add-note> Add support to <tt>header</tt> sections for
     including a <tt>.h</tt>
     file relative to the currently imported DML file
-    <bug number="2209645860"/>. </add-note></build-id>
+    <bug number="HSD-2209645860"/>. </add-note></build-id>
   <build-id value="6030"><add-note> Fixed a bug where the
     <tt>DMLDIR_<v>&lt;name&gt;</v>_H</tt> macro was
     undefined when generating dependency files. </add-note></build-id>
@@ -1613,7 +1613,7 @@
     parameter of the register or attribute. </add-note></build-id>
   <build-id value="6075"><add-note> Fixed a bug that could cause a segmentation
       fault when instantiating a device with register arrays following
-      certain patterns <bug number="1508585437"/>.</add-note></build-id>
+      certain patterns <bug number="HSD-1508585437"/>.</add-note></build-id>
   <build-id value="6079"><add-note> If an array of <tt>connect</tt>
     objects is declared
     as <tt>configuration=optional</tt>, then it is now permitted to
@@ -1677,7 +1677,7 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
       path. </add-note></build-id>
   <build-id value="6132"><add-note> Fixed a problem with `log error`
       statements when there are more than 32 log groups
-      <bug number="1305472692"/>. </add-note></build-id>
+      <bug number="HSD-1305472692"/>. </add-note></build-id>
   <build-id value="6132"><add-note> Unicode BiDi control characters
       are no longer permitted in DML source files, for security
       reasons. </add-note></build-id>
@@ -1698,7 +1698,7 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
       </pre></add-note></build-id>
   <build-id value="6141"><add-note> <tt>break</tt> may now be used within
       <tt>foreach</tt> statements in DML 1.2 and <tt>#foreach</tt> statements in
-      DML 1.4 <bug number="1309451301"/>.
+      DML 1.4 <bug number="HSD-1309451301"/>.
   </add-note></build-id>
   <build-id value="6143"><add-note> (Partially) const-qualified <tt>session</tt>
       variables no longer result in invalid generated C
@@ -1726,7 +1726,7 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
   </add-note></build-id>
   <build-id value="6247"><add-note> Added a warning for if a specified log
       level of a log statement is likely intended to instead specify the log
-      groups, and/or vice versa <bug number="22018374443"/>.
+      groups, and/or vice versa <bug number="HSD-22018374443"/>.
       This warning is only enabled by default with Simics API version 7 or
       above. With version 6 and below it must be explicitly enabled by passing
       <tt>--warn=WLOGMIXUP</tt> to DMLC.</add-note></build-id>


### PR DESCRIPTION
In particular, use prefix for the tracker-system, always a space before the
bug-tag, as well as no dot before the tag but after - SIMICS-21408.
