### PR TITLE
Make global device/hook lists available only during code generation

### DIFF
--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -3656,7 +3656,7 @@ the [`shown_desc`](#shown_desc) template.
 template event is (object, shown_desc) {
     // hack: using double pointer here, since the automatic initialization of
     // the evclass pointer happens after vtables are initialized
-    param _pevclass : event_class_t **;
+    param _pevclass : event_class_t *const*;
     param _pevclass = &evclass;
     param objtype = "event";
     param _is_simics_object = false;

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -2124,14 +2124,8 @@ def generate_port_object_assocs_array():
                        else node.object_parent)
         if (object_node is not dml.globals.device
             # Anonymous banks
-            and not (compat.dml12_misc in dml.globals.enabled_compat
-                     and object_node.ident is None)
-            # HACK compile errors may lead to .name of nodes never being set.
-            # This issue has proven difficult to fix due to multiple technical
-            # debts, most egregiously that the various uses of
-            # dml.globals.objects and dml.globals.hooks don't properly take
-            # into account the possibility of objects becoming rejected
-            and object_node.name is not None):
+            and (compat.dml12_misc not in dml.globals.enabled_compat
+                 or object_node.ident is not None)):
             port_obj_offset = (
                 f'offsetof({crep.structtype(dml.globals.device)}, '
                 + f'{crep.cref_portobj(object_node, ())})')

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -1238,7 +1238,7 @@ def generate_simple_events_control_methods(device):
 
     site = logging.SimpleSite('<_cancel_simple_events>')
     by_dims = {}
-    for hook in dml.globals.hooks:
+    for hook in objects.Device.hooks:
         by_dims.setdefault(hook.dimsizes, []).append(hook)
 
     for (dims, hooks) in by_dims.items():
@@ -1474,8 +1474,8 @@ def generate_identity_data_decls():
                                  'HT_STR_NULL(false)')
 
     declare_id_infos(objects.Device.objects, '')
-    if dml.globals.hooks:
-        declare_id_infos(dml.globals.hooks, '_hook')
+    if objects.Device.hooks:
+        declare_id_infos(objects.Device.hooks, '_hook')
 
 def generate_class_var_decl():
     add_variable_declaration('conf_class_t *_dev_class')
@@ -1493,8 +1493,8 @@ def generate_init_identity_hashtable():
         postindent=1)
     out('ht_insert_str(&_id_info_ht, _id_infos[i].logname, &_id_infos[i]);\n')
     out('}\n', preindent=-1)
