### PR TITLE
Add DMLC option to not suppress GCC's Wunused for local variables -- SIMICS-21585

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -521,4 +521,14 @@
       This fix is only enabled by default with Simics API version 7 or above.
       With version 6 or below it must be explicitly enabled by passing
       <tt>--no-compat=shared_logs_on_device</tt> to DMLC.</add-note></build-id>
+  <build-id value="next"><add-note> Added the <em>discard reference</em>
+      '<tt>_</tt>' &mdash; a non-value expression which may be used as an assign
+      target in order to explictly discard the result of an evaluated expression
+      or return value of a method call <bug number="SIMICS-21584"/>.
+      Example usage:
+      <pre>
+      _ = any_expression;
+      _ = throwing_method();
+      (_, x, _) = method_with_multiple_return_values();
+      </pre></add-note></build-id>
 </rn>

--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -530,5 +530,11 @@
       _ = any_expression;
       _ = throwing_method();
       (_, x, _) = method_with_multiple_return_values();
-      </pre></add-note></build-id>
+      </pre>
+      For backwards compatibility, declared variables and object members are
+      still allowed to be named '<tt>_</tt>' with Simics API version 6 or below.
+      Any such declaration will <em>shadow</em> the discard reference &mdash;
+      i.e. make it unavailable within the scope that the declaration is
+      accessible. This compatibility feature can be disabled by passing
+      <tt>--no-compat=discard_ref_shadowing</tt> to DMLC.</add-note></build-id>
 </rn>

--- a/doc/1.4/language.md
+++ b/doc/1.4/language.md
@@ -3817,9 +3817,10 @@ The discard reference *`_`* is an expression without any run-time representation
 that may be used as the target of an assignment in order to explicitly discard
 the result of an evaluated expression or return value of a method call.
 
-For backwards compatibility reasons, `_` is not a keyword, but instead behaves
-more closely as a global identifier. What this means is that declared
-identifiers (e.g. local variables) are allowed to shadow it by being named `_`.
+When the compatibility feature `discard_ref_shadowing` is enabled, `_` is not a
+keyword, but instead behaves more closely as a global identifier.
+What this means is that declared identifiers (e.g. local variables) are allowed
+to shadow it by being named `_`.
 
 Example usage:
 ```

--- a/doc/1.4/language.md
+++ b/doc/1.4/language.md
@@ -3808,6 +3808,32 @@ independent method callback(int i, void *aux) {
 }
 ```
 
+### The Discard Reference (`_`)
+```
+_
+```
+
+The discard reference *`_`* is an expression without any run-time representation
+that may be used as the target of an assignment in order to explicitly discard
+the result of an evaluated expression or return value of a method call.
+
+For backwards compatibility reasons, `_` is not a keyword, but instead behaves
+more closely as a global identifier. What this means is that declared
+identifiers (e.g. local variables) are allowed to shadow it by being named `_`.
+
+Example usage:
+```
+// Evaluate an expression and explicitly discard its result.
+// Can be relevant to e.g. suppress Coverity's CHECKED_RETURN checker
+_ = nonthrowing_single_return_method();
+
+// Calls to methods that throw or have multiple return values require a target
+// for each return value. `_` can be used to discard return values not of
+// interest.
+_ = throwing_method();
+(_, x, _) = method_with_multiple_return_values();
+```
+
 ### New Expressions
 
 <pre>

