### PR TITLE
Store all permutations in a global shared array, so that one 32-bit index per register is sufficient.

### DIFF
--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -2877,70 +2877,58 @@ template register is (_conf_attribute, get, set, shown_desc,
         return (n, unmapped);
     }
 
-    // fills in the passed array with all fields in this register, and returns
-    // the number of elements and a bitmask showing bits not covered by fields.
-    shared independent startup memoized method _get_write_fields()
-        -> (int, const _write_field *, uint64) /* n, fields, unmapped */ {
-        local _write_field fields[64];
-        local uint64 unmapped;
-        unmapped[this.bitsize-1:0] = -1;
-        local int n = 0;
-        // TODO: it is inefficient to re-generate the field list each call
-        foreach f in (this._write_fields) {
-            local int lsb = f.lsb;
+    shared independent method _sort_permutation(const uint8 *keys, int n)
+        -> (uint8 *) {
+        assert n <= 64;
+        local uint8 sorted[n];
+        local uint8 idx[n];
+        local uint8 perm[n];
+        for (local int i = 0; i < n; i++) {
+            local int lsb = keys[i];
             // sort 'fields' by lsb
-            local int i;
-            for (i = n; i > 0; --i) {
-                local int next_lsb = fields[i - 1].lsb;
+            local int j;
+            for (j = i; j > 0; --j) {
+                local int next_lsb = sorted[j - 1];
                 if (next_lsb > lsb) {
-                    fields[i] = fields[i - 1];
+                    sorted[j] = sorted[j - 1];
+                    idx[j] = idx[j - 1];
+                    perm[idx[j]] += 1;
                 } else {
                     break;
                 }
             }
-            fields[i] = f;
-            unmapped[lsb + f.bitsize - 1 : lsb] = 0;
-            ++n;
+            sorted[j] = lsb;
+            idx[j] = i;
+            perm[i] = j;// | 0x80;
         }
-        assert n <= 64;
-        local _write_field *ret = new _write_field[n];
+        local uint8 *ret = new uint8[n];
         for (local int i = 0; i < n; i++) {
-            ret[i] = fields[i];
+            ret[i] = perm[i];
         }
-        return (n, ret, unmapped);
+        return ret;
     }
 
-    // fills in the passed array with all fields in this register, and returns
-    // the number of elements and a bitmask showing bits not covered by fields.
-    shared independent startup memoized method _get_read_fields()
-        -> (int, const _read_field *, uint64) /* n, fields, unmapped */ {
-        local _read_field fields[64];
-        local uint64 unmapped;
-        unmapped[this.bitsize-1:0] = -1;
+    // returns how to permute `_write_fields` to order it by lsb
+    shared independent startup memoized method _get_write_fields()
+        -> (uint8 *) {
+        local uint8 lsbs[64];
         local int n = 0;
-        // TODO: it is inefficient to re-generate the field list each call
-        foreach f in (this._read_fields) {
-            local int lsb = f.lsb;
-            // sort 'fields' by lsb
-            local int i;
-            for (i = n; i > 0; --i) {
-                local int next_lsb = fields[i - 1].lsb;
-                if (next_lsb > lsb) {
-                    fields[i] = fields[i - 1];
-                } else {
-                    break;
-                }
-            }
-            fields[i] = f;
-            unmapped[lsb + f.bitsize - 1 : lsb] = 0;
+        foreach f in (this._write_fields) {
+            lsbs[n] = f.lsb;
             ++n;
         }
-        assert n <= 64;
-        local _read_field *ret = new _read_field[n];
-        for (local int i = 0; i < n; i++) {
-            ret[i] = fields[i];
+        return _sort_permutation(lsbs, n);
+    }
+
+    // returns how to permute `_write_fields` to order it by lsb
+    shared independent startup memoized method _get_read_fields() -> (uint8 *) {
+        local uint8 lsbs[64];
+        local int n = 0;
+        foreach f in (this._read_fields) {
+            lsbs[n] = f.lsb;
+            ++n;
         }
-        return (n, ret, unmapped);
+        return _sort_permutation(lsbs, n);
     }
 
     // Reset register to init_val, except bits covered by fields. Only intended
@@ -2969,22 +2957,31 @@ template register is (_conf_attribute, get, set, shown_desc,
            // if no fields, then default is to return the value
            return val & enabled_bytes;
         }
-        local int num_fields;
-        local const _read_field *fields;
-        local uint64 unmapped;
-        (num_fields, fields, unmapped) = this._get_read_fields();
+        local _read_field fields[64];
+        local uint8 lsbs[64];
+        local uint8 msbs[64];
+        local uint8 *perm = this._get_read_fields();
+        local uint64 unmapped = 0;
+        unmapped[this.bitsize-1:0] = -1;
+        local int num_fields = 0;
+        foreach f in (this._read_fields) {
+            local int idx = perm[num_fields];
+            fields[idx] = f;
+            lsbs[idx] = f.lsb;
+            msbs[idx] = lsbs[idx] + f.bitsize - 1;
+            unmapped[msbs[idx] : lsbs[idx]] = 0;
+            ++num_fields;
+        }
+
         local uint64 default_access_bits = unmapped & field_bits;
         local uint64 unmapped_bits = unmapped & ~field_bits;
         local uint64 val = (this.val & default_access_bits & enabled_bytes);
 
         local int r_lsb = _enabled_bytes_to_offset(enabled_bytes) * 8;
         for (local int f = 0; f < num_fields; f++) {
-            local int f_lsb = fields[f].lsb;
-            local int f_msb = f_lsb + fields[f].bitsize - 1;
-
-            local uint64 f_enabled_bytes = enabled_bytes[f_msb : f_lsb];
+            local uint64 f_enabled_bytes = enabled_bytes[msbs[f] : lsbs[f]];
             if (f_enabled_bytes != 0) {
-                val[f_msb : f_lsb]
+                val[msbs[f] : lsbs[f]]
                     = fields[f].read_field(f_enabled_bytes,
                                            aux) & f_enabled_bytes;
             }
@@ -3056,10 +3053,21 @@ template register is (_conf_attribute, get, set, shown_desc,
             this.val = (this.val & ~enabled_bytes) | (value & enabled_bytes);
             return;
         }
-        local int num_fields;
-        local const _write_field *fields;
-        local uint64 unmapped;
-        (num_fields, fields, unmapped) = this._get_write_fields();
+        local _write_field fields[64];
+        local uint8 lsbs[64];
+        local uint8 msbs[64];
+        local uint8 *perm = this._get_write_fields();
+        local uint64 unmapped = 0;
+        unmapped[this.bitsize-1:0] = -1;
+        local int num_fields = 0;
+        foreach f in (this._write_fields) {
+            local int idx = perm[num_fields];
+            fields[idx] = f;
+            lsbs[idx] = f.lsb;
+            msbs[idx] = lsbs[idx] + f.bitsize - 1;
+            unmapped[msbs[idx] : lsbs[idx]] = 0;
+            ++num_fields;
+        }
         local uint64 default_write_bits = unmapped & field_bits;
         local uint64 unmapped_bits = unmapped & ~field_bits;
         if (enabled_bytes == 0) {

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -2825,33 +2825,6 @@ template register is (_conf_attribute, get, set, shown_desc,
 
     // fills in the passed array with all fields in this register, and returns
     // the number of elements and a bitmask showing bits not covered by fields.
-    shared method _get_all_fields(field *fields) -> (int, uint64) /* n, unmapped */ {
-        local uint64 unmapped;
-        unmapped[this.bitsize-1:0] = -1;
-        local int n = 0;
-        // TODO: it is inefficient to re-generate the field list each call
-        foreach f in (this.fields) {
-            local int lsb = f.lsb;
-            // sort 'fields' by lsb
-            local int i;
-            for (i = n; i > 0; --i) {
-                local int next_lsb = fields[i - 1].lsb;
-                if (next_lsb > lsb) {
-                    fields[i] = fields[i - 1];
-                } else {
-                    break;
-                }
-            }
-            fields[i] = f;
-            unmapped[lsb + f.bitsize - 1 : lsb] = 0;
-            ++n;
-        }
-        assert n <= 64;
-        return (n, unmapped);
-    }
-
-    // fills in the passed array with all fields in this register, and returns
-    // the number of elements and a bitmask showing bits not covered by fields.
     shared method _get_get_fields(_get_field *fields) -> (int, uint64) /* n, unmapped */ {
         local uint64 unmapped;
         unmapped[this.bitsize-1:0] = -1;

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -72,6 +72,22 @@ extern typedef struct {
     _identity_t id;
 } _traitref_t;
 
+extern typedef struct {} _permutation_helper_t;
+
+extern _permutation_helper_t *_DML_new_permutation_helper(void);
+
+extern void _DML_add_read_permutation(
+    _permutation_helper_t *h, _identity_t id, const char *perm);
+
+extern void _DML_add_write_permutation(_permutation_helper_t *h, _identity_t id,
+                                        const char *perm);
+
+extern int _DML_permutation_index_read(_permutation_helper_t *h, _identity_t id);
+extern int _DML_permutation_index_write(
+    _permutation_helper_t *h, _identity_t id);
+extern const uint8 *_DML_field_permutations(_permutation_helper_t *h);
+extern void _DML_destroy_permutation_table_helper(_permutation_helper_t *helper);
+
 extern bank_callback_handle_t _register_before_read(
     conf_object_t *bank,
     conf_object_t *connection,
@@ -574,6 +590,51 @@ template device {
     method post_init() default {}
 
     method destroy() default { }
+
+    independent startup memoized method _permutation_table_helper()
+        -> (_permutation_helper_t *) {
+        local _permutation_helper_t *h = _DML_new_permutation_helper();
+        foreach reg in (each register in (dev)) {
+            local uint8 lsbs[64];
+            local int n = 0;
+            foreach f in (reg._read_fields) {
+                lsbs[n] = f.lsb;
+                ++n;
+            }
+            _DML_add_read_permutation(h, cast(&reg, _traitref_t *)->id,
+                                      reg._sort_permutation(lsbs, n));
+            n = 0;
+            foreach f in (reg._write_fields) {
+                lsbs[n] = f.lsb;
+                ++n;
+            }
+            _DML_add_write_permutation(h, cast(&reg, _traitref_t *)->id,
+                                       reg._sort_permutation(lsbs, n));
+        }
+        return h;
+    }
+    independent startup memoized method _field_permutation_table()
+        -> (const uint8 *) {
+        return _DML_field_permutations(_permutation_table_helper());
+    }
+    independent method _permutation_index_read(object o)
+        -> (uint32) {
+        return _DML_permutation_index_read(_permutation_table_helper(),
+                                           cast(&o, _traitref_t *)->id);
+    }
+    independent method _permutation_index_write(object o)
+        -> (uint32) {
+        return _DML_permutation_index_write(_permutation_table_helper(),
+                                            cast(&o, _traitref_t *)->id);
+    }
+    independent startup method _cleanup_permutation_table_helper() {
+        foreach reg in (each register in (dev)) {
+            reg._get_read_fields();
+            reg._get_write_fields();
+        }
+        _field_permutation_table();
+        _DML_destroy_permutation_table_helper(_permutation_table_helper());
+    }
 }
 
 /**
@@ -2877,12 +2938,18 @@ template register is (_conf_attribute, get, set, shown_desc,
         return (n, unmapped);
     }
 
+    // given an unordered list of keys, return a list that describes how to
+    // permute the list to make it sorted: index N in the return value says to
+    // what index keys[N] should be moved in order to make the list sorted.
+    // The returned permutation is scrambled by adding 0x80 to every element.
+    // This is to avoid the 0 element: we want the entire permutation to be a C
+    // string so we can use it as the key in a hash table.
     shared independent method _sort_permutation(const uint8 *keys, int n)
-        -> (uint8 *) {
+        -> (char *) {
         assert n <= 64;
         local uint8 sorted[n];
         local uint8 idx[n];
-        local uint8 perm[n];
+        local char perm[n];
         for (local int i = 0; i < n; i++) {
             local int lsb = keys[i];
             // sort 'fields' by lsb
@@ -2899,36 +2966,25 @@ template register is (_conf_attribute, get, set, shown_desc,
             }
             sorted[j] = lsb;
             idx[j] = i;
-            perm[i] = j;// | 0x80;
+            perm[i] = j | 0x80;
         }
-        local uint8 *ret = new uint8[n];
+        local char *ret = new char[n + 1];
         for (local int i = 0; i < n; i++) {
             ret[i] = perm[i];
         }
         return ret;
     }
 
-    // returns how to permute `_write_fields` to order it by lsb
-    shared independent startup memoized method _get_write_fields()
-        -> (uint8 *) {
-        local uint8 lsbs[64];
-        local int n = 0;
-        foreach f in (this._write_fields) {
-            lsbs[n] = f.lsb;
-            ++n;
-        }
-        return _sort_permutation(lsbs, n);
+    // returns how to permute `_read_fields` to order it by lsb
+    shared independent startup memoized method _get_read_fields()
+        -> (int) {
+        return dev._permutation_index_read(cast(this, object));
     }
 
     // returns how to permute `_write_fields` to order it by lsb
-    shared independent startup memoized method _get_read_fields() -> (uint8 *) {
-        local uint8 lsbs[64];
-        local int n = 0;
-        foreach f in (this._read_fields) {
-            lsbs[n] = f.lsb;
-            ++n;
-        }
-        return _sort_permutation(lsbs, n);
+    shared independent startup memoized method _get_write_fields()
+        -> (int) {
+        return dev._permutation_index_write(cast(this, object));
     }
 
     // Reset register to init_val, except bits covered by fields. Only intended
@@ -2960,7 +3016,8 @@ template register is (_conf_attribute, get, set, shown_desc,
         local _read_field fields[64];
         local uint8 lsbs[64];
         local uint8 msbs[64];
-        local uint8 *perm = this._get_read_fields();
+        local const uint8 *perm = dev._field_permutation_table()
+            + this._get_write_fields();
         local uint64 unmapped = 0;
         unmapped[this.bitsize-1:0] = -1;
         local int num_fields = 0;
@@ -3056,7 +3113,8 @@ template register is (_conf_attribute, get, set, shown_desc,
         local _write_field fields[64];
         local uint8 lsbs[64];
         local uint8 msbs[64];
-        local uint8 *perm = this._get_write_fields();
+        local const uint8 *perm = dev._field_permutation_table() +
+            this._get_write_fields();
         local uint64 unmapped = 0;
         unmapped[this.bitsize-1:0] = -1;
         local int num_fields = 0;

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -2879,7 +2879,9 @@ template register is (_conf_attribute, get, set, shown_desc,
 
     // fills in the passed array with all fields in this register, and returns
     // the number of elements and a bitmask showing bits not covered by fields.
-    shared method _get_write_fields(_write_field *fields) -> (int, uint64) /* n, unmapped */ {
+    shared independent startup memoized method _get_write_fields()
+        -> (int, const _write_field *, uint64) /* n, fields, unmapped */ {
+        local _write_field fields[64];
         local uint64 unmapped;
         unmapped[this.bitsize-1:0] = -1;
         local int n = 0;
@@ -2901,12 +2903,18 @@ template register is (_conf_attribute, get, set, shown_desc,
             ++n;
         }
         assert n <= 64;
-        return (n, unmapped);
+        local _write_field *ret = new _write_field[n];
+        for (local int i = 0; i < n; i++) {
+            ret[i] = fields[i];
+        }
+        return (n, ret, unmapped);
     }
 
     // fills in the passed array with all fields in this register, and returns
     // the number of elements and a bitmask showing bits not covered by fields.
-    shared method _get_read_fields(_read_field *fields) -> (int, uint64) /* n, unmapped */ {
+    shared independent startup memoized method _get_read_fields()
+        -> (int, const _read_field *, uint64) /* n, fields, unmapped */ {
+        local _read_field fields[64];
         local uint64 unmapped;
         unmapped[this.bitsize-1:0] = -1;
         local int n = 0;
@@ -2928,7 +2936,11 @@ template register is (_conf_attribute, get, set, shown_desc,
             ++n;
         }
         assert n <= 64;
-        return (n, unmapped);
+        local _read_field *ret = new _read_field[n];
+        for (local int i = 0; i < n; i++) {
+            ret[i] = fields[i];
+        }
+        return (n, ret, unmapped);
     }
 
     // Reset register to init_val, except bits covered by fields. Only intended
@@ -2958,9 +2970,9 @@ template register is (_conf_attribute, get, set, shown_desc,
            return val & enabled_bytes;
         }
         local int num_fields;
-        local _read_field fields[64];
+        local const _read_field *fields;
         local uint64 unmapped;
-        (num_fields, unmapped) = this._get_read_fields(fields);
+        (num_fields, fields, unmapped) = this._get_read_fields();
         local uint64 default_access_bits = unmapped & field_bits;
         local uint64 unmapped_bits = unmapped & ~field_bits;
         local uint64 val = (this.val & default_access_bits & enabled_bytes);
@@ -3045,9 +3057,9 @@ template register is (_conf_attribute, get, set, shown_desc,
             return;
         }
         local int num_fields;
-        local _write_field fields[64];
+        local const _write_field *fields;
         local uint64 unmapped;
-        (num_fields, unmapped) = this._get_write_fields(fields);
+        (num_fields, fields, unmapped) = this._get_write_fields();
         local uint64 default_write_bits = unmapped & field_bits;
         local uint64 unmapped_bits = unmapped & ~field_bits;
         if (enabled_bytes == 0) {


### PR DESCRIPTION
- remove unused method
- Avoid re-calculating read/write field order
- Store field order as permutation indices instead of field references
- Store all permutations in a global shared array, so that one 32-bit index per register is sufficient.