-    if dml.globals.hooks:
-        out('for (uint64 i = 0; i < %d; ++i) {\n' % (len(dml.globals.hooks),),
+    if objects.Device.hooks:
+        out('for (uint64 i = 0; i < %d; ++i) {\n' % (len(objects.Device.hooks),),
             postindent=1)
         out('ht_insert_str(&_hook_id_info_ht, _hook_id_infos[i].logname, '
             + '&_hook_id_infos[i]);\n')
@@ -1504,7 +1504,7 @@ def generate_init_identity_hashtable():
 
 def generate_hook_auxiliary_info_array():
     items = []
-    for hook in dml.globals.hooks:
+    for hook in objects.Device.hooks:
         offset = ('offsetof(%s, %s)'
                   % (crep.structtype(dml.globals.device),
                      crep.cref_hook(
@@ -1517,11 +1517,11 @@ def generate_hook_auxiliary_info_array():
             items.append('{%s, %d, %d}' % (offset, typeseq_uniq, hook.uniq))
         except DMLUnkeyableType:
             pass # already reported
-    if dml.globals.hooks:
+    if objects.Device.hooks:
         init = '{\n%s\n}' % (',\n'.join(f'    {item}' for item in items),)
         add_variable_declaration(
             'const _dml_hook_aux_info_t '
-            + f'_hook_aux_infos[{len(dml.globals.hooks)}]',
+            + f'_hook_aux_infos[{len(objects.Device.hooks)}]',
             init)
 
 def generate_alloc(device):
@@ -1665,7 +1665,7 @@ def generate_deinit(device):
 
         # Cancel all pending afters on hooks
         by_dims = {}
-        for hook in dml.globals.hooks:
+        for hook in objects.Device.hooks:
             by_dims.setdefault(hook.dimsizes, []).append(hook)
 
         for (dims, hooks) in by_dims.items():
@@ -2975,7 +2975,7 @@ def register_hook_attributes(initcode, dev):
 
 
 def generate_hook_attribute_funs():
-    if not dml.globals.hooks:
+    if not objects.Device.hooks:
         return
 
     start_function_definition(

--- a/py/dml/globals.py
+++ b/py/dml/globals.py
@@ -28,8 +28,6 @@ api_version = None
 # This is a tuple (major, minor)
 dml_version = None
 
-# Array of all declared composite objects
-objects = []
 
 # Array of all declared hooks
 hooks = []

--- a/py/dml/globals.py
+++ b/py/dml/globals.py
@@ -29,9 +29,6 @@ api_version = None
 dml_version = None
 
 
-# Array of all declared hooks
-hooks = []
-
 # Array of all session/saved variables declared in methods, represented by
 # pairs (Symbol, init) where init is str or None
 static_vars = []

--- a/py/dml/objects.py
+++ b/py/dml/objects.py
@@ -136,7 +136,7 @@ class DMLObject(object):
         """Return the qualified DML identity of the object, relative to
         nearest ancestor of type 'relative'
 
-        The DML identity of an object is how it would be reffered to
+        The DML identity of an object is how it would be referred to
         within DML code.
         Roughly speaking, objectref(node.identity()) == node."""
         ident = self.ident

--- a/py/dml/serialize.py
+++ b/py/dml/serialize.py
@@ -5,6 +5,7 @@
 # dml values and attribute values
 
 from . import ctree, expr, types, logging, symtab, messages, output, logging
+from . import objects
 from .types import *
 from .logging import *
 from .expr_util import *
@@ -184,7 +185,7 @@ def serialize(real_type, current_expr, target_expr):
                                        ctree.ExpressionInitializer(apply_expr))
     elif isinstance(real_type, THook):
         id_infos = expr.mkLit(current_site,
-                              '_hook_id_infos' if dml.globals.hooks
+                              '_hook_id_infos' if objects.Device.hooks
                               else 'NULL',
                               TPtr(TNamed('_id_info_t', const = True)))
         apply_expr = apply_c_fun(current_site, "_serialize_identity",
@@ -311,11 +312,11 @@ def deserialize(real_type, current_expr, target_expr, error_out):
     elif isinstance(real_type, THook):
         id_info_ht = expr.mkLit(current_site,
                                 '&_hook_id_info_ht'
-                                if dml.globals.hooks else 'NULL',
+                                if objects.Device.hooks else 'NULL',
                                 TPtr(TNamed('ht_str_table_t')))
         hook_aux_infos = expr.mkLit(current_site,
                                     '_hook_aux_infos'
-                                    if dml.globals.hooks else 'NULL',
+                                    if objects.Device.hooks else 'NULL',
                                     TPtr(const_void))
         from .codegen import get_type_sequence_info
         expected_typ_uniq = ctree.mkIntegerConstant(

--- a/py/dml/traits_test.py
+++ b/py/dml/traits_test.py
@@ -31,13 +31,14 @@ class Test_traits(unittest.TestCase):
         t = Trait(None, 't', set(), {}, {}, {}, {}, {}, {}, {})
         ot = ObjTraits(self.dev, {t}, {}, {}, {})
         self.dev.set_traits(ot)
-        self.assertEqual(
-            dml.ctree.mkCast(
-                self.site, dml.ctree.mkNodeRef(self.site, self.dev, ()),
-                t.type()).read(),
-            '((t) {(&_tr__dev__t), '
-            + '((_identity_t) {.id = 1, .encoded_index = 0})})'
-            )
+        with self.dev.use_for_codegen():
+            self.assertEqual(
+                dml.ctree.mkCast(
+                    self.site, dml.ctree.mkNodeRef(self.site, self.dev, ()),
+                    t.type()).read(),
+                '((t) {(&_tr__dev__t), '
+                + '((_identity_t) {.id = 1, .encoded_index = 0})})'
+                )
 
     def test_one_default_method(self):
         body = dml.ast.compound(self.site, [], self.site)
@@ -50,5 +51,5 @@ class Test_traits(unittest.TestCase):
         ref = ot.lookup_shared_method_impl(self.site, 'm', ())
         self.assertTrue(ref)
         # does not crash
-        with crep.DeviceInstanceContext():
+        with crep.DeviceInstanceContext(), self.dev.use_for_codegen():
             ref.call_expr([], types.TVoid()).read()

--- a/test/1.4/legacy/T_port_proxy_attrs_disabled.dml
+++ b/test/1.4/legacy/T_port_proxy_attrs_disabled.dml
@@ -6,7 +6,6 @@ dml 1.4;
 
 device test;
 
-/// DMLC-FLAG --simics-api=6
 /// DMLC-FLAG --no-compat=port_proxy_attrs
 
 import "port_proxy_attrs.dml";

--- a/test/1.4/legacy/T_port_proxy_ifaces_disabled.dml
+++ b/test/1.4/legacy/T_port_proxy_ifaces_disabled.dml
@@ -6,7 +6,6 @@ dml 1.4;
 
 device test;
 
-/// DMLC-FLAG --simics-api=6
 /// DMLC-FLAG --no-compat=port_proxy_ifaces
 
 import "port_proxy_ifaces.dml";


### PR DESCRIPTION
- Fix spelling
- Remove redundant flag
- Make global device list available only during code generation
- Make global hook list available only during code generation
- Only worry about None names in obsolete DML
