### PR TITLE
Don't transform empty compounds to `;`

### DIFF
--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -3160,7 +3160,7 @@ def foreach_constant_list(site, itername, lst, statement, location, scope):
                 itername, items.expr(loopvars), site))
             stmt = codegen_statement(statement, location, loopscope)
 
-            if isinstance(stmt, Null):
+            if stmt.is_empty:
                 continue
 
             decls = []

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -336,13 +336,14 @@ class Compound(Statement):
 
     def toc_stmt(self):
         self.linemark()
-        if self.is_empty:
-            out(';\n')
-        else:
-            out('{\n', postindent=1)
-            self.toc_inline()
-            site_linemark(self.rbrace_site)
-            out('}\n', preindent=-1)
+        out('{\n', postindent=1)
+        self.toc_inline()
+        site_linemark(self.rbrace_site)
+        out('}\n', preindent=-1)
+
+    @property
+    def is_empty(self):
+        return all(stmt.is_empty for stmt in self.substatements)
 
     def toc(self):
         if any(sub.is_declaration for sub in self.substatements):
@@ -375,10 +376,8 @@ def mkCompound(site, statements, rbrace_site=None):
             collapsed.append(stmt)
     if len(collapsed) == 1 and not collapsed[0].is_declaration:
         return collapsed[0]
-    elif collapsed:
-        return Compound(site, collapsed, rbrace_site)
     else:
-        return mkNull(site)
+        return Compound(site, collapsed, rbrace_site)
 
 class Null(Statement):
     is_empty = True
@@ -409,13 +408,10 @@ class UnrolledLoop(Statement):
 
     def toc_stmt(self):
         self.linemark()
-        if all(sub.is_empty for sub in self.substatements):
-            out(';\n')
-        else:
-            out('{\n', postindent=1)
-            self.toc_inline()
-            self.linemark()
-            out('}\n', preindent=-1)
+        out('{\n', postindent=1)
+        self.toc_inline()
+        self.linemark()
+        out('}\n', preindent=-1)
 
     def toc(self):
         for substatement in self.substatements:

--- a/py/dml/ctree_test.py
+++ b/py/dml/ctree_test.py
@@ -56,7 +56,7 @@ class Test_mkcompound(unittest.TestCase):
         n = ctree.mkNull(s)
         d = DummyStatement(s)
         decl = DummyDecl(s)
-        expect_repr(mkCompound(s, []), 'Null()')
+        expect_repr(mkCompound(s, []), 'Compound([])')
         expect_repr(mkCompound(s, [d]), 'D')
         expect_repr(mkCompound(s, [d, d]), 'Compound([D, D])')
         # Shallowly nested compounds are collapsed

--- a/test/1.4/misc/linemarks.dml
+++ b/test/1.4/misc/linemarks.dml
@@ -270,10 +270,7 @@ method test_brace_linemarks()
     // NOT-LINEMARKED
     {
         if (true)
-        // .toc_stmt() of empty braces emits ';', which gets linemarked to the
-        // leading brace
         {
-            // NOT-LINEMARKED
         }
     // NOT-LINEMARKED
     }


### PR DESCRIPTION
This matters for Coverity's `STRAY_SEMICOLON` checker. We didn't notice this before as `If.toc()` always used to emit braces.

@JonatanWaern You have to be the reviewer now as Erik's on vacation.