### PR TITLE
Use compat features to deprecate bad version statements

### DIFF
--- a/lib/1.2/dml-builtins.dml
+++ b/lib/1.2/dml-builtins.dml
@@ -208,6 +208,7 @@ template device {
 
     parameter _compat_port_proxy_ifaces auto;
     parameter _compat_port_proxy_attrs auto;
+    parameter _compat_optional_version_statement auto;
     parameter _compat_function_in_extern_struct auto;
     parameter _compat_port_obj_param auto;
     parameter _compat_io_memory auto;

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -544,6 +544,7 @@ template device {
     param _compat_port_proxy_ifaces auto;
     param _compat_port_proxy_attrs auto;
     param _compat_function_in_extern_struct auto;
+    param _compat_optional_version_statement auto;
     param _compat_port_obj_param auto;
     param _compat_io_memory auto;
     param _compat_shared_logs_on_device auto;

--- a/py/dml/compat.py
+++ b/py/dml/compat.py
@@ -102,6 +102,18 @@ class function_in_extern_struct(CompatFeature):
     short = 'Disallow non-pointer function members in extern structs'
     last_api_version = api_7
 
+
+@feature
+class optional_version_statement(CompatFeature):
+    '''When this compatibility feature is enabled, the version
+    specification statement (`dml 1.4;`) statement at the start of
+    each file is optional (but the compiler warns if it is
+    omitted). Also, `dml 1.3;` is permitted as a deprecated alias for
+    `dml 1.4;`, with a warning.'''
+    short = "Make the DML version statement optional"
+    last_api_version = api_7
+
+
 @feature
 class io_memory(CompatFeature):
     '''The `transaction` interface was introduced in 6, and will

--- a/py/dml/compat.py
+++ b/py/dml/compat.py
@@ -99,7 +99,7 @@ class function_in_extern_struct(CompatFeature):
     } my_interface_t;
     ```
     '''
-    short = 'Disallow non-pointer function members in extern structs'
+    short = 'Allow non-pointer function members in extern structs'
     last_api_version = api_7
 
 

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1645,7 +1645,7 @@ class ELOGGROUPS(DMLError):
 
 class WNOVER(DMLWarning):
     """
-    A DML file must start with a version statement, such as `dml 1.2;`
+    A DML file must start with a version statement, such as `dml 1.4;`
     """
     fmt = "file has no version tag, assuming version 1.2"
 

--- a/test/1.2/errors/T_WNOVER.dml
+++ b/test/1.2/errors/T_WNOVER.dml
@@ -1,8 +1,0 @@
-/*
-  © 2021 Intel Corporation
-  SPDX-License-Identifier: MPL-2.0
-*/
-/// WARNING WNOVER T_WNOVER.dml
-/// COMPILE-ONLY
-
-device test;

--- a/test/1.4/legacy/T_optional_version_statement_1.3_disabled.dml
+++ b/test/1.4/legacy/T_optional_version_statement_1.3_disabled.dml
@@ -1,0 +1,9 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+/// DMLC-FLAG --no-compat=optional_version_statement
+/// ERROR ESYNTAX
+dml 1.3;
+
+device test;

--- a/test/1.4/legacy/T_optional_version_statement_1.3_enabled.dml
+++ b/test/1.4/legacy/T_optional_version_statement_1.3_enabled.dml
@@ -1,0 +1,9 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+/// DMLC-FLAG --simics-api=7
+/// WARNING WDEPRECATED
+dml 1.3;
+
+device test;

--- a/test/1.4/legacy/T_optional_version_statement_disabled.dml
+++ b/test/1.4/legacy/T_optional_version_statement_disabled.dml
@@ -1,0 +1,8 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+/// DMLC-FLAG --no-compat=optional_version_statement
+/// ERROR ESYNTAX T_optional_version_statement_disabled.dml
+
+device test;

--- a/test/1.4/legacy/T_optional_version_statement_enabled.dml
+++ b/test/1.4/legacy/T_optional_version_statement_enabled.dml
@@ -1,0 +1,8 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+/// DMLC-FLAG --simics-api=7
+/// WARNING WNOVER T_optional_version_statement_enabled.dml
+
+device test;

--- a/test/tests.py
+++ b/test/tests.py
@@ -15,9 +15,9 @@ from os.path import join, isdir, exists
 import glob
 import json
 from simicsutils.host import host_type, is_windows, batch_suffix
-from simicsutils.internal import package_path, get_simics_major
+from simicsutils.internal import get_simics_major
 import testparams
-from testparams import simics_base_path
+from testparams import package_path, simics_base_path
 import traceback
 from depfile import parse_depfile
 import pstats


### PR DESCRIPTION
- **Use compat features to deprecate bad version statements**
- **Improve wording**
- **Use package_path from Simics base**
