### PR TITLE
Leverage location when typechecking method overrides

### DIFF
--- a/RELEASENOTES.docu
+++ b/RELEASENOTES.docu
@@ -1757,4 +1757,8 @@ extern typedef struct { } my_type_t;</pre> </add-note></build-id>
       version 7 by passing either <tt>--warn=WLOGMIXUP</tt> (as before) or
       <tt>--no-compat=suppress_WLOGMIXUP</tt> to DMLC.</add-note>
   </build-id>
+  <build-id _6="next" _7="next"><add-note> Fixed an issue where leveraging
+      <tt>typeof</tt> within a method signature would lead to incorrect
+      compile-time errors when the method is overridden.</add-note>
+  </build-id>
 </rn>

--- a/test/1.4/types/T_typeof.dml
+++ b/test/1.4/types/T_typeof.dml
@@ -1,0 +1,25 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+
+template negative_checker {
+    param int_type_carrier;
+    method is_negative(typeof(int_type_carrier) i) -> (bool) default {
+        return false;
+    }
+}
+
+group int64_checker is negative_checker {
+    param int_type_carrier = *cast(NULL, int64 *);
+    method is_negative(int64 i) -> (bool) {
+        return i < 0;
+    }
+}
+
+
+method init() {
+    assert int64_checker.is_negative(-1);
+}


### PR DESCRIPTION
This fixes an issue when leveraging `typeof`: that a method signature using it would lead to incorrect compile-time errors if the method is overridden.

Ran into this while doing simple regs work. This PR alone should be an uncontroversial fix, however, I am looking warily at other uses of `eval_type` where `None` is passed as the location. Most of it is trait-related, which should really only be able to leverage top-level stuff -- however, today, they can't even do that, as they have no access to even `dev`. That question however should be left to a different PR.