### PR TITLE
Document order semantics of `each`-`in` and `init`

### DIFF
--- a/doc/1.4/language.md
+++ b/doc/1.4/language.md
@@ -3897,6 +3897,13 @@ template itself contain a method that descends into subobjects; the
 implementation of `hard_reset` in `utility.dml`
 demonstrates how this can be done.
 
+The order in which objects are given by a specific `each`-`in` expression is not
+defined, except for that it is deterministic. That is, for a particular choice
+of template `X` and object `Y` in an `each X in (Y)` expression, for a
+particular iteration of the device model, and for the particular DMLC build
+used, the order in which objects are given by that expression is guaranteed to
+be consistent.
+
 ### List Expressions
 
 <pre>

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -365,7 +365,12 @@ device is created, *before* any attributes have been
 initialized. Typically used to initialize a default value, or to set up data
 structures.
 
-The method `init` is automatically called on all objects that implement the `init` template.
+The method `init` is automatically called on all objects that implement the
+`init` template. The order in which `init` of objects are called is not
+defined, except that `init` of a particular object is guaranteed to be called
+before `init` of any of its parent objects. In particular, `init` of the device
+object will be called only after all other implementations of `init`.
+
 */
 template init {
     param _each_init : sequence(init);


### PR DESCRIPTION
I thought we already did explicitly say the order of `each`-`in`s was not defined, but nope.