### PR TITLE
Fix immediate after callbacks not notifying about state change

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -526,4 +526,7 @@
   <build-id _6="6287" _7="7012"><add-note> Fixed a bug where overlapping
       registers would not be rejected if they were part of a bank within a group
       or subdevice.</add-note></build-id>
+  <build-id _6="next" _7="next"><add-note> Fixed a bug where executed callbacks
+      posted via immediate after statements would not trigger the device state
+      change notifier.</add-note></build-id>
 </rn>

--- a/py/dml/c_backend.py
+++ b/py/dml/c_backend.py
@@ -1222,6 +1222,7 @@ def generate_immediate_after_callbacks(device):
         indices_lit = 'indices' if info.dimensions else None
         args_lit = 'args' if info.args_type else None
         info.generate_callback_call(indices_lit, args_lit)
+        output_dml_state_change('_dev')
         out('}\n\n', preindent = -1)
         splitting_point()
 

--- a/test/1.4/misc/T_notify_state.dml
+++ b/test/1.4/misc/T_notify_state.dml
@@ -100,6 +100,16 @@ attribute ev is write_only_attr {
     }
 }
 
+attribute immediate_after is write_only_attr {
+    param type = "n";
+    method event() {
+        log info, 1: "Immediate after triggered";
+    }
+    method set(attr_value_t val) throws default {
+        after: event();
+    }
+}
+
 implement signal {
     method signal_raise() {
         log info, 1: "Interface method called";

--- a/test/1.4/misc/T_notify_state.py
+++ b/test/1.4/misc/T_notify_state.py
@@ -39,3 +39,11 @@ stest.expect_equal(obj.count, 6)
 SIM_notify(obj, SIM_notifier_type("statically-exported-entry"))
 
 stest.expect_equal(obj.count, 7)
+
+obj.immediate_after = None
+
+stest.expect_equal(obj.count, 8)
+
+SIM_process_pending_work()
+
+stest.expect_equal(obj.count, 9)


### PR DESCRIPTION
I kinda sorta forgot about this when I wrote immediate after.

After-on-hooks doesn't have the same problem as messages can only be sent through a hook from within DML itself.