### PR TITLE
Remove end-year test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 #

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/RELEASENOTES-1.2.docu
+++ b/RELEASENOTES-1.2.docu
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/RELEASENOTES-experimental.docu
+++ b/RELEASENOTES-experimental.docu
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/copy_h.py
+++ b/copy_h.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import os

--- a/dmlast.py
+++ b/dmlast.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys

--- a/dmlcomments_to_md.py
+++ b/dmlcomments_to_md.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys

--- a/doc/1.2/index.md
+++ b/doc/1.2/index.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.2/introduction.md
+++ b/doc/1.2/introduction.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.2/language.md
+++ b/doc/1.2/language.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.2/libraries.md
+++ b/doc/1.2/libraries.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.2/limitations.md
+++ b/doc/1.2/limitations.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.2/object-model.md
+++ b/doc/1.2/object-model.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.2/standard-templates.md
+++ b/doc/1.2/standard-templates.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.4/changes-manual.md
+++ b/doc/1.4/changes-manual.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.4/changes.md
+++ b/doc/1.4/changes.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.4/index.md
+++ b/doc/1.4/index.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.4/introduction.md
+++ b/doc/1.4/introduction.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.4/language.md
+++ b/doc/1.4/language.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.4/port-dml.md
+++ b/doc/1.4/port-dml.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/doc/1.4/running-dmlc.md
+++ b/doc/1.4/running-dmlc.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/generate_env.py
+++ b/generate_env.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys

--- a/generate_parsetabs.py
+++ b/generate_parsetabs.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import os

--- a/grammar_to_md.py
+++ b/grammar_to_md.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Convert a parser.out file fron yacc.py to jDOCU format

--- a/include/simics/dmllib.h
+++ b/include/simics/dmllib.h
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/i2c.dml
+++ b/lib-old-4.8/1.2/i2c.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/ieee-802-3.dml
+++ b/lib-old-4.8/1.2/ieee-802-3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/interrupt.dml
+++ b/lib-old-4.8/1.2/interrupt.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/microwire.dml
+++ b/lib-old-4.8/1.2/microwire.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/mii.dml
+++ b/lib-old-4.8/1.2/mii.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/mips.dml
+++ b/lib-old-4.8/1.2/mips.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/nand-flash.dml
+++ b/lib-old-4.8/1.2/nand-flash.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/ppc.dml
+++ b/lib-old-4.8/1.2/ppc.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/recorder.dml
+++ b/lib-old-4.8/1.2/recorder.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/sata-interface.dml
+++ b/lib-old-4.8/1.2/sata-interface.dml
@@ -1,5 +1,5 @@
 /*
-  © 2011-2024 Intel Corporation
+  © 2011 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/serial-device.dml
+++ b/lib-old-4.8/1.2/serial-device.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/serial-peripheral-interface.dml
+++ b/lib-old-4.8/1.2/serial-peripheral-interface.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/usb.dml
+++ b/lib-old-4.8/1.2/usb.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib-old-4.8/1.2/x86.dml
+++ b/lib-old-4.8/1.2/x86.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/arinc-429.dml
+++ b/lib/1.2/arinc-429.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/crc.dml
+++ b/lib/1.2/crc.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/dml-builtins.dml
+++ b/lib/1.2/dml-builtins.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/dml12-compatibility.dml
+++ b/lib/1.2/dml12-compatibility.dml
@@ -1,5 +1,5 @@
 /*
-  © 2019-2024 Intel Corporation
+  © 2019 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/ethernet.dml
+++ b/lib/1.2/ethernet.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/io-memory.dml
+++ b/lib/1.2/io-memory.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/mil-std-1553.dml
+++ b/lib/1.2/mil-std-1553.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/rapidio-device.dml
+++ b/lib/1.2/rapidio-device.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/rapidio.dml
+++ b/lib/1.2/rapidio.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/simics-api.dml
+++ b/lib/1.2/simics-api.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/simics-breakpoints.dml
+++ b/lib/1.2/simics-breakpoints.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/simics-configuration.dml
+++ b/lib/1.2/simics-configuration.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/simics-device.dml
+++ b/lib/1.2/simics-device.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/simics-event.dml
+++ b/lib/1.2/simics-event.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/simics-hindsight.dml
+++ b/lib/1.2/simics-hindsight.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/simics-memory.dml
+++ b/lib/1.2/simics-memory.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/simics-processor.dml
+++ b/lib/1.2/simics-processor.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/simics-types.dml
+++ b/lib/1.2/simics-types.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.2/utility.dml
+++ b/lib/1.2/utility.dml
@@ -1,5 +1,5 @@
 /*
-  © 2010-2024 Intel Corporation
+  © 2010 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -1,5 +1,5 @@
 /*
-  © 2013-2024 Intel Corporation
+  © 2013 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.4/dml12-compatibility.dml
+++ b/lib/1.4/dml12-compatibility.dml
@@ -1,5 +1,5 @@
 /*
-  © 2019-2024 Intel Corporation
+  © 2019 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.4/internal.dml
+++ b/lib/1.4/internal.dml
@@ -1,5 +1,5 @@
 /*
-  © 2013-2024 Intel Corporation
+  © 2013 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1,5 +1,5 @@
 /*
-  © 2013-2024 Intel Corporation
+  © 2013 Intel Corporation
   SPDX-License-Identifier: 0BSD
 */
 

--- a/md_to_github.py
+++ b/md_to_github.py
@@ -46,7 +46,7 @@ tving vattenpass
 ''').groups() == ('skruv spik hammare',)
 
 copyright = '''<!--