--- a/lib/1.2/dml-builtins.dml
+++ b/lib/1.2/dml-builtins.dml
@@ -211,6 +211,7 @@ template device {
     parameter _compat_port_obj_param auto;
     parameter _compat_io_memory auto;
     parameter _compat_shared_logs_on_device auto;
+    parameter _compat_discard_ref_shadowing auto;
     parameter _compat_dml12_inline auto;
     parameter _compat_dml12_not auto;
     parameter _compat_dml12_goto auto;

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -545,6 +545,7 @@ template device {
     param _compat_port_obj_param auto;
     param _compat_io_memory auto;
     param _compat_shared_logs_on_device auto;
+    param _compat_discard_ref_shadowing auto;
     param _compat_dml12_inline auto;
     param _compat_dml12_not auto;
     param _compat_dml12_goto auto;
@@ -1848,7 +1849,7 @@ template bank is (object, shown_desc) {
     }
 
     shared method _num_registers() -> (uint32) {
-        local (const register *_, uint64 table_size) = _reginfo_table();
+        local (const register *_table, uint64 table_size) = _reginfo_table();
         return table_size;
     }
 

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -2809,7 +2809,7 @@ template register is (_conf_attribute, get, set, shown_desc,
     shared method _size() -> (int) { return this.bitsize / 8; }
     shared method _num_fields() -> (uint32) {
         local uint32 num_fields = 0;
-        foreach f in (fields) {
+        foreach _f in (fields) {
             num_fields++;
         }
         return num_fields;
@@ -2992,7 +2992,6 @@ template register is (_conf_attribute, get, set, shown_desc,
         local uint64 unmapped_bits = unmapped & ~field_bits;
         local uint64 val = (this.val & default_access_bits & enabled_bytes);
 
-        local int r_lsb = _enabled_bytes_to_offset(enabled_bytes) * 8;
         for (local int f = 0; f < num_fields; f++) {
             local int f_lsb = fields[f].lsb;
             local int f_msb = f_lsb + fields[f].bitsize - 1;
@@ -3081,8 +3080,6 @@ template register is (_conf_attribute, get, set, shown_desc,
             return;
         }
 
-        local int r_lsb = _enabled_bytes_to_offset(enabled_bytes) * 8;
-        local int r_msb = _enabled_bytes_to_size(enabled_bytes) * 8 - 1;
         for (local int f = 0; f < num_fields; f++) {
             local int f_lsb = fields[f].lsb;
             local int f_msb = f_lsb + fields[f].bitsize - 1;

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -3122,12 +3122,7 @@ def generate_startup_trait_calls(data, idxvars):
         ref = ObjTraitRef(site, node, trait, indices)
         out(f'_tref = {ref.read()};\n')
         for method in trait_methods:
-            outargs = [mkLit(method.site,
-                             ('*((%s) {0})'
-                              % ((TArray(t, mkIntegerLiteral(method.site, 1))
-                                  .declaration('')),)),
-                             t)
-                       for (_, t) in method.outp]
+            outargs = [mkDiscardRef(method.site) for _ in method.outp]
 
             method_ref = TraitMethodDirect(
                 method.site, mkLit(method.site, '_tref', TTrait(trait)), method)
@@ -3139,12 +3134,7 @@ def generate_startup_trait_calls(data, idxvars):
 def generate_startup_regular_call(method, idxvars):
     site = method.site
     indices = tuple(mkLit(site, idx, TInt(32, False)) for idx in idxvars)
-    outargs = [mkLit(site,
-                     ('*((%s) {0})'
-                      % ((TArray(t, mkIntegerLiteral(site, 1))
-                          .declaration('')),)),
-                     t)
-               for (_, t) in method.outp]
+    outargs = [mkDiscardRef(method.site) for _ in method.outp]
     # startup memoized methods can throw, which is ignored during startup.
     # Memoization of the throw then allows for the user to check whether
     # or not the method did throw during startup by calling the method

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -1148,7 +1148,7 @@ def expr_unop(tree, location, scope):
     elif op == 'post--':  return mkPostDec(tree.site, rh)
     elif op == 'sizeof':
         if (compat.dml12_misc not in dml.globals.enabled_compat
-            and not isinstance(rh, ctree.LValue)):
+            and not rh.addressable):
             raise ERVAL(rh.site, 'sizeof')
         return codegen_sizeof(tree.site, rh)
     elif op == 'defined': return mkBoolConstant(tree.site, True)
@@ -1538,7 +1538,7 @@ def eval_type(asttype, site, location, scope, extern=False, typename=None,
                     etype = expr.node_type
                 else:
                     raise expr.exc()
-            elif (not isinstance(expr, ctree.LValue)
+            elif (not expr.addressable
                   and compat.dml12_misc not in dml.globals.enabled_compat):
                 raise ERVAL(expr.site, 'typeof')
             else:

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -704,9 +704,9 @@ class AfterOnHookIntoMethodInfo(AfterOnHookInfo):
             site, val_expr, targets, error_out_at_index,
             f'deserialization of arguments to {self.method.name}')
         if self.args_type:
-            ctree.mkAssignStatement(site, out_expr,
-                                    ctree.ExpressionInitializer(
-                                        tmp_out_ref)).toc()
+            ctree.AssignStatement(site, out_expr,
+                                  ctree.ExpressionInitializer(
+                                      tmp_out_ref)).toc()
 
     @property
     def args_type(self):
@@ -822,8 +822,8 @@ class AfterOnHookIntoSendNowInfo(AfterOnHookInfo):
                 'deserialization of arguments to a send_now')
 
 
-        ctree.mkAssignStatement(site, out_expr,
-                                ctree.ExpressionInitializer(tmp_out_ref)).toc()
+        ctree.AssignStatement(site, out_expr,
+                              ctree.ExpressionInitializer(tmp_out_ref)).toc()
 
     @property
     def args_type(self):
@@ -2131,8 +2131,8 @@ def make_static_var(site, location, static_sym_type, name, init=None,
         with init_code:
             if deep_const(static_sym_type):
                 coverity_marker('store_writes_const_field', 'FALSE')
-            init.assign_to(mkStaticVariable(site, static_sym),
-                           static_sym_type)
+            out(init.assign_to(mkStaticVariable(site, static_sym).read(),
+                               static_sym_type) + ';\n')
         c_init = init_code.buf
     else:
         c_init = None
@@ -2354,7 +2354,6 @@ def stmt_assign(stmt, location, scope):
     else:
         method_tgts = tgts
 
-    # TODO support multiple assign sources. It should be generalized.
     method_invocation = try_codegen_invocation(site, src_asts, method_tgts,
                                                location, scope)
     if method_invocation:
@@ -2370,19 +2369,26 @@ def stmt_assign(stmt, location, scope):
                            + f'initializer: Expected {src_asts}, got 1'))
             return []
 
-        stmts = []
         lscope = Symtab(scope)
+        init_typ = tgts[-1].ctype()
         init = eval_initializer(
-            site, tgts[-1].ctype(), src_asts[0], location, scope, False)
+            tgts[-1].site, init_typ, src_asts[0], location, scope, False)
 
-        for (i, tgt) in enumerate(reversed(tgts[1:])):
-            name = 'tmp%d' % (i,)
-            sym = lscope.add_variable(
-                name, type=tgt.ctype(), site=tgt.site, init=init, stmt=True)
-            init = ExpressionInitializer(mkLocalVariable(tgt.site, sym))
-            stmts.extend([sym_declaration(sym),
-                          mkAssignStatement(tgt.site, tgt, init)])
-        return stmts + [mkAssignStatement(tgts[0].site, tgts[0], init)]
+        if len(tgts) == 1:
+            return [mkAssignStatement(tgts[0].site, tgts[0], init)]
+
+        sym = lscope.add_variable(
+            'tmp', type=init_typ, site=init.site, init=init,
+            stmt=True)
+        init_expr = mkLocalVariable(init.site, sym)
+        stmts = [sym_declaration(sym)]
+        for tgt in reversed(tgts[1:]):
+            stmts.append(mkCopyData(tgt.site, init_expr, tgt))
+            init_expr = (tgt if isinstance(tgt, NonValue)
+                         else source_for_assignment(tgt.site, tgt.ctype(),
+                                                    init_expr))
+        stmts.append(mkCopyData(tgts[0].site, init_expr, tgts[0]))
+        return [mkCompound(site, stmts)]
     else:
         # Guaranteed by grammar
         assert tgt_ast.kind == 'assign_target_tuple' and len(tgts) > 1
@@ -2409,43 +2415,51 @@ def stmt_assign(stmt, location, scope):
                     stmt=True)
             syms.append(sym)
 
-        stmts.extend(map(sym_declaration, syms))
+        stmts.extend(sym_declaration(sym) for sym in syms)
         stmts.extend(
-            mkAssignStatement(
-                tgt.site, tgt, ExpressionInitializer(mkLocalVariable(tgt.site,
-                                                                     sym)))
+            AssignStatement(
+                tgt.site, tgt,
+                ExpressionInitializer(mkLocalVariable(tgt.site, sym)))
             for (tgt, sym) in zip(tgts, syms))
-        return stmts
+        return [mkCompound(site, stmts)]
 
 @statement_dispatcher
 def stmt_assignop(stmt, location, scope):
-    (kind, site, tgt_ast, op, src_ast) = stmt
+    (_, site, tgt_ast, op, src_ast) = stmt
 
     tgt = codegen_expression(tgt_ast, location, scope)
-    if deep_const(tgt.ctype()):
-        raise ECONST(tgt.site)
-    if isinstance(tgt, ctree.BitSlice):
-        # destructive hack
-        return stmt_assign(
-            ast.assign(site, ast.assign_target_chain(site, [tgt_ast]),
-                       [ast.initializer_scalar(
-                           site,
-                           ast.binop(site, tgt_ast, op[:-1], src_ast))]),
-            location, scope)
-    src = codegen_expression(src_ast, location, scope)
-    ttype = tgt.ctype()
-    lscope = Symtab(scope)
-    sym = lscope.add_variable(
-        'tmp', type = TPtr(ttype), site = tgt.site,
-        init = ExpressionInitializer(mkAddressOf(tgt.site, tgt)), stmt=True)
-    # Side-Effect Free representation of the tgt lvalue
-    tgt_sef = mkDereference(site, mkLocalVariable(tgt.site, sym))
-    return [
-        sym_declaration(sym), mkExpressionStatement(
-        site,
-            mkAssignOp(site, tgt_sef, arith_binops[op[:-1]](
-                site, tgt_sef, src)))]
+    if isinstance(tgt, ctree.InlinedParam):
+        raise EASSINL(tgt.site, tgt.name)
+    if not tgt.writable:
+        raise EASSIGN(site, tgt)
 
+    ttype = tgt.ctype()
+    if deep_const(ttype):
+        raise ECONST(tgt.site)
+
+    src = codegen_expression(src_ast, location, scope)
+
+    if tgt.addressable:
+        lscope = Symtab(scope)
+        tmp_tgt_sym = lscope.add_variable(
+            '_tmp_tgt', type = TPtr(ttype), site = tgt.site,
+            init = ExpressionInitializer(mkAddressOf(tgt.site, tgt)),
+            stmt=True)
+        # Side-Effect Free representation of the tgt lvalue
+        tgt = mkDereference(site, mkLocalVariable(tgt.site, tmp_tgt_sym))
+    else:
+        # TODO Not ideal. This path is needed to deal with writable
+        # expressions that do not correspond to C lvalues; such as bit slices.
+        # The incurred repeated evaluation is painful.
+        tmp_tgt_sym = None
+
+    assign_src = source_for_assignment(site, ttype,
+                                       arith_binops[op[:-1]](site, tgt, src))
+
+    return [mkCompound(site,
+        ([sym_declaration(tmp_tgt_sym)] if tmp_tgt_sym else [])
+        + [mkExpressionStatement(site,
+                                 ctree.AssignOp(site, tgt, assign_src))])]
 @statement_dispatcher
 def stmt_expression(stmt, location, scope):
     [expr] = stmt.args
@@ -3885,7 +3899,7 @@ def codegen_method(site, inp, outp, throws, independent, memoization, ast,
                         param = mkDereference(site,
                                               mkLit(site, name, TPtr(typ)))
                         fnscope.add(ExpressionSymbol(name, param, site))
-                        code.append(mkAssignStatement(site, param, init))
+                        code.append(AssignStatement(site, param, init))
                 else:
                     code = []
 

--- a/py/dml/compat.py
+++ b/py/dml/compat.py
@@ -117,6 +117,13 @@ class shared_logs_on_device(CompatFeature):
     short = "Make logs inside shared methods always log on the device object"
     last_api_version = api_6
 
+@feature
+class discard_ref_shadowing(CompatFeature):
+    '''This compatibility feature allows declarations (within methods or
+    objects) to be named '_'. This will cause the discard reference `_` to be
+    inaccessible (*shadowed*) in all scopes with such a declaration.'''
+    short = "Allow declarations to shadow '_'"
+    last_api_version = api_6
 
 @feature
 class dml12_inline(CompatFeature):

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -5146,7 +5146,8 @@ def sym_declaration(sym, unused=False):
         return None
 
     # This will prevent warnings from the C compiler
-    unused = unused or (refcount == 0) or sym.value.startswith("__")
+    unused = (unused or (refcount == 0 and dml.globals.suppress_wunused)
+              or sym.name.startswith("_") or sym.value.startswith("__"))
 
     return mkDeclaration(sym.site, sym.value, sym.type,
                          sym.init, unused)

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -455,9 +455,6 @@ def main(argv):
         default="0",
         help=('Limit the number of error messages to N'))
 
-    # </dl>
-    # </add>
-
     # <dt>--no-compat=<i>TAG</i></dt>
     # <dd>Disable a compatibility feature</dd>
     parser.add_argument(
@@ -467,6 +464,14 @@ def main(argv):
     parser.add_argument(
         '--help-no-compat', action=CompatHelpAction,
         help='List the available tags for --no-compat')
+
+    # <dt>--no-suppress-wunused</dt>
+    # <dd>Disable the automatic suppression of GCC warnings for unused local
+    # variables</dd>
+    parser.add_argument(
+        '--no-suppress-wunused', action='store_true',
+        help=("Disable the automatic suppression of GCC warnings for unused "
+              + "local variables"))
 
     # </dl>
     # </add>
@@ -576,6 +581,7 @@ def main(argv):
         sys.exit(1)
 
     dml.globals.coverity = options.coverity
+    dml.globals.suppress_wunused = not options.no_suppress_wunused
 
     dml.globals.linemarks_enabled = not options.noline
 

--- a/py/dml/expr.py
+++ b/py/dml/expr.py
@@ -174,12 +174,10 @@ class Expression(Code):
     # storage this expression represents
     # This should only be called if either writable or c_lval is True
     def write(self, source):
-        assert self.c_lval
-        rt = realtype(self.ctype())
-        if isinstance(rt, TEndianInt):
-            return (f'{rt.dmllib_fun("copy")}(&{self.read()},'
-                    + f' {source.read()})')
-        return '%s = %s' % (self.read(), source.read())
+        assert self.c_lval, repr(self)
+        # Wrap .read() in parantheses if its priority is less than that of &
+        dest = self.read() if self.priority >= 150 else f'({self.read()})'
+        return source.assign_to(dest, self.ctype())
 
 class NonValue(Expression):
     '''An expression that is not really a value, but which may validly

--- a/py/dml/expr.py
+++ b/py/dml/expr.py
@@ -136,8 +136,16 @@ class Expression(Code):
         raise ICE(self.site, "can't read %r" % self)
 
     # Produce a C expression but don't worry about the value.
-    def discard(self):
-        return self.read()
+    def discard(self, explicit=False):
+        if not explicit or safe_realtype_shallow(self.ctype()).void:
+            return self.read()
+
+        if self.constant:
+            return '(void)0'
+        from .ctree import Cast
+        expr = (f'({self.read()})'
+                if self.priority < Cast.priority else self.read())
+        return f'(void){expr}'
 
     def ctype(self):
         '''The corresponding DML type of this expression'''

--- a/py/dml/globals.py
+++ b/py/dml/globals.py
@@ -106,3 +106,6 @@ linemarks_enabled = False
 
 # Relevant during C emission: indicates if linemarks should currently be generated
 linemarks = False
+
+# Insert UNUSED for user variable declarations when they are indeed unused
+suppress_wunused = False

--- a/py/dml/io_memory.py
+++ b/py/dml/io_memory.py
@@ -221,7 +221,8 @@ def codegen_access(bank, bank_indices, isread, memop, offset, size, writevalue,
                 regvar, size.read())])
         lines.append(
                 '            %s;' % (
-            size2.write(mkLit(site, 'bytes', TInt(64, False)))))
+            size2.write(ExpressionInitializer(mkLit(site, 'bytes',
+                                                    TInt(64, False))))))
         if partial:
             if bigendian:
                 lines.extend([
@@ -246,7 +247,8 @@ def codegen_access(bank, bank_indices, isread, memop, offset, size, writevalue,
                     regvar, indices, memop.read(), bytepos_args),
                 '            if (ret) return true;',
                 '            %s;' % (
-                    value2.write(mkLit(site, 'val', TInt(64, False)))),
+                    value2.write(ExpressionInitializer(
+                        mkLit(site, 'val', TInt(64, False))))),
                 '            return false;'])
         else:
             # Shifting/masking can normally be skipped in banks with
@@ -272,7 +274,8 @@ def codegen_access(bank, bank_indices, isread, memop, offset, size, writevalue,
                 '        if (offset >= %s[last].offset' % (regvar,)
                 + ' && offset < %s[last].offset + %s[last].size) {'
                 % (regvar, regvar),
-                '            %s;' % (size2.write(mkIntegerLiteral(site, 0)),),
+                '            %s;' % (size2.write(ExpressionInitializer(
+                    mkIntegerLiteral(site, 0))),),
                 '            return false;',
                 '        }'])
         lines.extend([

--- a/py/dml/types.py
+++ b/py/dml/types.py
@@ -12,6 +12,7 @@ __all__ = (
     'realtype',
     'safe_realtype_shallow',
     'safe_realtype',
+    'safe_realtype_unconst',
     'conv_const',
     'deep_const',
     'type_union',
@@ -154,6 +155,20 @@ def safe_realtype_shallow(t):
         return realtype_shallow(t)
     except DMLUnknownType as e:
         raise ETYPE(e.type.declaration_site or None, e.type)
+
+def safe_realtype_unconst(t0):
+    def sub(t):
+        if isinstance(t, (TArray, TVector)):
+            base = sub(t.base)
+            if t.const or base is not t.base:
+                t = t.clone()
+                t.const = False
+                t.base = base
+        elif t.const:
+            t = t.clone()
+            t.const = False
+        return t
+    return sub(safe_realtype(t0))
 
 def conv_const(const, t):
     if const and not t.const:

--- a/test/1.4/expressions/T_discard_ref.dml
+++ b/test/1.4/expressions/T_discard_ref.dml
@@ -1,0 +1,46 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+
+header %{
+    #define FUNCLIKE_MACRO() 4
+    #define VARLIKE_MACRO ++counter
+
+    static int counter = 0;
+%}
+
+extern int FUNCLIKE_MACRO(void);
+extern int VARLIKE_MACRO;
+extern int counter;
+
+method t() -> (int) throws {
+    return 1;
+}
+method m2() -> (int, int) {
+    return (1, 2);
+}
+
+method init() {
+    local int x;
+    // Explicit discard guarantees GCC doesn't emit -Wunused by always
+    // void-casting, unless the expression is already void
+    _ = x;
+    _ = FUNCLIKE_MACRO();
+    // Explicit discard does generate C, which evaluates the initializer
+    assert counter == 0;
+    _ = VARLIKE_MACRO;
+    assert counter == 1;
+    try
+        _ = t();
+    catch assert false;
+    (x, _) = m2();
+    assert x == 1;
+    local int y;
+    // Tuple initializers retain the property of each expression being
+    // evaluated left-to-right
+    (_, y) = (x++, x);
+    assert y == 2;
+}

--- a/test/1.4/expressions/T_discard_ref.dml
+++ b/test/1.4/expressions/T_discard_ref.dml
@@ -5,6 +5,8 @@
 dml 1.4;
 device test;
 
+/// DMLC-FLAG --no-suppress-wunused
+
 header %{
     #define FUNCLIKE_MACRO() 4
     #define VARLIKE_MACRO ++counter
@@ -24,10 +26,10 @@ method m2() -> (int, int) {
 }
 
 method init() {
-    local int x;
+    local int unused;
     // Explicit discard guarantees GCC doesn't emit -Wunused by always
     // void-casting, unless the expression is already void
-    _ = x;
+    _ = unused;
     _ = FUNCLIKE_MACRO();
     // Explicit discard does generate C, which evaluates the initializer
     assert counter == 0;
@@ -36,9 +38,9 @@ method init() {
     try
         _ = t();
     catch assert false;
+    local (int x, int y);
     (x, _) = m2();
     assert x == 1;
-    local int y;
     // Tuple initializers retain the property of each expression being
     // evaluated left-to-right
     (_, y) = (x++, x);

--- a/test/1.4/legacy/T_discard_ref_shadowing_disabled.dml
+++ b/test/1.4/legacy/T_discard_ref_shadowing_disabled.dml
@@ -1,0 +1,27 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+/// DMLC-FLAG --no-compat=discard_ref_shadowing
+
+/// ERROR ESYNTAX
+constant _ = 1;
+
+group g is init {
+    /// ERROR ESYNTAX
+    param _ = 2;
+    method init() {
+        assert _ == 2;
+    }
+}
+
+method init() {
+    assert _ == 1;
+    /// ERROR ESYNTAX
+    local int _ = 2;
+    assert _ == 2;
+}

--- a/test/1.4/legacy/T_discard_ref_shadowing_enabled.dml
+++ b/test/1.4/legacy/T_discard_ref_shadowing_enabled.dml
@@ -1,0 +1,24 @@
+/*
+  © 2023 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+/// DMLC-FLAG --simics-api=6
+
+constant _ = 1;
+
+group g is init {
+    param _ = 2;
+    method init() {
+        assert _ == 2;
+    }
+}
+
+method init() {
+    assert _ == 1;
+    local int _ = 2;
+    assert _ == 2;
+}


### PR DESCRIPTION
Implemented clumsily in a way that doesn't necessarily only affect local variables.
This PR is more of a way to investigate the impact this has, and serve as a talking
point. We likely want to report unused variables in DMLC directly instead.

Depends on #237 