### PR TITLE
Make test works with sym-linked sources

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -1203,7 +1203,8 @@ class DmlDep(DmlDepBase):
             join(testdir, '1.2', 'misc', 'rel', 'a', 'x.h'),
             join(testdir, '1.2', 'misc', 'rel', 'a', 'y.h')]
         for exp in expected_subset:
-            if all(os.path.normpath(p) != os.path.normpath(exp)
+            if all(os.path.normpath(os.path.realpath(p))
+                   != os.path.normpath(os.path.realpath(exp))
                    for p in prereqs):
                 raise TestFail('missing prerequisite: ' + exp)
 


### PR DESCRIPTION
More recent MinGW versions resolve symlinks when embedded source references in dependecy files.
Hence, the test should also ensure it always uses the resolved locations for both source and target (older MinGW might still not resolve locations, so only resolving one of the two would then confuse these).