-  © 2021-2024 Intel Corporation
+  © 2024 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 '''

--- a/md_to_github.py
+++ b/md_to_github.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Convert .md files tailored for dodoc, into files suitable for

--- a/messages_to_md.py
+++ b/messages_to_md.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys

--- a/porting_to_md.py
+++ b/porting_to_md.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys

--- a/py/README.md
+++ b/py/README.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/py/__main__.py
+++ b/py/__main__.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys

--- a/py/dml/__init__.py
+++ b/py/dml/__init__.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # dml package init file

--- a/py/dml/ast.py
+++ b/py/dml/ast.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import builtins

--- a/py/dml/ast_test.py
+++ b/py/dml/ast_test.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from dml import ast

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys, os

--- a/py/dml/clone_test.py
+++ b/py/dml/clone_test.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dml.types as dt

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import re

--- a/py/dml/codegen_test.py
+++ b/py/dml/codegen_test.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import unittest

--- a/py/dml/crep.py
+++ b/py/dml/crep.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # This module tries to contain all the code that describes the

--- a/py/dml/ctree-test.h
+++ b/py/dml/ctree-test.h
@@ -1,5 +1,5 @@
 /*
-  © 2013-2024 Intel Corporation
+  © 2013 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Intermediate representation of the device model

--- a/py/dml/ctree_test.py
+++ b/py/dml/ctree_test.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import unittest

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys, os, traceback, re

--- a/py/dml/dmllex.py
+++ b/py/dml/dmllex.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Lexer

--- a/py/dml/dmllex12.py
+++ b/py/dml/dmllex12.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from .dmllex import *

--- a/py/dml/dmllex14.py
+++ b/py/dml/dmllex14.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from .dmllex import *

--- a/py/dml/dmlparse.py
+++ b/py/dml/dmlparse.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Parser for DML 1.2

--- a/py/dml/expr.py
+++ b/py/dml/expr.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import abc

--- a/py/dml/expr_util.py
+++ b/py/dml/expr_util.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Various convenience functions for common operations on expressions

--- a/py/dml/g_backend.py
+++ b/py/dml/g_backend.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Generates DML debugging info

--- a/py/dml/globals.py
+++ b/py/dml/globals.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Global variables

--- a/py/dml/info_backend.py
+++ b/py/dml/info_backend.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 __all__ = ['generate']

--- a/py/dml/int_register.py
+++ b/py/dml/int_register.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from .expr import *

--- a/py/dml/io_memory.py
+++ b/py/dml/io_memory.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import operator

--- a/py/dml/logging.py
+++ b/py/dml/logging.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # This module handles errors and warnings

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from .logging import (DMLError, DMLWarning, SimpleSite, PortingMessage, ICE,

--- a/py/dml/objects.py
+++ b/py/dml/objects.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import itertools

--- a/py/dml/output.py
+++ b/py/dml/output.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import os

--- a/py/dml/reginfo.py
+++ b/py/dml/reginfo.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from collections import namedtuple

--- a/py/dml/reginfo_test.py
+++ b/py/dml/reginfo_test.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import unittest

--- a/py/dml/serialize.py
+++ b/py/dml/serialize.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # This module contains the functions used to generate methods to convert between

--- a/py/dml/slotsmeta.py
+++ b/py/dml/slotsmeta.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import abc

--- a/py/dml/slotsmeta_test.py
+++ b/py/dml/slotsmeta_test.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import unittest

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Structure stuff

--- a/py/dml/structure_test.py
+++ b/py/dml/structure_test.py
@@ -1,4 +1,4 @@
-# © 2022-2024 Intel Corporation
+# © 2022 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import unittest

--- a/py/dml/symtab.py
+++ b/py/dml/symtab.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Symbol table management

--- a/py/dml/template.py
+++ b/py/dml/template.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Process templates, from ASTs to Template objects

--- a/py/dml/toplevel.py
+++ b/py/dml/toplevel.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Launch the parser, and expand imports

--- a/py/dml/topsort.py
+++ b/py/dml/topsort.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Utility function for topological sorting

--- a/py/dml/topsort_test.py
+++ b/py/dml/topsort_test.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import unittest

--- a/py/dml/traits.py
+++ b/py/dml/traits.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Infrastructure for traits

--- a/py/dml/traits_test.py
+++ b/py/dml/traits_test.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import unittest

--- a/py/dml/types.py
+++ b/py/dml/types.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Types in DML

--- a/py/port_dml.py
+++ b/py/port_dml.py
@@ -1,4 +1,4 @@
-# © 2014-2024 Intel Corporation
+# © 2014 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import os

--- a/run_unit_tests.py
+++ b/run_unit_tests.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import os, sys

--- a/test/1.2/errors/EBADFAIL_dml14.dml
+++ b/test/1.2/errors/EBADFAIL_dml14.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.2/errors/ECYCLICIMP_1.dml
+++ b/test/1.2/errors/ECYCLICIMP_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/ECYCLICIMP_2.dml
+++ b/test/1.2/errors/ECYCLICIMP_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/EERRSTMT_dml14.dml
+++ b/test/1.2/errors/EERRSTMT_dml14.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.2/errors/ENALLOW_dml14.dml
+++ b/test/1.2/errors/ENALLOW_dml14.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.2/errors/T_EABSTRAIT.dml
+++ b/test/1.2/errors/T_EABSTRAIT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EACHK.dml
+++ b/test/1.2/errors/T_EACHK.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAFTER.dml
+++ b/test/1.2/errors/T_EAFTER.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAINCOMP.dml
+++ b/test/1.2/errors/T_EAINCOMP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAMBDEFAULT.dml
+++ b/test/1.2/errors/T_EAMBDEFAULT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAMBINH.dml
+++ b/test/1.2/errors/T_EAMBINH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAMETH.dml
+++ b/test/1.2/errors/T_EAMETH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EANULL.dml
+++ b/test/1.2/errors/T_EANULL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAPPLY.dml
+++ b/test/1.2/errors/T_EAPPLY.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAPPLYMETH.dml
+++ b/test/1.2/errors/T_EAPPLYMETH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EARG.dml
+++ b/test/1.2/errors/T_EARG.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EARGD.dml
+++ b/test/1.2/errors/T_EARGD.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EARGT.dml
+++ b/test/1.2/errors/T_EARGT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EARRAY.dml
+++ b/test/1.2/errors/T_EARRAY.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN.dml
+++ b/test/1.2/errors/T_EASSIGN.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_06.dml
+++ b/test/1.2/errors/T_EASSIGN_06.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_09.dml
+++ b/test/1.2/errors/T_EASSIGN_09.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_12.dml
+++ b/test/1.2/errors/T_EASSIGN_12.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_13.dml
+++ b/test/1.2/errors/T_EASSIGN_13.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_15.dml
+++ b/test/1.2/errors/T_EASSIGN_15.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_16.dml
+++ b/test/1.2/errors/T_EASSIGN_16.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_19.dml
+++ b/test/1.2/errors/T_EASSIGN_19.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_20.dml
+++ b/test/1.2/errors/T_EASSIGN_20.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_21.dml
+++ b/test/1.2/errors/T_EASSIGN_21.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_22.dml
+++ b/test/1.2/errors/T_EASSIGN_22.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_23.dml
+++ b/test/1.2/errors/T_EASSIGN_23.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_24.dml
+++ b/test/1.2/errors/T_EASSIGN_24.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_25.dml
+++ b/test/1.2/errors/T_EASSIGN_25.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_34.dml
+++ b/test/1.2/errors/T_EASSIGN_34.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSIGN_target_type.dml
+++ b/test/1.2/errors/T_EASSIGN_target_type.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASSINL.dml
+++ b/test/1.2/errors/T_EASSINL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASTYPE.dml
+++ b/test/1.2/errors/T_EASTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASZR.dml
+++ b/test/1.2/errors/T_EASZR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EASZVAR_5.dml
+++ b/test/1.2/errors/T_EASZVAR_5.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EATTRDATA.dml
+++ b/test/1.2/errors/T_EATTRDATA.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EATYPE.dml
+++ b/test/1.2/errors/T_EATYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAUTOPARAM.dml
+++ b/test/1.2/errors/T_EAUTOPARAM.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAVAR.dml
+++ b/test/1.2/errors/T_EAVAR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EAVPARAM.dml
+++ b/test/1.2/errors/T_EAVPARAM.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBADFAIL.dml
+++ b/test/1.2/errors/T_EBADFAIL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBADFAIL_dml12.dml
+++ b/test/1.2/errors/T_EBADFAIL_dml12.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBFLD.dml
+++ b/test/1.2/errors/T_EBFLD.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBINOP.dml
+++ b/test/1.2/errors/T_EBINOP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBITO.dml
+++ b/test/1.2/errors/T_EBITO.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBITRN_1.dml
+++ b/test/1.2/errors/T_EBITRN_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBITRN_2.dml
+++ b/test/1.2/errors/T_EBITRN_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBITRO_1.dml
+++ b/test/1.2/errors/T_EBITRO_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBITRO_2.dml
+++ b/test/1.2/errors/T_EBITRO_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBITRR.dml
+++ b/test/1.2/errors/T_EBITRR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBREAK.dml
+++ b/test/1.2/errors/T_EBREAK.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBSBE.dml
+++ b/test/1.2/errors/T_EBSBE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBSLICE.dml
+++ b/test/1.2/errors/T_EBSLICE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBSSIZE.dml
+++ b/test/1.2/errors/T_EBSSIZE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EBTYPE.dml
+++ b/test/1.2/errors/T_EBTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECLST.dml
+++ b/test/1.2/errors/T_ECLST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECONDP.dml
+++ b/test/1.2/errors/T_ECONDP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECONDT.dml
+++ b/test/1.2/errors/T_ECONDT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECONST.dml
+++ b/test/1.2/errors/T_ECONST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECONSTP.dml
+++ b/test/1.2/errors/T_ECONSTP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECONT.dml
+++ b/test/1.2/errors/T_ECONT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECONTU.dml
+++ b/test/1.2/errors/T_ECONTU.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECYCLICIMP.dml
+++ b/test/1.2/errors/T_ECYCLICIMP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECYCLICTRAIT.dml
+++ b/test/1.2/errors/T_ECYCLICTRAIT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ECYCLICTRAIT_template.dml
+++ b/test/1.2/errors/T_ECYCLICTRAIT_template.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EDATAINIT.dml
+++ b/test/1.2/errors/T_EDATAINIT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EDBFUNC.dml
+++ b/test/1.2/errors/T_EDBFUNC.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EDEVICE.dml
+++ b/test/1.2/errors/T_EDEVICE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EDEVIMP.dml
+++ b/test/1.2/errors/T_EDEVIMP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EDISCONST.dml
+++ b/test/1.2/errors/T_EDISCONST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EDIVZ.dml
+++ b/test/1.2/errors/T_EDIVZ.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EDMETH.dml
+++ b/test/1.2/errors/T_EDMETH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EDVAR.dml
+++ b/test/1.2/errors/T_EDVAR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EEARG.dml
+++ b/test/1.2/errors/T_EEARG.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EERRSTMT.dml
+++ b/test/1.2/errors/T_EERRSTMT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EEXTERN.dml
+++ b/test/1.2/errors/T_EEXTERN.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EFMTARGN.dml
+++ b/test/1.2/errors/T_EFMTARGN.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EFMTARGT.dml
+++ b/test/1.2/errors/T_EFMTARGT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EFORMAT.dml
+++ b/test/1.2/errors/T_EFORMAT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EIDENT.dml
+++ b/test/1.2/errors/T_EIDENT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EIDXVAR.dml
+++ b/test/1.2/errors/T_EIDXVAR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EIFREF.dml
+++ b/test/1.2/errors/T_EIFREF.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EIFTYPE.dml
+++ b/test/1.2/errors/T_EIFTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EILLCOMP.dml
+++ b/test/1.2/errors/T_EILLCOMP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EIMPORT.dml
+++ b/test/1.2/errors/T_EIMPORT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EINC.dml
+++ b/test/1.2/errors/T_EINC.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EINCTYPE.dml
+++ b/test/1.2/errors/T_EINCTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EINTPTRTYPE.dml
+++ b/test/1.2/errors/T_EINTPTRTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EINVOVER.dml
+++ b/test/1.2/errors/T_EINVOVER.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ELAYOUT.dml
+++ b/test/1.2/errors/T_ELAYOUT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ELTYPE.dml
+++ b/test/1.2/errors/T_ELTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EMEMBER.dml
+++ b/test/1.2/errors/T_EMEMBER.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EMETH.dml
+++ b/test/1.2/errors/T_EMETH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENALLOC.dml
+++ b/test/1.2/errors/T_ENALLOC.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENALLOW.dml
+++ b/test/1.2/errors/T_ENALLOW.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENAMECOLL.dml
+++ b/test/1.2/errors/T_ENAMECOLL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENAMECOLL_uint32.dml
+++ b/test/1.2/errors/T_ENAMECOLL_uint32.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENARGT.dml
+++ b/test/1.2/errors/T_ENARGT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENARRAY.dml
+++ b/test/1.2/errors/T_ENARRAY.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENBOOL.dml
+++ b/test/1.2/errors/T_ENBOOL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENCONST.dml
+++ b/test/1.2/errors/T_ENCONST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENCONST_array_type.dml
+++ b/test/1.2/errors/T_ENCONST_array_type.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENDEFAULT.dml
+++ b/test/1.2/errors/T_ENDEFAULT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENLST.dml
+++ b/test/1.2/errors/T_ENLST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENMETH.dml
+++ b/test/1.2/errors/T_ENMETH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENODEV.dml
+++ b/test/1.2/errors/T_ENODEV.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENOPTR.dml
+++ b/test/1.2/errors/T_ENOPTR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENOSTRUCT.dml
+++ b/test/1.2/errors/T_ENOSTRUCT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENPARAM.dml
+++ b/test/1.2/errors/T_ENPARAM.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENSHARED.dml
+++ b/test/1.2/errors/T_ENSHARED.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENTMPL.dml
+++ b/test/1.2/errors/T_ENTMPL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENTYPE.dml
+++ b/test/1.2/errors/T_ENTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENVAL.dml
+++ b/test/1.2/errors/T_ENVAL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ENVAL_param_site.dml
+++ b/test/1.2/errors/T_ENVAL_param_site.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EOOB.dml
+++ b/test/1.2/errors/T_EOOB.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EPARAM.dml
+++ b/test/1.2/errors/T_EPARAM.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EPTYPE.dml
+++ b/test/1.2/errors/T_EPTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ERECPARAM.dml
+++ b/test/1.2/errors/T_ERECPARAM.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ERECUR.dml
+++ b/test/1.2/errors/T_ERECUR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EREF.dml
+++ b/test/1.2/errors/T_EREF.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EREGISZ.dml
+++ b/test/1.2/errors/T_EREGISZ.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EREGNSZ.dml
+++ b/test/1.2/errors/T_EREGNSZ.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EREGOL.dml
+++ b/test/1.2/errors/T_EREGOL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EREGVAL.dml
+++ b/test/1.2/errors/T_EREGVAL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESHNEG.dml
+++ b/test/1.2/errors/T_ESHNEG.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_01.dml
+++ b/test/1.2/errors/T_ESYNTAX_01.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_02.dml
+++ b/test/1.2/errors/T_ESYNTAX_02.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_03.dml
+++ b/test/1.2/errors/T_ESYNTAX_03.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_04.dml
+++ b/test/1.2/errors/T_ESYNTAX_04.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_05.dml
+++ b/test/1.2/errors/T_ESYNTAX_05.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_06.dml
+++ b/test/1.2/errors/T_ESYNTAX_06.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_07.dml
+++ b/test/1.2/errors/T_ESYNTAX_07.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_08.dml
+++ b/test/1.2/errors/T_ESYNTAX_08.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_10.dml
+++ b/test/1.2/errors/T_ESYNTAX_10.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_12.dml
+++ b/test/1.2/errors/T_ESYNTAX_12.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_13.dml
+++ b/test/1.2/errors/T_ESYNTAX_13.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_14.dml
+++ b/test/1.2/errors/T_ESYNTAX_14.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_15.dml
+++ b/test/1.2/errors/T_ESYNTAX_15.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_16.dml
+++ b/test/1.2/errors/T_ESYNTAX_16.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_17.dml
+++ b/test/1.2/errors/T_ESYNTAX_17.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_18.dml
+++ b/test/1.2/errors/T_ESYNTAX_18.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_19.dml
+++ b/test/1.2/errors/T_ESYNTAX_19.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_20.dml
+++ b/test/1.2/errors/T_ESYNTAX_20.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_21.dml
+++ b/test/1.2/errors/T_ESYNTAX_21.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_broken_utf8.dml
+++ b/test/1.2/errors/T_ESYNTAX_broken_utf8.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_local_untyped.dml
+++ b/test/1.2/errors/T_ESYNTAX_local_untyped.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_subdevice.dml
+++ b/test/1.2/errors/T_ESYNTAX_subdevice.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.2/errors/T_ESYNTAX_unnamed_cdecl.dml
+++ b/test/1.2/errors/T_ESYNTAX_unnamed_cdecl.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ESYNTAX_version_broken.dml
+++ b/test/1.2/errors/T_ESYNTAX_version_broken.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 /// ERROR ESYNTAX

--- a/test/1.2/errors/T_ESYNTAX_version_nosemi.dml
+++ b/test/1.2/errors/T_ESYNTAX_version_nosemi.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 /// ERROR ESYNTAX

--- a/test/1.2/errors/T_ESYNTAX_version_wrong.dml
+++ b/test/1.2/errors/T_ESYNTAX_version_wrong.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 /// ERROR ESYNTAX

--- a/test/1.2/errors/T_ETMETH.dml
+++ b/test/1.2/errors/T_ETMETH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ETREC.dml
+++ b/test/1.2/errors/T_ETREC.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ETREC_layout.dml
+++ b/test/1.2/errors/T_ETREC_layout.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_ETYPE.dml
+++ b/test/1.2/errors/T_ETYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EUNDEF.dml
+++ b/test/1.2/errors/T_EUNDEF.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EUNINITIALIZED.dml
+++ b/test/1.2/errors/T_EUNINITIALIZED.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EVARPARAM_2.dml
+++ b/test/1.2/errors/T_EVARPARAM_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EVARPARAM_3.dml
+++ b/test/1.2/errors/T_EVARPARAM_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EVARPARAM_5.dml
+++ b/test/1.2/errors/T_EVARPARAM_5.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EVARPARAM_6.dml
+++ b/test/1.2/errors/T_EVARPARAM_6.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EVARPARAM_bug22466.dml
+++ b/test/1.2/errors/T_EVARPARAM_bug22466.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EVARTYPE.dml
+++ b/test/1.2/errors/T_EVARTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EVLACONST.dml
+++ b/test/1.2/errors/T_EVLACONST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_EZRANGE.dml
+++ b/test/1.2/errors/T_EZRANGE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_WDEPRECATED.dml
+++ b/test/1.2/errors/T_WDEPRECATED.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_WDEPRECATED_scope.dml
+++ b/test/1.2/errors/T_WDEPRECATED_scope.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_WNDOCRA.dml
+++ b/test/1.2/errors/T_WNDOCRA.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_WNOVER.dml
+++ b/test/1.2/errors/T_WNOVER.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 /// WARNING WNOVER T_WNOVER.dml

--- a/test/1.2/errors/T_WUNUSEDDEFAULT_01.dml
+++ b/test/1.2/errors/T_WUNUSEDDEFAULT_01.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_WUNUSED_DML12.dml
+++ b/test/1.2/errors/T_WUNUSED_DML12.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_WWRNSTMT.dml
+++ b/test/1.2/errors/T_WWRNSTMT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_endian_int_return.dml
+++ b/test/1.2/errors/T_endian_int_return.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/T_strict.dml
+++ b/test/1.2/errors/T_strict.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/errors/WREF.dml
+++ b/test/1.2/errors/WREF.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_after.dml
+++ b/test/1.2/events/T_after.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_after.py
+++ b/test/1.2/events/T_after.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 cpu = SIM_create_object("clock", "clock", [["freq_mhz", 1]])

--- a/test/1.2/events/T_after_array.dml
+++ b/test/1.2/events/T_after_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_after_array.py
+++ b/test/1.2/events/T_after_array.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_after_chk_dup.cont.py
+++ b/test/1.2/events/T_after_chk_dup.cont.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_after_chk_dup.dml
+++ b/test/1.2/events/T_after_chk_dup.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_after_chk_dup.py
+++ b/test/1.2/events/T_after_chk_dup.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from os.path import join

--- a/test/1.2/events/T_after_param.dml
+++ b/test/1.2/events/T_after_param.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_after_param.py
+++ b/test/1.2/events/T_after_param.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_describe_event.dml
+++ b/test/1.2/events/T_describe_event.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_describe_event.py
+++ b/test/1.2/events/T_describe_event.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_dup.cont.py
+++ b/test/1.2/events/T_dup.cont.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_dup.dml
+++ b/test/1.2/events/T_dup.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_dup.py
+++ b/test/1.2/events/T_dup.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from os.path import join

--- a/test/1.2/events/T_event_info.dml
+++ b/test/1.2/events/T_event_info.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_event_info.py
+++ b/test/1.2/events/T_event_info.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_next.dml
+++ b/test/1.2/events/T_next.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_next.py
+++ b/test/1.2/events/T_next.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_next_time.dml
+++ b/test/1.2/events/T_next_time.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_next_time.py
+++ b/test/1.2/events/T_next_time.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_no_queue.dml
+++ b/test/1.2/events/T_no_queue.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_no_queue.py
+++ b/test/1.2/events/T_no_queue.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_posted.dml
+++ b/test/1.2/events/T_posted.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_posted.py
+++ b/test/1.2/events/T_posted.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_remove.dml
+++ b/test/1.2/events/T_remove.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_remove.py
+++ b/test/1.2/events/T_remove.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/events/T_stacked.dml
+++ b/test/1.2/events/T_stacked.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_stacked.py
+++ b/test/1.2/events/T_stacked.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 cpu = SIM_create_object("clock", "clock", [["freq_mhz", 1]])

--- a/test/1.2/events/T_steps.dml
+++ b/test/1.2/events/T_steps.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/events/T_unused.dml
+++ b/test/1.2/events/T_unused.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/interfaces/T_call.dml
+++ b/test/1.2/interfaces/T_call.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/interfaces/T_iface_decl_1.dml
+++ b/test/1.2/interfaces/T_iface_decl_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/interfaces/T_implement.dml
+++ b/test/1.2/interfaces/T_implement.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/internal/README.md
+++ b/test/1.2/internal/README.md
@@ -1,5 +1,5 @@
 <!--
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 -->
 

--- a/test/1.2/internal/T_WCONFIDENTIAL.dml
+++ b/test/1.2/internal/T_WCONFIDENTIAL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/internal/T_confidential.dml
+++ b/test/1.2/internal/T_confidential.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/internal/T_index.dml
+++ b/test/1.2/internal/T_index.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/internal/T_indices.dml
+++ b/test/1.2/internal/T_indices.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/internal/T_int_register.dml
+++ b/test/1.2/internal/T_int_register.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/internal/T_int_register.py
+++ b/test/1.2/internal/T_int_register.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 RN = 17

--- a/test/1.2/internal/T_norenaming.dml
+++ b/test/1.2/internal/T_norenaming.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/internal/T_vect.dml
+++ b/test/1.2/internal/T_vect.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/internal/T_vect_select.dml
+++ b/test/1.2/internal/T_vect_select.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/internal/saved_object.dml
+++ b/test/1.2/internal/saved_object.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.2/layout/T_addressof.dml
+++ b/test/1.2/layout/T_addressof.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_array.dml
+++ b/test/1.2/layout/T_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_assignment.dml
+++ b/test/1.2/layout/T_assignment.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_bitfields.dml
+++ b/test/1.2/layout/T_bitfields.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_bitfields_be.dml
+++ b/test/1.2/layout/T_bitfields_be.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_bitfields_endian.dml
+++ b/test/1.2/layout/T_bitfields_endian.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_const.dml
+++ b/test/1.2/layout/T_const.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_data.dml
+++ b/test/1.2/layout/T_data.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_local-pointer.dml
+++ b/test/1.2/layout/T_local-pointer.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_local.dml
+++ b/test/1.2/layout/T_local.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_member_addressof.dml
+++ b/test/1.2/layout/T_member_addressof.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_namecoll.dml
+++ b/test/1.2/layout/T_namecoll.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_nested-assignment.dml
+++ b/test/1.2/layout/T_nested-assignment.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_nested.dml
+++ b/test/1.2/layout/T_nested.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_nested_arg.dml
+++ b/test/1.2/layout/T_nested_arg.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_simple.dml
+++ b/test/1.2/layout/T_simple.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_size_t.dml
+++ b/test/1.2/layout/T_size_t.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_slice.dml
+++ b/test/1.2/layout/T_slice.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/layout/T_typedef.dml
+++ b/test/1.2/layout/T_typedef.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_call_const_arg.dml
+++ b/test/1.2/methods/T_call_const_arg.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_call_event.dml
+++ b/test/1.2/methods/T_call_event.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_call_expr.dml
+++ b/test/1.2/methods/T_call_expr.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_call_iface.dml
+++ b/test/1.2/methods/T_call_iface.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_call_outp.dml
+++ b/test/1.2/methods/T_call_outp.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_call_stringlit.dml
+++ b/test/1.2/methods/T_call_stringlit.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_constprop.dml
+++ b/test/1.2/methods/T_constprop.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_default.dml
+++ b/test/1.2/methods/T_default.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_inline.dml
+++ b/test/1.2/methods/T_inline.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_inline_array.dml
+++ b/test/1.2/methods/T_inline_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_inline_event.dml
+++ b/test/1.2/methods/T_inline_event.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_inline_iface.dml
+++ b/test/1.2/methods/T_inline_iface.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_inline_ignored_arg.dml
+++ b/test/1.2/methods/T_inline_ignored_arg.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_inline_params.dml
+++ b/test/1.2/methods/T_inline_params.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_inline_params_index.dml
+++ b/test/1.2/methods/T_inline_params_index.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_inline_smallint.dml
+++ b/test/1.2/methods/T_inline_smallint.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_inline_untyped_extern.dml
+++ b/test/1.2/methods/T_inline_untyped_extern.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_noargs.dml
+++ b/test/1.2/methods/T_noargs.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/methods/T_ref.dml
+++ b/test/1.2/methods/T_ref.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_get.dml
+++ b/test/1.2/misc/T_array_get.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_qname.dml
+++ b/test/1.2/misc/T_array_qname.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_read.dml
+++ b/test/1.2/misc/T_array_read.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_set_1.dml
+++ b/test/1.2/misc/T_array_set_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_set_2.dml
+++ b/test/1.2/misc/T_array_set_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_set_3.dml
+++ b/test/1.2/misc/T_array_set_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_set_4.dml
+++ b/test/1.2/misc/T_array_set_4.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_set_5.dml
+++ b/test/1.2/misc/T_array_set_5.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_set_6.dml
+++ b/test/1.2/misc/T_array_set_6.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_array_set_7.dml
+++ b/test/1.2/misc/T_array_set_7.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_attr_lvalue.dml
+++ b/test/1.2/misc/T_attr_lvalue.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_d_arg.dml
+++ b/test/1.2/misc/T_d_arg.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_destroy.dml
+++ b/test/1.2/misc/T_destroy.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_destroy.py
+++ b/test/1.2/misc/T_destroy.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # We need to create a second object, since run-test.py expects obj to

--- a/test/1.2/misc/T_import_dml14.dml
+++ b/test/1.2/misc/T_import_dml14.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_import_rel_1.dml
+++ b/test/1.2/misc/T_import_rel_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_inheritance_from_14.dml
+++ b/test/1.2/misc/T_inheritance_from_14.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_init_data.dml
+++ b/test/1.2/misc/T_init_data.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_init_local.dml
+++ b/test/1.2/misc/T_init_local.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_init_static.dml
+++ b/test/1.2/misc/T_init_static.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_locals.dml
+++ b/test/1.2/misc/T_locals.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_nested_14_layout.dml
+++ b/test/1.2/misc/T_nested_14_layout.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_notify_state.dml
+++ b/test/1.2/misc/T_notify_state.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_notify_state.py
+++ b/test/1.2/misc/T_notify_state.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/misc/T_porting.dml
+++ b/test/1.2/misc/T_porting.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_porting_compat.dml
+++ b/test/1.2/misc/T_porting_compat.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_porting_fail.dml
+++ b/test/1.2/misc/T_porting_fail.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_register_view_no_xml.dml
+++ b/test/1.2/misc/T_register_view_no_xml.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 // Make sure that register_view can handle when device info is not present

--- a/test/1.2/misc/T_register_view_no_xml.py
+++ b/test/1.2/misc/T_register_view_no_xml.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/misc/T_split_output.dml
+++ b/test/1.2/misc/T_split_output.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_static_indexed.dml
+++ b/test/1.2/misc/T_static_indexed.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_unimpl_templates.dml
+++ b/test/1.2/misc/T_unimpl_templates.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_unimpl_templates.py
+++ b/test/1.2/misc/T_unimpl_templates.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util as du

--- a/test/1.2/misc/T_utility_14_api.dml
+++ b/test/1.2/misc/T_utility_14_api.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/T_utility_14_api.py
+++ b/test/1.2/misc/T_utility_14_api.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/misc/T_vla.dml
+++ b/test/1.2/misc/T_vla.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/devinfo.dml
+++ b/test/1.2/misc/devinfo.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/dml14.dml
+++ b/test/1.2/misc/dml14.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.2/misc/nested_14_layout.dml
+++ b/test/1.2/misc/nested_14_layout.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.2/misc/porting-common.dml
+++ b/test/1.2/misc/porting-common.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/porting-import.dml
+++ b/test/1.2/misc/porting-import.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/porting-imported.dml
+++ b/test/1.2/misc/porting-imported.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/porting.dml
+++ b/test/1.2/misc/porting.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.2/misc/register_view.dml
+++ b/test/1.2/misc/register_view.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/register_view.py
+++ b/test/1.2/misc/register_view.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import test_register_view

--- a/test/1.2/misc/register_view_bitorder_be.dml
+++ b/test/1.2/misc/register_view_bitorder_be.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/register_view_bitorder_be.py
+++ b/test/1.2/misc/register_view_bitorder_be.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from stest import expect_true

--- a/test/1.2/misc/register_view_bitorder_le.dml
+++ b/test/1.2/misc/register_view_bitorder_le.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/register_view_bitorder_le.py
+++ b/test/1.2/misc/register_view_bitorder_le.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from stest import expect_false

--- a/test/1.2/misc/register_view_descriptions.dml
+++ b/test/1.2/misc/register_view_descriptions.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/register_view_descriptions.py
+++ b/test/1.2/misc/register_view_descriptions.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import test_register_view_descriptions

--- a/test/1.2/misc/register_view_fields.dml
+++ b/test/1.2/misc/register_view_fields.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/register_view_fields.py
+++ b/test/1.2/misc/register_view_fields.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from simics import *

--- a/test/1.2/misc/register_view_inquiry.dml
+++ b/test/1.2/misc/register_view_inquiry.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/register_view_inquiry.py
+++ b/test/1.2/misc/register_view_inquiry.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import test_register_view_inquiry

--- a/test/1.2/misc/rel/a/x.dml
+++ b/test/1.2/misc/rel/a/x.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/rel/a/x.h
+++ b/test/1.2/misc/rel/a/x.h
@@ -1,5 +1,5 @@
 /*
-  © 2013-2024 Intel Corporation
+  © 2013 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.2/misc/rel/a/y.dml
+++ b/test/1.2/misc/rel/a/y.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/rel/a/y.h
+++ b/test/1.2/misc/rel/a/y.h
@@ -1,5 +1,5 @@
 /*
-  © 2013-2024 Intel Corporation
+  © 2013 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.2/misc/rel/misc/rel/z.dml
+++ b/test/1.2/misc/rel/misc/rel/z.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/rel/z.dml
+++ b/test/1.2/misc/rel/z.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/misc/test_dmlc_g.dml
+++ b/test/1.2/misc/test_dmlc_g.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 // test-dmlc-g.dml - A device containing all DML items is to test dmlc -g option.

--- a/test/1.2/misc/test_dmlc_g.py
+++ b/test/1.2/misc/test_dmlc_g.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import os

--- a/test/1.2/misc/unified_template.dml
+++ b/test/1.2/misc/unified_template.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.2/operators/T_apply_2.dml
+++ b/test/1.2/operators/T_apply_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_arith.dml
+++ b/test/1.2/operators/T_arith.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_array.dml
+++ b/test/1.2/operators/T_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_arrayref_node_nonint.dml
+++ b/test/1.2/operators/T_arrayref_node_nonint.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_assign_1.dml
+++ b/test/1.2/operators/T_assign_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_assign_type.dml
+++ b/test/1.2/operators/T_assign_type.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_bitfields_member_sign.dml
+++ b/test/1.2/operators/T_bitfields_member_sign.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_bitop_bitfields.dml
+++ b/test/1.2/operators/T_bitop_bitfields.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 // Bit-manipulation operations support operands of bitfields type

--- a/test/1.2/operators/T_cast.dml
+++ b/test/1.2/operators/T_cast.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_complement.dml
+++ b/test/1.2/operators/T_complement.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_cond.dml
+++ b/test/1.2/operators/T_cond.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_equal_1.dml
+++ b/test/1.2/operators/T_equal_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_equal_booleans_1.dml
+++ b/test/1.2/operators/T_equal_booleans_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_equal_booleans_2.dml
+++ b/test/1.2/operators/T_equal_booleans_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_equal_booleans_3.dml
+++ b/test/1.2/operators/T_equal_booleans_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_equal_booleans_4.dml
+++ b/test/1.2/operators/T_equal_booleans_4.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_incdec.dml
+++ b/test/1.2/operators/T_incdec.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_incdec_layout.dml
+++ b/test/1.2/operators/T_incdec_layout.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_interface_avail.dml
+++ b/test/1.2/operators/T_interface_avail.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_interface_avail.py
+++ b/test/1.2/operators/T_interface_avail.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 cpu = SIM_create_object("clock", "cpu", [["freq_mhz", 1]])

--- a/test/1.2/operators/T_list_ref.dml
+++ b/test/1.2/operators/T_list_ref.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_neq_obj.dml
+++ b/test/1.2/operators/T_neq_obj.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_new.dml
+++ b/test/1.2/operators/T_new.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_prepost_incdec.dml
+++ b/test/1.2/operators/T_prepost_incdec.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_shift.dml
+++ b/test/1.2/operators/T_shift.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_sizeof.dml
+++ b/test/1.2/operators/T_sizeof.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_sizeof_layout.dml
+++ b/test/1.2/operators/T_sizeof_layout.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_slice_1.dml
+++ b/test/1.2/operators/T_slice_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_slice_2.dml
+++ b/test/1.2/operators/T_slice_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_slice_assignment.dml
+++ b/test/1.2/operators/T_slice_assignment.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_slice_bool.dml
+++ b/test/1.2/operators/T_slice_bool.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_string_plus.dml
+++ b/test/1.2/operators/T_string_plus.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_unary_arith.dml
+++ b/test/1.2/operators/T_unary_arith.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/operators/T_undefined.dml
+++ b/test/1.2/operators/T_undefined.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_bankarray.dml
+++ b/test/1.2/registers/T_bankarray.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_bankarray.py
+++ b/test/1.2/registers/T_bankarray.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/1.2/registers/T_bankarray_2.dml
+++ b/test/1.2/registers/T_bankarray_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_be_import.dml
+++ b/test/1.2/registers/T_be_import.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_be_slice.dml
+++ b/test/1.2/registers/T_be_slice.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_be_slice.py
+++ b/test/1.2/registers/T_be_slice.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from functools import reduce

--- a/test/1.2/registers/T_byteorder.dml
+++ b/test/1.2/registers/T_byteorder.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_conditional_fields.dml
+++ b/test/1.2/registers/T_conditional_fields.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_field_order.dml
+++ b/test/1.2/registers/T_field_order.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_get_exc.dml
+++ b/test/1.2/registers/T_get_exc.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_get_exc.py
+++ b/test/1.2/registers/T_get_exc.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 try:

--- a/test/1.2/registers/T_inquiry.dml
+++ b/test/1.2/registers/T_inquiry.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_inquiry.py
+++ b/test/1.2/registers/T_inquiry.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import random

--- a/test/1.2/registers/T_instrumentation.dml
+++ b/test/1.2/registers/T_instrumentation.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_instrumentation.py
+++ b/test/1.2/registers/T_instrumentation.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import instrumentation_access_inquire

--- a/test/1.2/registers/T_large_stride.dml
+++ b/test/1.2/registers/T_large_stride.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_large_stride.py
+++ b/test/1.2/registers/T_large_stride.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest, dev_util

--- a/test/1.2/registers/T_largearray.dml
+++ b/test/1.2/registers/T_largearray.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_largearray.py
+++ b/test/1.2/registers/T_largearray.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/1.2/registers/T_largeoffset.dml
+++ b/test/1.2/registers/T_largeoffset.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_largeoffset_map.dml
+++ b/test/1.2/registers/T_largeoffset_map.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_lowarray.dml
+++ b/test/1.2/registers/T_lowarray.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_lowarray.py
+++ b/test/1.2/registers/T_lowarray.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from stest import *

--- a/test/1.2/registers/T_miss.dml
+++ b/test/1.2/registers/T_miss.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_miss.py
+++ b/test/1.2/registers/T_miss.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Test how side-effects are carried out in failing accesses.

--- a/test/1.2/registers/T_miss_pattern.dml
+++ b/test/1.2/registers/T_miss_pattern.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_miss_pattern.py
+++ b/test/1.2/registers/T_miss_pattern.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import contextlib

--- a/test/1.2/registers/T_numbered.dml
+++ b/test/1.2/registers/T_numbered.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_numbered.py
+++ b/test/1.2/registers/T_numbered.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/registers/T_obj_lists.dml
+++ b/test/1.2/registers/T_obj_lists.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_par_over_endian.dml
+++ b/test/1.2/registers/T_par_over_endian.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_par_over_endian.py
+++ b/test/1.2/registers/T_par_over_endian.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import contextlib

--- a/test/1.2/registers/T_param_expr.dml
+++ b/test/1.2/registers/T_param_expr.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_qname.dml
+++ b/test/1.2/registers/T_qname.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_read_constant.dml
+++ b/test/1.2/registers/T_read_constant.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_read_constant.py
+++ b/test/1.2/registers/T_read_constant.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/registers/T_read_only.dml
+++ b/test/1.2/registers/T_read_only.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_read_only.py
+++ b/test/1.2/registers/T_read_only.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # Test that the read_only template works on registers with and without

--- a/test/1.2/registers/T_register_desc.dml
+++ b/test/1.2/registers/T_register_desc.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_reserved.dml
+++ b/test/1.2/registers/T_reserved.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_reserved.py
+++ b/test/1.2/registers/T_reserved.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 SIM_run_command("log-level 4")

--- a/test/1.2/registers/T_reset.dml
+++ b/test/1.2/registers/T_reset.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_smallarray.dml
+++ b/test/1.2/registers/T_smallarray.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_unmapped_hole.dml
+++ b/test/1.2/registers/T_unmapped_hole.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/registers/T_unmapped_hole.py
+++ b/test/1.2/registers/T_unmapped_hole.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest, dev_util

--- a/test/1.2/registers/imported_be.dml
+++ b/test/1.2/registers/imported_be.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_dowhile.dml
+++ b/test/1.2/statements/T_dowhile.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_for.dml
+++ b/test/1.2/statements/T_for.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_if.dml
+++ b/test/1.2/statements/T_if.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_local_const_struct.dml
+++ b/test/1.2/statements/T_local_const_struct.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_log.dml
+++ b/test/1.2/statements/T_log.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_log.py
+++ b/test/1.2/statements/T_log.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 conf.sim.stop_on_error = False

--- a/test/1.2/statements/T_log_new.dml
+++ b/test/1.2/statements/T_log_new.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_log_new.py
+++ b/test/1.2/statements/T_log_new.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 conf.sim.stop_on_error = False

--- a/test/1.2/statements/T_log_variable_width.dml
+++ b/test/1.2/statements/T_log_variable_width.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_static_in_array.dml
+++ b/test/1.2/statements/T_static_in_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_switch.dml
+++ b/test/1.2/statements/T_switch.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/statements/T_throw.dml
+++ b/test/1.2/statements/T_throw.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_anonymous_objs.dml
+++ b/test/1.2/structure/T_anonymous_objs.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_array_ref.dml
+++ b/test/1.2/structure/T_array_ref.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_array_size_const.dml
+++ b/test/1.2/structure/T_array_size_const.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_attribute_array_1.dml
+++ b/test/1.2/structure/T_attribute_array_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_attribute_array_1.py
+++ b/test/1.2/structure/T_attribute_array_1.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_attribute_array_2.dml
+++ b/test/1.2/structure/T_attribute_array_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_attribute_conf.dml
+++ b/test/1.2/structure/T_attribute_conf.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_attribute_conf.py
+++ b/test/1.2/structure/T_attribute_conf.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_attribute_string.dml
+++ b/test/1.2/structure/T_attribute_string.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_attribute_string.py
+++ b/test/1.2/structure/T_attribute_string.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 obj.s = "teststring"

--- a/test/1.2/structure/T_attribute_throw.dml
+++ b/test/1.2/structure/T_attribute_throw.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_attribute_throw.py
+++ b/test/1.2/structure/T_attribute_throw.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_connect.dml
+++ b/test/1.2/structure/T_connect.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_connect_array.dml
+++ b/test/1.2/structure/T_connect_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_connect_array.py
+++ b/test/1.2/structure/T_connect_array.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_connect_nonreq_int.dml
+++ b/test/1.2/structure/T_connect_nonreq_int.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_connect_obj.dml
+++ b/test/1.2/structure/T_connect_obj.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_connect_validate.dml
+++ b/test/1.2/structure/T_connect_validate.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_connect_validate.py
+++ b/test/1.2/structure/T_connect_validate.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 conf.sim.stop_on_error = False

--- a/test/1.2/structure/T_connects_in_port_array.dml
+++ b/test/1.2/structure/T_connects_in_port_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_connects_in_port_array.py
+++ b/test/1.2/structure/T_connects_in_port_array.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_data.dml
+++ b/test/1.2/structure/T_data.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_desc.dml
+++ b/test/1.2/structure/T_desc.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_desc.py
+++ b/test/1.2/structure/T_desc.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_device.dml
+++ b/test/1.2/structure/T_device.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_doc.dml
+++ b/test/1.2/structure/T_doc.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_doc.py
+++ b/test/1.2/structure/T_doc.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_event_in_connect.dml
+++ b/test/1.2/structure/T_event_in_connect.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_field_data_1.dml
+++ b/test/1.2/structure/T_field_data_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_group.dml
+++ b/test/1.2/structure/T_group.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_group_attr.dml
+++ b/test/1.2/structure/T_group_attr.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_group_attr.py
+++ b/test/1.2/structure/T_group_attr.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 print(obj.b_ga_a)

--- a/test/1.2/structure/T_if.dml
+++ b/test/1.2/structure/T_if.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_istemplate.dml
+++ b/test/1.2/structure/T_istemplate.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_mappable.dml
+++ b/test/1.2/structure/T_mappable.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_mappable.py
+++ b/test/1.2/structure/T_mappable.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_method_parameter_1.dml
+++ b/test/1.2/structure/T_method_parameter_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_method_parameter_2.dml
+++ b/test/1.2/structure/T_method_parameter_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_object_scope.dml
+++ b/test/1.2/structure/T_object_scope.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_parameter_if.dml
+++ b/test/1.2/structure/T_parameter_if.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_parameters.dml
+++ b/test/1.2/structure/T_parameters.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_port.dml
+++ b/test/1.2/structure/T_port.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_port.py
+++ b/test/1.2/structure/T_port.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_port_array.dml
+++ b/test/1.2/structure/T_port_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_port_array.py
+++ b/test/1.2/structure/T_port_array.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.2/structure/T_register_data_1.dml
+++ b/test/1.2/structure/T_register_data_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_register_data_4.dml
+++ b/test/1.2/structure/T_register_data_4.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_register_value_1.dml
+++ b/test/1.2/structure/T_register_value_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_string_attribute.dml
+++ b/test/1.2/structure/T_string_attribute.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/T_string_attribute.py
+++ b/test/1.2/structure/T_string_attribute.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import simics

--- a/test/1.2/structure/T_trait_diamond.dml
+++ b/test/1.2/structure/T_trait_diamond.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/structure/imported_array_size_const.dml
+++ b/test/1.2/structure/imported_array_size_const.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_bitorder_3.dml
+++ b/test/1.2/syntax/T_bitorder_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_cast.dml
+++ b/test/1.2/syntax/T_cast.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_charlit.dml
+++ b/test/1.2/syntax/T_charlit.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_extern_func_1.dml
+++ b/test/1.2/syntax/T_extern_func_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_float.dml
+++ b/test/1.2/syntax/T_float.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_ident.dml
+++ b/test/1.2/syntax/T_ident.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_int.dml
+++ b/test/1.2/syntax/T_int.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_is.dml
+++ b/test/1.2/syntax/T_is.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_local_struct.dml
+++ b/test/1.2/syntax/T_local_struct.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_locals.dml
+++ b/test/1.2/syntax/T_locals.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_newfield.dml
+++ b/test/1.2/syntax/T_newfield.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_precedence.dml
+++ b/test/1.2/syntax/T_precedence.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_select.dml
+++ b/test/1.2/syntax/T_select.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_static.dml
+++ b/test/1.2/syntax/T_static.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_stringlit.dml
+++ b/test/1.2/syntax/T_stringlit.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_typedecl.dml
+++ b/test/1.2/syntax/T_typedecl.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/syntax/T_unicode.dml
+++ b/test/1.2/syntax/T_unicode.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/testing.dml
+++ b/test/1.2/testing.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/toplevel/T_import_alias.dml
+++ b/test/1.2/toplevel/T_import_alias.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/toplevel/import_alias_1.dml
+++ b/test/1.2/toplevel/import_alias_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/toplevel/import_alias_2.dml
+++ b/test/1.2/toplevel/import_alias_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_bank_1.dml
+++ b/test/1.2/trivial/T_bank_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_bank_2.dml
+++ b/test/1.2/trivial/T_bank_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_bank_3.dml
+++ b/test/1.2/trivial/T_bank_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_c_function_1.dml
+++ b/test/1.2/trivial/T_c_function_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_constant_1.dml
+++ b/test/1.2/trivial/T_constant_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_data_1.dml
+++ b/test/1.2/trivial/T_data_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_data_2.dml
+++ b/test/1.2/trivial/T_data_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_extern_1.dml
+++ b/test/1.2/trivial/T_extern_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_field_1.dml
+++ b/test/1.2/trivial/T_field_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_field_2.dml
+++ b/test/1.2/trivial/T_field_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_field_3.dml
+++ b/test/1.2/trivial/T_field_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_header_comment_1.dml
+++ b/test/1.2/trivial/T_header_comment_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 // This is a header comment.

--- a/test/1.2/trivial/T_header_comment_2.dml
+++ b/test/1.2/trivial/T_header_comment_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 // This is a header comment consisting

--- a/test/1.2/trivial/T_header_comment_3.dml
+++ b/test/1.2/trivial/T_header_comment_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.2/trivial/T_header_comment_4.dml
+++ b/test/1.2/trivial/T_header_comment_4.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 /* This is a delimited header comment */

--- a/test/1.2/trivial/T_header_comment_5.dml
+++ b/test/1.2/trivial/T_header_comment_5.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 /* This is a multi-line

--- a/test/1.2/trivial/T_literals_1.dml
+++ b/test/1.2/trivial/T_literals_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_locals_1.dml
+++ b/test/1.2/trivial/T_locals_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_locals_2.dml
+++ b/test/1.2/trivial/T_locals_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_locals_3.dml
+++ b/test/1.2/trivial/T_locals_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_locals_4.dml
+++ b/test/1.2/trivial/T_locals_4.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_locals_5.dml
+++ b/test/1.2/trivial/T_locals_5.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_locals_6.dml
+++ b/test/1.2/trivial/T_locals_6.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_loggroup_1.dml
+++ b/test/1.2/trivial/T_loggroup_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_methods_1.dml
+++ b/test/1.2/trivial/T_methods_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_methods_2.dml
+++ b/test/1.2/trivial/T_methods_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_methods_3.dml
+++ b/test/1.2/trivial/T_methods_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_methods_4.dml
+++ b/test/1.2/trivial/T_methods_4.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_methods_5.dml
+++ b/test/1.2/trivial/T_methods_5.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_methods_6.dml
+++ b/test/1.2/trivial/T_methods_6.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_methods_7.dml
+++ b/test/1.2/trivial/T_methods_7.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_methods_8.dml
+++ b/test/1.2/trivial/T_methods_8.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_nolinebreak_1.dml
+++ b/test/1.2/trivial/T_nolinebreak_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2; device test;

--- a/test/1.2/trivial/T_nolinebreak_2.dml
+++ b/test/1.2/trivial/T_nolinebreak_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 /* a comment */ dml 1.2; device test;

--- a/test/1.2/trivial/T_nolinebreak_3.dml
+++ b/test/1.2/trivial/T_nolinebreak_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2; device test; // a comment

--- a/test/1.2/trivial/T_register_1.dml
+++ b/test/1.2/trivial/T_register_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_register_2.dml
+++ b/test/1.2/trivial/T_register_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_struct_1.dml
+++ b/test/1.2/trivial/T_struct_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_template_1.dml
+++ b/test/1.2/trivial/T_template_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_template_2.dml
+++ b/test/1.2/trivial/T_template_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_template_3.dml
+++ b/test/1.2/trivial/T_template_3.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_typedef_1.dml
+++ b/test/1.2/trivial/T_typedef_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/trivial/T_typedef_2.dml
+++ b/test/1.2/trivial/T_typedef_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/types/T_bitfields.dml
+++ b/test/1.2/types/T_bitfields.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/types/T_endian_int.dml
+++ b/test/1.2/types/T_endian_int.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 // Test functionality of EndianInt types in various contexts

--- a/test/1.2/types/T_inlined_params.dml
+++ b/test/1.2/types/T_inlined_params.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/types/T_pointers.dml
+++ b/test/1.2/types/T_pointers.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/types/T_typedef.dml
+++ b/test/1.2/types/T_typedef.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.2/werror/T_WUNUSEDDEFAULT.dml
+++ b/test/1.2/werror/T_WUNUSEDDEFAULT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.4/errors/EINVOVER.dml
+++ b/test/1.4/errors/EINVOVER.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/ETYPE_integer_t.dml
+++ b/test/1.4/errors/ETYPE_integer_t.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EABSTEMPLATE.dml
+++ b/test/1.4/errors/T_EABSTEMPLATE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EAINCOMP.dml
+++ b/test/1.4/errors/T_EAINCOMP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EAMBINH.dml
+++ b/test/1.4/errors/T_EAMBINH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EANAME.dml
+++ b/test/1.4/errors/T_EANAME.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EANONSTRUCT.dml
+++ b/test/1.4/errors/T_EANONSTRUCT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EAPPLY.dml
+++ b/test/1.4/errors/T_EAPPLY.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EAPPLYMETH.dml
+++ b/test/1.4/errors/T_EAPPLYMETH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EARGD.dml
+++ b/test/1.4/errors/T_EARGD.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EARGT.dml
+++ b/test/1.4/errors/T_EARGT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EASZLARGE.dml
+++ b/test/1.4/errors/T_EASZLARGE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EATTRCOLL.dml
+++ b/test/1.4/errors/T_EATTRCOLL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EAUNKDIMSIZE.dml
+++ b/test/1.4/errors/T_EAUNKDIMSIZE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EBITRN.dml
+++ b/test/1.4/errors/T_EBITRN.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EBITRO.dml
+++ b/test/1.4/errors/T_EBITRO.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EBITRR.dml
+++ b/test/1.4/errors/T_EBITRR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EBTYPE.dml
+++ b/test/1.4/errors/T_EBTYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ECAST.dml
+++ b/test/1.4/errors/T_ECAST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ECONDINEACH.dml
+++ b/test/1.4/errors/T_ECONDINEACH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ECONSTP_stringlit.dml
+++ b/test/1.4/errors/T_ECONSTP_stringlit.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ECSADD.dml
+++ b/test/1.4/errors/T_ECSADD.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ECYCLICTRAIT.dml
+++ b/test/1.4/errors/T_ECYCLICTRAIT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EDATAINIT.dml
+++ b/test/1.4/errors/T_EDATAINIT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EDVAR.dml
+++ b/test/1.4/errors/T_EDVAR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EEMPTYSTRUCT.dml
+++ b/test/1.4/errors/T_EEMPTYSTRUCT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EERRSTMT.dml
+++ b/test/1.4/errors/T_EERRSTMT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EEXPORT.dml
+++ b/test/1.4/errors/T_EEXPORT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EIDENT.dml
+++ b/test/1.4/errors/T_EIDENT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EIDENTSIZEOF.dml
+++ b/test/1.4/errors/T_EIDENTSIZEOF.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EIDXVAR.dml
+++ b/test/1.4/errors/T_EIDXVAR.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EILLCOMP.dml
+++ b/test/1.4/errors/T_EILLCOMP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EINDEPENDENTVIOL.dml
+++ b/test/1.4/errors/T_EINDEPENDENTVIOL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EINVOVER.dml
+++ b/test/1.4/errors/T_EINVOVER.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EINVOVER_confidentiality.dml
+++ b/test/1.4/errors/T_EINVOVER_confidentiality.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ELAYOUT.dml
+++ b/test/1.4/errors/T_ELAYOUT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ELLEV.dml
+++ b/test/1.4/errors/T_ELLEV.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.4/errors/T_EMETH.dml
+++ b/test/1.4/errors/T_EMETH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ENALLOW.dml
+++ b/test/1.4/errors/T_ENALLOW.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.4/errors/T_ENAMECOLL.dml
+++ b/test/1.4/errors/T_ENAMECOLL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ENAMEID.dml
+++ b/test/1.4/errors/T_ENAMEID.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ENCONST.dml
+++ b/test/1.4/errors/T_ENCONST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ENMETH.dml
+++ b/test/1.4/errors/T_ENMETH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ENOBJ.dml
+++ b/test/1.4/errors/T_ENOBJ.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ENORET.dml
+++ b/test/1.4/errors/T_ENORET.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ENSHARED.dml
+++ b/test/1.4/errors/T_ENSHARED.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ENTMPL.dml
+++ b/test/1.4/errors/T_ENTMPL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ENVAL.dml
+++ b/test/1.4/errors/T_ENVAL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EREGOL.dml
+++ b/test/1.4/errors/T_EREGOL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ERETARGNAME.dml
+++ b/test/1.4/errors/T_ERETARGNAME.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ERETARGS.dml
+++ b/test/1.4/errors/T_ERETARGS.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ERETLVALS.dml
+++ b/test/1.4/errors/T_ERETLVALS.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ERVAL.dml
+++ b/test/1.4/errors/T_ERVAL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESAVEDCONST.dml
+++ b/test/1.4/errors/T_ESAVEDCONST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESERIALIZE.dml
+++ b/test/1.4/errors/T_ESERIALIZE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESTATICEXPORT.dml
+++ b/test/1.4/errors/T_ESTATICEXPORT.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESTOREDINLINE.dml
+++ b/test/1.4/errors/T_ESTOREDINLINE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESWITCH.dml
+++ b/test/1.4/errors/T_ESWITCH.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX.dml
+++ b/test/1.4/errors/T_ESYNTAX.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_async.dml
+++ b/test/1.4/errors/T_ESYNTAX_async.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_await.dml
+++ b/test/1.4/errors/T_ESYNTAX_await.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_dollar.dml
+++ b/test/1.4/errors/T_ESYNTAX_dollar.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_hash.dml
+++ b/test/1.4/errors/T_ESYNTAX_hash.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_int_int.dml
+++ b/test/1.4/errors/T_ESYNTAX_int_int.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_label.dml
+++ b/test/1.4/errors/T_ESYNTAX_label.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_method_qualifiers.dml
+++ b/test/1.4/errors/T_ESYNTAX_method_qualifiers.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_multiassign.dml
+++ b/test/1.4/errors/T_ESYNTAX_multiassign.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_after.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_after.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_anon_bank.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_anon_bank.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_array_1.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_array_1.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_array_2.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_array_2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_assign.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_assign.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_assignop.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_assignop.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_call_noargs.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_call_noargs.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_field.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_field.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_log_type.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_log_type.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_method_noparams.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_method_noparams.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_old_parameter.dml
+++ b/test/1.4/errors/T_ESYNTAX_old_parameter.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_signed.dml
+++ b/test/1.4/errors/T_ESYNTAX_signed.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_stringify.dml
+++ b/test/1.4/errors/T_ESYNTAX_stringify.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_struct.dml
+++ b/test/1.4/errors/T_ESYNTAX_struct.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_switch_nested_case.dml
+++ b/test/1.4/errors/T_ESYNTAX_switch_nested_case.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_switch_noncompound.dml
+++ b/test/1.4/errors/T_ESYNTAX_switch_noncompound.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_this.dml
+++ b/test/1.4/errors/T_ESYNTAX_this.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_time_unit.dml
+++ b/test/1.4/errors/T_ESYNTAX_time_unit.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_unicode_bidi.dml
+++ b/test/1.4/errors/T_ESYNTAX_unicode_bidi.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.4/errors/T_ESYNTAX_with.dml
+++ b/test/1.4/errors/T_ESYNTAX_with.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ESYNTAX_zero.dml
+++ b/test/1.4/errors/T_ESYNTAX_zero.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ETRAITUPCAST.dml
+++ b/test/1.4/errors/T_ETRAITUPCAST.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ETYPE.dml
+++ b/test/1.4/errors/T_ETYPE.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_ETYPEDPARAMVIOL.dml
+++ b/test/1.4/errors/T_ETYPEDPARAMVIOL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EUNDEF.dml
+++ b/test/1.4/errors/T_EUNDEF.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EUNOP.dml
+++ b/test/1.4/errors/T_EUNOP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EVERS.dml
+++ b/test/1.4/errors/T_EVERS.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EVLALEN.dml
+++ b/test/1.4/errors/T_EVLALEN.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EVOID.dml
+++ b/test/1.4/errors/T_EVOID.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_EVOID_typedefed.dml
+++ b/test/1.4/errors/T_EVOID_typedefed.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_WASTRUNC.dml
+++ b/test/1.4/errors/T_WASTRUNC.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_WEXPERIMENTAL.dml
+++ b/test/1.4/errors/T_WEXPERIMENTAL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_WNEGCONSTCOMP.dml
+++ b/test/1.4/errors/T_WNEGCONSTCOMP.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_WNOIS.dml
+++ b/test/1.4/errors/T_WNOIS.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_WREDUNDANTLEVEL.dml
+++ b/test/1.4/errors/T_WREDUNDANTLEVEL.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_WTEMPLATEIS.dml
+++ b/test/1.4/errors/T_WTEMPLATEIS.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_WTTYPEC.dml
+++ b/test/1.4/errors/T_WTTYPEC.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/T_WUNUSED_DML12.dml
+++ b/test/1.4/errors/T_WUNUSED_DML12.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/WUNUSED_DML12.dml
+++ b/test/1.4/errors/WUNUSED_DML12.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/errors/dml-1.2.dml
+++ b/test/1.4/errors/dml-1.2.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/1.4/events/T_after.dml
+++ b/test/1.4/events/T_after.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/events/T_after.py
+++ b/test/1.4/events/T_after.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/events/T_after_cancel.dml
+++ b/test/1.4/events/T_after_cancel.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/events/T_after_cancel.py
+++ b/test/1.4/events/T_after_cancel.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/events/T_after_chk.cont.py
+++ b/test/1.4/events/T_after_chk.cont.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/events/T_after_chk.dml
+++ b/test/1.4/events/T_after_chk.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/events/T_after_chk.py
+++ b/test/1.4/events/T_after_chk.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from os.path import join

--- a/test/1.4/expressions/T_add_overflow.dml
+++ b/test/1.4/expressions/T_add_overflow.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/expressions/T_each_in.dml
+++ b/test/1.4/expressions/T_each_in.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/expressions/T_endian_int.dml
+++ b/test/1.4/expressions/T_endian_int.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 // Test functionality of EndianInt types in various contexts

--- a/test/1.4/expressions/T_illegal_arithmetic.dml
+++ b/test/1.4/expressions/T_illegal_arithmetic.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/expressions/T_illegal_arithmetic.py
+++ b/test/1.4/expressions/T_illegal_arithmetic.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import simics

--- a/test/1.4/expressions/T_length.dml
+++ b/test/1.4/expressions/T_length.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/expressions/T_ptr_incdec.dml
+++ b/test/1.4/expressions/T_ptr_incdec.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/expressions/T_static_export.dml
+++ b/test/1.4/expressions/T_static_export.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/expressions/T_stringify.dml
+++ b/test/1.4/expressions/T_stringify.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 // Test the current expected functionality of the 'stringify' construct

--- a/test/1.4/expressions/T_trait_identity.dml
+++ b/test/1.4/expressions/T_trait_identity.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/layout/T_array.dml
+++ b/test/1.4/layout/T_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/layout/T_bitfields.dml
+++ b/test/1.4/layout/T_bitfields.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/layout/T_member_ref.dml
+++ b/test/1.4/layout/T_member_ref.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/layout/T_mixed_endian.dml
+++ b/test/1.4/layout/T_mixed_endian.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/layout/T_nested-assignment.dml
+++ b/test/1.4/layout/T_nested-assignment.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/layout/T_simple.dml
+++ b/test/1.4/layout/T_simple.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_attributes.dml
+++ b/test/1.4/lib/T_attributes.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_bad_subobj_connect.dml
+++ b/test/1.4/lib/T_bad_subobj_connect.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_bad_subobj_connect.py
+++ b/test/1.4/lib/T_bad_subobj_connect.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from simics_common import CriticalErrors

--- a/test/1.4/lib/T_byte_enable.dml
+++ b/test/1.4/lib/T_byte_enable.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_connect.dml
+++ b/test/1.4/lib/T_connect.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_connect.py
+++ b/test/1.4/lib/T_connect.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import pyobj

--- a/test/1.4/lib/T_event.dml
+++ b/test/1.4/lib/T_event.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_event.py
+++ b/test/1.4/lib/T_event.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/lib/T_event_large_uint64.dml
+++ b/test/1.4/lib/T_event_large_uint64.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_event_large_uint64.py
+++ b/test/1.4/lib/T_event_large_uint64.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/lib/T_field.dml
+++ b/test/1.4/lib/T_field.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_field.py
+++ b/test/1.4/lib/T_field.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/1.4/lib/T_indices.dml
+++ b/test/1.4/lib/T_indices.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_internal.dml
+++ b/test/1.4/lib/T_internal.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_io_memory.dml
+++ b/test/1.4/lib/T_io_memory.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_io_memory.py
+++ b/test/1.4/lib/T_io_memory.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/lib/T_largearray.dml
+++ b/test/1.4/lib/T_largearray.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_largearray.py
+++ b/test/1.4/lib/T_largearray.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/1.4/lib/T_map_target_connect.dml
+++ b/test/1.4/lib/T_map_target_connect.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_map_target_connect.py
+++ b/test/1.4/lib/T_map_target_connect.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/lib/T_miss_pattern.dml
+++ b/test/1.4/lib/T_miss_pattern.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_miss_pattern.py
+++ b/test/1.4/lib/T_miss_pattern.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import contextlib

--- a/test/1.4/lib/T_obscureable.dml
+++ b/test/1.4/lib/T_obscureable.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_qname.dml
+++ b/test/1.4/lib/T_qname.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_regdisp.dml
+++ b/test/1.4/lib/T_regdisp.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_regdisp.py
+++ b/test/1.4/lib/T_regdisp.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import contextlib

--- a/test/1.4/lib/T_registers.dml
+++ b/test/1.4/lib/T_registers.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_reset.dml
+++ b/test/1.4/lib/T_reset.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_reset.py
+++ b/test/1.4/lib/T_reset.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/lib/T_signal_templates.dml
+++ b/test/1.4/lib/T_signal_templates.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 /// INSTANTIATE-MANUALLY

--- a/test/1.4/lib/T_signal_templates.py
+++ b/test/1.4/lib/T_signal_templates.py
@@ -1,4 +1,4 @@
-# © 2022-2024 Intel Corporation
+# © 2022 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import os

--- a/test/1.4/lib/T_transaction.dml
+++ b/test/1.4/lib/T_transaction.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.4/lib/T_transaction.py
+++ b/test/1.4/lib/T_transaction.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from simics import Sim_PE_No_Exception

--- a/test/1.4/lib/T_unmapped_access.dml
+++ b/test/1.4/lib/T_unmapped_access.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_utility.dml
+++ b/test/1.4/lib/T_utility.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/lib/T_utility.py
+++ b/test/1.4/lib/T_utility.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/lib/utility_12_common.dml
+++ b/test/1.4/lib/utility_12_common.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/methods/T_default.dml
+++ b/test/1.4/methods/T_default.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/methods/T_independent.dml
+++ b/test/1.4/methods/T_independent.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/methods/T_inline.dml
+++ b/test/1.4/methods/T_inline.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/methods/T_startup.dml
+++ b/test/1.4/methods/T_startup.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/methods/T_startup.py
+++ b/test/1.4/methods/T_startup.py
@@ -1,4 +1,4 @@
-# © 2022-2024 Intel Corporation
+# © 2022 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/methods/T_startup_memoized.dml
+++ b/test/1.4/methods/T_startup_memoized.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/methods/T_startup_memoized.py
+++ b/test/1.4/methods/T_startup_memoized.py
@@ -1,4 +1,4 @@
-# © 2022-2024 Intel Corporation
+# © 2022 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import itertools

--- a/test/1.4/methods/T_trunc.dml
+++ b/test/1.4/methods/T_trunc.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_bitorder_override.dml
+++ b/test/1.4/misc/T_bitorder_override.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_dmllib.dml
+++ b/test/1.4/misc/T_dmllib.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_dmllib.h
+++ b/test/1.4/misc/T_dmllib.h
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.4/misc/T_import_dml14.dml
+++ b/test/1.4/misc/T_import_dml14.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_import_rel.dml
+++ b/test/1.4/misc/T_import_rel.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_integer_t.dml
+++ b/test/1.4/misc/T_integer_t.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_notify_state.dml
+++ b/test/1.4/misc/T_notify_state.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_notify_state.py
+++ b/test/1.4/misc/T_notify_state.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/misc/T_porting.dml
+++ b/test/1.4/misc/T_porting.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_porting_compat.dml
+++ b/test/1.4/misc/T_porting_compat.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_porting_fail.dml
+++ b/test/1.4/misc/T_porting_fail.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_register_view.dml
+++ b/test/1.4/misc/T_register_view.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_register_view.py
+++ b/test/1.4/misc/T_register_view.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import test_register_view

--- a/test/1.4/misc/T_register_view_bitorder_be.dml
+++ b/test/1.4/misc/T_register_view_bitorder_be.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_register_view_bitorder_be.py
+++ b/test/1.4/misc/T_register_view_bitorder_be.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from stest import expect_true

--- a/test/1.4/misc/T_register_view_bitorder_le.dml
+++ b/test/1.4/misc/T_register_view_bitorder_le.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_register_view_bitorder_le.py
+++ b/test/1.4/misc/T_register_view_bitorder_le.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from stest import expect_false

--- a/test/1.4/misc/T_register_view_descriptions.dml
+++ b/test/1.4/misc/T_register_view_descriptions.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_register_view_descriptions.py
+++ b/test/1.4/misc/T_register_view_descriptions.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import test_register_view_descriptions

--- a/test/1.4/misc/T_register_view_fields.dml
+++ b/test/1.4/misc/T_register_view_fields.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_register_view_fields.py
+++ b/test/1.4/misc/T_register_view_fields.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from simics import *

--- a/test/1.4/misc/T_register_view_inquiry.dml
+++ b/test/1.4/misc/T_register_view_inquiry.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_register_view_inquiry.py
+++ b/test/1.4/misc/T_register_view_inquiry.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import test_register_view_inquiry

--- a/test/1.4/misc/T_register_view_read_only.dml
+++ b/test/1.4/misc/T_register_view_read_only.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/T_register_view_read_only.py
+++ b/test/1.4/misc/T_register_view_read_only.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from simics import SIM_get_port_interface

--- a/test/1.4/misc/T_unmapped_get.dml
+++ b/test/1.4/misc/T_unmapped_get.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/devinfo.dml
+++ b/test/1.4/misc/devinfo.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/porting-common-compat.dml
+++ b/test/1.4/misc/porting-common-compat.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/porting-common-dml14.dml
+++ b/test/1.4/misc/porting-common-dml14.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/porting-common.dml
+++ b/test/1.4/misc/porting-common.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/porting-import.dml
+++ b/test/1.4/misc/porting-import.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/porting-imported.dml
+++ b/test/1.4/misc/porting-imported.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/porting.dml
+++ b/test/1.4/misc/porting.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 

--- a/test/1.4/misc/rel/a/x.dml
+++ b/test/1.4/misc/rel/a/x.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/rel/a/y.dml
+++ b/test/1.4/misc/rel/a/y.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/rel/misc/rel/z.dml
+++ b/test/1.4/misc/rel/misc/rel/z.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/rel/z.dml
+++ b/test/1.4/misc/rel/z.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/misc/test_dmlc_g.dml
+++ b/test/1.4/misc/test_dmlc_g.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 // test-dmlc-g.dml - A device containing DML items to test dmlc's -g flag

--- a/test/1.4/misc/test_dmlc_g.py
+++ b/test/1.4/misc/test_dmlc_g.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import os

--- a/test/1.4/registers/T_inquiry.dml
+++ b/test/1.4/registers/T_inquiry.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/registers/T_inquiry.py
+++ b/test/1.4/registers/T_inquiry.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from dev_util import Register_LE

--- a/test/1.4/registers/T_instrumentation_io_memory.dml
+++ b/test/1.4/registers/T_instrumentation_io_memory.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/registers/T_instrumentation_io_memory.py
+++ b/test/1.4/registers/T_instrumentation_io_memory.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import instrumentation_test

--- a/test/1.4/registers/T_instrumentation_transaction.dml
+++ b/test/1.4/registers/T_instrumentation_transaction.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/registers/T_instrumentation_transaction.py
+++ b/test/1.4/registers/T_instrumentation_transaction.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from instrumentation_test import test

--- a/test/1.4/registers/instrumentation.dml
+++ b/test/1.4/registers/instrumentation.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/registers/instrumentation_test.py
+++ b/test/1.4/registers/instrumentation_test.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import instrumentation_access_inquire

--- a/test/1.4/saved/T_simple.py
+++ b/test/1.4/saved/T_simple.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/serialize/T_identity_compat.dml
+++ b/test/1.4/serialize/T_identity_compat.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/serialize/T_identity_compat.py
+++ b/test/1.4/serialize/T_identity_compat.py
@@ -1,4 +1,4 @@
-# © 2022-2024 Intel Corporation
+# © 2022 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/serialize/T_saved_dead_vtable.dml
+++ b/test/1.4/serialize/T_saved_dead_vtable.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/serialize/T_saved_declaration.dml
+++ b/test/1.4/serialize/T_saved_declaration.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/serialize/T_saved_declaration.py
+++ b/test/1.4/serialize/T_saved_declaration.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/serialize/T_saved_failure.dml
+++ b/test/1.4/serialize/T_saved_failure.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/serialize/T_saved_failure.py
+++ b/test/1.4/serialize/T_saved_failure.py
@@ -1,4 +1,4 @@
-# © 2022-2024 Intel Corporation
+# © 2022 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/serialize/T_saved_statement.dml
+++ b/test/1.4/serialize/T_saved_statement.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/serialize/T_saved_statement.py
+++ b/test/1.4/serialize/T_saved_statement.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/serialize/T_shared_method.dml
+++ b/test/1.4/serialize/T_shared_method.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/statements/T_endian_int_aliasing.dml
+++ b/test/1.4/statements/T_endian_int_aliasing.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/statements/T_export.dml
+++ b/test/1.4/statements/T_export.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/statements/T_hashforeach.dml
+++ b/test/1.4/statements/T_hashforeach.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/statements/T_log.dml
+++ b/test/1.4/statements/T_log.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/statements/T_nonconstant_compound_inits.dml
+++ b/test/1.4/statements/T_nonconstant_compound_inits.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/statements/T_return.dml
+++ b/test/1.4/statements/T_return.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/statements/T_subsequent_log.dml
+++ b/test/1.4/statements/T_subsequent_log.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/statements/T_subsequent_log.py
+++ b/test/1.4/statements/T_subsequent_log.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import simics

--- a/test/1.4/statements/T_throwing_initializers.dml
+++ b/test/1.4/statements/T_throwing_initializers.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_array_size_param.dml
+++ b/test/1.4/structure/T_array_size_param.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_connect_array.dml
+++ b/test/1.4/structure/T_connect_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_connect_array.py
+++ b/test/1.4/structure/T_connect_array.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/structure/T_group.dml
+++ b/test/1.4/structure/T_group.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_in_each.dml
+++ b/test/1.4/structure/T_in_each.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_loggroup.dml
+++ b/test/1.4/structure/T_loggroup.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_loggroup.py
+++ b/test/1.4/structure/T_loggroup.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/structure/T_name_parameter.dml
+++ b/test/1.4/structure/T_name_parameter.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_object_naming.dml
+++ b/test/1.4/structure/T_object_naming.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_portobj.dml
+++ b/test/1.4/structure/T_portobj.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_scope.dml
+++ b/test/1.4/structure/T_scope.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_subobjs.dml
+++ b/test/1.4/structure/T_subobjs.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_subobjs.py
+++ b/test/1.4/structure/T_subobjs.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/1.4/structure/T_trait.dml
+++ b/test/1.4/structure/T_trait.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_trait_abstract.dml
+++ b/test/1.4/structure/T_trait_abstract.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_trait_array.dml
+++ b/test/1.4/structure/T_trait_array.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_trait_dce.dml
+++ b/test/1.4/structure/T_trait_dce.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_trait_diamond_default.dml
+++ b/test/1.4/structure/T_trait_diamond_default.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_trait_largearray.dml
+++ b/test/1.4/structure/T_trait_largearray.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_trait_largearray.py
+++ b/test/1.4/structure/T_trait_largearray.py
@@ -1,4 +1,4 @@
-# © 2022-2024 Intel Corporation
+# © 2022 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from simicsutils.host import is_windows

--- a/test/1.4/structure/T_trait_shadow.dml
+++ b/test/1.4/structure/T_trait_shadow.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/T_traitref_data_init.dml
+++ b/test/1.4/structure/T_traitref_data_init.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/structure/group_hierarchy.dml
+++ b/test/1.4/structure/group_hierarchy.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/syntax/T_assign.dml
+++ b/test/1.4/syntax/T_assign.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/syntax/T_designated_initializers.dml
+++ b/test/1.4/syntax/T_designated_initializers.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/syntax/T_invoke.dml
+++ b/test/1.4/syntax/T_invoke.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/syntax/T_multidecls.dml
+++ b/test/1.4/syntax/T_multidecls.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/syntax/T_objects.dml
+++ b/test/1.4/syntax/T_objects.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/syntax/T_shadowing.dml
+++ b/test/1.4/syntax/T_shadowing.dml
@@ -1,5 +1,5 @@
 /*
-  © 2022-2024 Intel Corporation
+  © 2022 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/syntax/T_switch.dml
+++ b/test/1.4/syntax/T_switch.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/trivial/T_minimal.dml
+++ b/test/1.4/trivial/T_minimal.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/types/T_anonymous_structs.dml
+++ b/test/1.4/types/T_anonymous_structs.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/1.4/types/T_extern_typedef.dml
+++ b/test/1.4/types/T_extern_typedef.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.4;

--- a/test/bugs/T_10206.dml
+++ b/test/bugs/T_10206.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_10634.dml
+++ b/test/bugs/T_10634.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_11373.dml
+++ b/test/bugs/T_11373.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_15852.dml
+++ b/test/bugs/T_15852.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_15852.py
+++ b/test/bugs/T_15852.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/bugs/T_17420.dml
+++ b/test/bugs/T_17420.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_17423.dml
+++ b/test/bugs/T_17423.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_17423.py
+++ b/test/bugs/T_17423.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 obj.log_level = 4

--- a/test/bugs/T_17729.dml
+++ b/test/bugs/T_17729.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_17729.py
+++ b/test/bugs/T_17729.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import stest

--- a/test/bugs/T_1973.dml
+++ b/test/bugs/T_1973.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_24144.dml
+++ b/test/bugs/T_24144.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_2595.dml
+++ b/test/bugs/T_2595.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_2722.dml
+++ b/test/bugs/T_2722.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_2967.dml
+++ b/test/bugs/T_2967.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_3059.dml
+++ b/test/bugs/T_3059.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_3193.dml
+++ b/test/bugs/T_3193.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_3307.dml
+++ b/test/bugs/T_3307.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_3369.dml
+++ b/test/bugs/T_3369.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_4050.dml
+++ b/test/bugs/T_4050.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_4776.dml
+++ b/test/bugs/T_4776.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_4873.dml
+++ b/test/bugs/T_4873.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_4873.py
+++ b/test/bugs/T_4873.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 mem = SIM_create_object("memory-space", "mem",

--- a/test/bugs/T_4888.dml
+++ b/test/bugs/T_4888.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_4970.dml
+++ b/test/bugs/T_4970.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5023.dml
+++ b/test/bugs/T_5023.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5182.dml
+++ b/test/bugs/T_5182.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5229_12.dml
+++ b/test/bugs/T_5229_12.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5262.dml
+++ b/test/bugs/T_5262.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5269.dml
+++ b/test/bugs/T_5269.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5290.dml
+++ b/test/bugs/T_5290.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5425.dml
+++ b/test/bugs/T_5425.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5557.dml
+++ b/test/bugs/T_5557.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5878.dml
+++ b/test/bugs/T_5878.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_5878.py
+++ b/test/bugs/T_5878.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 obj.log_level = 4

--- a/test/bugs/T_6227.dml
+++ b/test/bugs/T_6227.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_6987.dml
+++ b/test/bugs/T_6987.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_9335.dml
+++ b/test/bugs/T_9335.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/bugs/T_9563.dml
+++ b/test/bugs/T_9563.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/common/instrumentation_access_inquire.py
+++ b/test/common/instrumentation_access_inquire.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_access_set_missed.py
+++ b/test/common/instrumentation_access_set_missed.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_access_set_offset.py
+++ b/test/common/instrumentation_access_set_offset.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_access_set_value.py
+++ b/test/common/instrumentation_access_set_value.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_access_suppress.py
+++ b/test/common/instrumentation_access_suppress.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_access_value_at_miss.py
+++ b/test/common/instrumentation_access_value_at_miss.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_bank_array.py
+++ b/test/common/instrumentation_bank_array.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from dev_util import Register_LE

--- a/test/common/instrumentation_callback_args.py
+++ b/test/common/instrumentation_callback_args.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_callback_inquiry.py
+++ b/test/common/instrumentation_callback_inquiry.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_callback_order.py
+++ b/test/common/instrumentation_callback_order.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_common.py
+++ b/test/common/instrumentation_common.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 from pyobj import ConfObject

--- a/test/common/instrumentation_connection_order.py
+++ b/test/common/instrumentation_connection_order.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_disable_connection.py
+++ b/test/common/instrumentation_disable_connection.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_endianness.py
+++ b/test/common/instrumentation_endianness.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_endianness_overlapping.py
+++ b/test/common/instrumentation_endianness_overlapping.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_instrument_all.py
+++ b/test/common/instrumentation_instrument_all.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_instrument_edge.py
+++ b/test/common/instrumentation_instrument_edge.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_overlapping_order.py
+++ b/test/common/instrumentation_overlapping_order.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_range.py
+++ b/test/common/instrumentation_range.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_remove_callback.py
+++ b/test/common/instrumentation_remove_callback.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_remove_connection_callbacks.py
+++ b/test/common/instrumentation_remove_connection_callbacks.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/instrumentation_subscribe_multiple.py
+++ b/test/common/instrumentation_subscribe_multiple.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/test_register_view.py
+++ b/test/common/test_register_view.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import dev_util

--- a/test/common/test_register_view_descriptions.py
+++ b/test/common/test_register_view_descriptions.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 # This test makes sure we always return the same documentation of DML

--- a/test/common/test_register_view_inquiry.py
+++ b/test/common/test_register_view_inquiry.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import simics

--- a/test/depfile.py
+++ b/test/depfile.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 def parse_depfile(f):

--- a/test/minimal.dml
+++ b/test/minimal.dml
@@ -1,5 +1,5 @@
 /*
-  © 2021-2024 Intel Corporation
+  © 2021 Intel Corporation
   SPDX-License-Identifier: MPL-2.0
 */
 dml 1.2;

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys, time

--- a/validate_md_links.py
+++ b/validate_md_links.py
@@ -1,4 +1,4 @@
-# © 2021-2024 Intel Corporation
+# © 2021 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
 import sys


### PR DESCRIPTION
I suppose this should be fine, since the rest of Simics no longer requires
the end-year to be up to date.
