### PR TITLE
Template-Qualified Method Implementation Calls -- SIMICS-22264

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -537,4 +537,11 @@
       template now allows for its implementations of <tt>unmapped_read</tt>,
       <tt>unmapped_write</tt>, and <tt>unmapped_get</tt> to be
       overridden. </add-note></build-id>
+  <build-id _6="next" _7="next"><add-note> It's now allowed to instantiate
+      multiple unrelated templates that offer different <tt>shared</tt>
+      implementations of the same method, as long as that method is declared
+      in a common ancestor template, and the conflict is resolved through
+      an implementation that overrides all the unrelated implementations
+      <bug number="SIMICS-20431"/>. This mirrors the pre-existing semantics for
+      non-<tt>shared</tt> methods.</add-note></build-id>
 </rn>

--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -544,4 +544,18 @@
       an implementation that overrides all the unrelated implementations
       <bug number="SIMICS-20431"/>. This mirrors the pre-existing semantics for
       non-<tt>shared</tt> methods.</add-note></build-id>
+  <build-id _6="next" _7="next"><add-note> Added the `templates` member for
+      all objects and values of template types, which allows for making calls
+      to any particular implementation of a method as provided by a specified
+      template <bug number="SIMICS-22264"/>. Example syntax:
+      <pre>
+      // Call the `write_register()` implementation as provided by the
+      // `register` template on the `r` register of the bank `b`.
+      b.r.templates.register.write_register(...);
+      </pre>
+      Calls of this form are called <em>Template-Qualified Method Implementation
+      Calls</em>, and are primarily meant to make it easier to resolve conflicts
+      in multiple inheritance: it allows any method that overrides multiple
+      implementations from unrelated templates to individually reference and
+      call the implementations it overrides.</add-note></build-id>
 </rn>

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -429,6 +429,9 @@ which cannot be overridden:
 
 * dev: The top-level `device` object
 
+* templates: see [Template-Qualified Method Implementation
+  Calls](language.html#template-qualified-method-implementation-calls).
+
 * indices: List of local indices for this object. For a non-array
   object, this is the empty list. In a register array of size N, it is
   a list with one element, a non-negative integer smaller than N. The

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -482,6 +482,9 @@ template object is (name, _qname, desc, documentation, limitations) {
 
     param dev                       = defined parent #? parent.dev #: this;
 
+    // For template-qualified method implementation calls
+    param templates                 auto;
+
     shared method cancel_after() {
         local object ref = this;
         _cancel_simple_events(dev.obj, cast(&ref, _traitref_t *)->id);

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -1245,37 +1245,10 @@ def expr_objectref(tree, location, scope):
                     dmlparse.start_site(tree.site), '', prefix))
     return e
 
-def try_resolve_len(site, lh):
-    if isinstance(lh, NonValue):
-        if isinstance(lh, AbstractList):
-            return mkIntegerConstant(site,
-                                     len(tuple(lh.iter_flat())), False)
-        elif isinstance(lh, NonValueArrayRef):
-            return mkIntegerConstant(site,
-                                     lh.local_dimsizes[len(lh.local_indices)],
-                                     False)
-    return None
-
 @expression_dispatcher
 def expr_member(tree, location, scope):
     [lh, op, rh] = tree.args
     lh = codegen_expression_maybe_nonvalue(lh, location, scope)
-    if op == '.':
-        if not tree.site.dml_version() == (1, 2) and rh == 'len':
-            member = try_resolve_len(tree.site, lh)
-            if member:
-                return member
-        elif isinstance(lh, TemplatesRef):
-            return mkTemplatesSubRef(tree.site, lh, rh)
-        elif isinstance(lh, TemplatesSubRef):
-            return mkTemplateQualifiedMethodRef(tree.site, lh, rh)
-        elif isinstance(lh, TraitTemplatesRef):
-            return mkTraitTemplatesSubRef(tree.site, lh, rh)
-        elif isinstance(lh, TraitTemplatesSubRef):
-            return mkTraitTemplateQualifiedMethodRef(tree.site, lh, rh)
-
-    if isinstance(lh, NonValue) and not isinstance(lh, NodeRef):
-        raise lh.exc()
 
     return mkSubRef(tree.site, lh, rh, op)
 

--- a/py/dml/codegen.py
+++ b/py/dml/codegen.py
@@ -1260,10 +1260,19 @@ def try_resolve_len(site, lh):
 def expr_member(tree, location, scope):
     [lh, op, rh] = tree.args
     lh = codegen_expression_maybe_nonvalue(lh, location, scope)
-    if not tree.site.dml_version() == (1, 2) and op == '.' and rh == 'len':
-        member = try_resolve_len(tree.site, lh)
-        if member:
-            return member
+    if op == '.':
+        if not tree.site.dml_version() == (1, 2) and rh == 'len':
+            member = try_resolve_len(tree.site, lh)
+            if member:
+                return member
+        elif isinstance(lh, TemplatesRef):
+            return mkTemplatesSubRef(tree.site, lh, rh)
+        elif isinstance(lh, TemplatesSubRef):
+            return mkTemplateQualifiedMethodRef(tree.site, lh, rh)
+        elif isinstance(lh, TraitTemplatesRef):
+            return mkTraitTemplatesSubRef(tree.site, lh, rh)
+        elif isinstance(lh, TraitTemplatesSubRef):
+            return mkTraitTemplateQualifiedMethodRef(tree.site, lh, rh)
 
     if isinstance(lh, NonValue) and not isinstance(lh, NodeRef):
         raise lh.exc()

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1639,6 +1639,56 @@ class ELOGGROUPS(DMLError):
     fmt = ("Too many loggroup declarations. A maximum of 63 log groups (61 "
            + "excluding builtins) may be declared per device.")
 
+class ETQMIC(DMLError):
+    """A template-qualified method implementation call can only be done if
+    the specified template is actually instantiated by the object. """
+    fmt = ("invalid template-qualified method implementation call, '%s' does "
+           + "not instantiate '%s'")
+
+class EAMBTQMIC(DMLError):
+    """A template-qualified method implementation call was made, when the
+    template inheritance graph for specified template is insufficient to infer
+    that one implementation overrides the others.
+    To resolve this, the template-qualified method implementation call should
+    instead be qualified with the specific ancestor template that has the
+    desired implementation.
+    """
+    fmt = ("Ambiguous invocation of template-qualified method implementation "
+           + "call. '%s' does not provide an implementation of '%s', and "
+           + "inherits multiple unrelated implementations from its ancestor "
+           + "templates.")
+    def __init__(self, site, template, method, candidates):
+        DMLError.__init__(self, site, template, method)
+        self.candidates = candidates
+    def log(self):
+        DMLError.log(self)
+        for (ancestor, candidate) in self.candidates:
+            self.print_site_message(
+                candidate.site,
+                "implementation candidate provided by ancestor template "
+                + f"'{ancestor.name}'")
+
+class ENSHAREDTQMIC(DMLError):
+    """A template-qualified method implementation call via a value of template
+    type, including when `(this.)templates` is used within the body of a
+    shared method, can only be done if the specified template provides or
+    inherits a shared implementation of the specified method. If an
+    implementation is never provided or inherited by the template, or the
+    template provides or inherits a non-shared implementation, then the call
+    can't be made."""
+    fmt = ("invalid template-qualified method implementation call made via a "
+           + "value of template type: '%s' does not provide nor inherit a "
+           + "shared implementation of '%s'")
+
+class ETTQMIC(DMLError):
+    """A template-qualified method implementation via a value of template type,
+    including when `(this.)templates` is used within the body call casting to
+    a template type, can only be done if the specified template is a parent
+    template of the template type, or the template type itself."""
+    version = "1.4"
+    fmt = ("invalid template-qualified method implementation call, "
+           + "'%s' not a subtemplate of '%s'")
+
 #
 # WARNINGS (keep these as few as possible)
 #

--- a/py/dml/objects.py
+++ b/py/dml/objects.py
@@ -194,7 +194,8 @@ class DMLObject(object):
 class CompositeObject(DMLObject):
     '''A DML object that may contain other DML objects'''
     __slots__ = ('name', '_components', '_component_dict', '_arraylens',
-                 '_idxvars', 'traits', '_confidential', 'uniq')
+                 '_idxvars', 'traits', 'templates', 'template_method_impls',
+                 '_confidential', 'uniq')
 
     def __init__(self, ident, site, parent, arraylens = (), idxvars = ()):
         super(CompositeObject, self).__init__(ident, site, parent)
@@ -213,6 +214,15 @@ class CompositeObject(DMLObject):
 
         # set to an ObjTraits object after object creation
         self.traits = None
+
+        # Template -> ObjectSpec (site-wrapped)
+        # Set after object creation
+        self.templates = None
+
+        # (Template, string) -> Method
+        # ... where the string is a method identifier
+        # Populated after object creation
+        self.template_method_impls = {}
 
         self._confidential = False
 

--- a/py/dml/objects.py
+++ b/py/dml/objects.py
@@ -222,6 +222,10 @@ class CompositeObject(DMLObject):
         # (Template, string) -> Method
         # ... where the string is a method identifier
         # Populated after object creation
+        # TODO: Preferably, the Method class architecture should be revamped
+        # such that this information can be derived instead. Possibly: a
+        # method component of an object is represented by a MethodNode that has
+        # a dictionary from Rank to implementation.
         self.template_method_impls = {}
 
         self._confidential = False

--- a/py/dml/set.py
+++ b/py/dml/set.py
@@ -40,6 +40,9 @@ class Set:
     def add(self, x):
         self._d[x] = None
 
+    def pop(self):
+        return self._d.popitem()[0]
+
     def update(self, xs):
         self._d.update((x, None) for x in xs)
 

--- a/test/1.2/errors/T_EAMBINH.dml
+++ b/test/1.2/errors/T_EAMBINH.dml
@@ -6,16 +6,16 @@ dml 1.2;
 
 device test;
 
+/// WARNING WEXPERIMENTAL T_EAMBINH.dml
+
 // trivial example
-/// WARNING WEXPERIMENTAL
 trait a {
     method m() default {}
 }
-/// WARNING WEXPERIMENTAL
+
 trait b {
     method m() default {}
 }
-/// WARNING WEXPERIMENTAL T_EAMBINH.dml
 /// ERROR EAMBINH
 trait c {
     is a;
@@ -33,41 +33,42 @@ trait cp {
 }
 
 // nontrivial example
-/// WARNING WEXPERIMENTAL
 trait d {
     method m();
 }
-/// WARNING WEXPERIMENTAL
 trait e {
     is d;
     method m() default {}
 }
-/// WARNING WEXPERIMENTAL
 trait f {
     is d;
     method m() default {}
 }
-/// WARNING WEXPERIMENTAL
 trait g {
     is e;
 }
-/// ERROR EAMBINH
+// no error
 trait h {
     is g;
     is f;
 }
 
+/// ERROR EAMBINH
+bank b1 is h;
+
+// no error
+bank b2 is h {
+    method m() nothrow {}
+}
+
 // Currently, not even abstract methods may clash. We don't have a good reason
 // to disallow this clash; we just haven't implemented it yet.
-/// WARNING WEXPERIMENTAL
 trait i {
     method m();
 }
-/// WARNING WEXPERIMENTAL
 trait j {
     method m();
 }
-/// WARNING WEXPERIMENTAL T_EAMBINH.dml
 /// ERROR EAMBINH
 trait k {
     is i;

--- a/test/1.4/errors/T_EAMBINH.dml
+++ b/test/1.4/errors/T_EAMBINH.dml
@@ -56,3 +56,32 @@ template asm4 is (asm1, asm2) {
 template asm5 is (asm1, asm3) {
     shared method m() {}
 }
+
+template asm6 is asm1 {
+    shared method m() default {}
+}
+template asm7 is asm1 {
+    shared method m() default {}
+}
+template asm8 is (asm6, asm7) {
+    shared method m() {}
+}
+
+template asm9 is asm1 {
+    shared method m() {}
+}
+
+/// ERROR EAMBINH
+template asm10 is (asm6, asm9) {}
+
+/// ERROR EAMBINH
+group g1 is (asm6, asm7);
+
+// no error
+group g2 is (asm6, asm7) {
+    method m() {}
+}
+
+// Redundancy as a smoke test that ancestor vtable merging works properly
+// no error
+group g3 is (asm6, asm7, asm1, asm8);

--- a/test/1.4/errors/T_EAMBTQMIC.dml
+++ b/test/1.4/errors/T_EAMBTQMIC.dml
@@ -1,0 +1,68 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+template t {
+    shared method m();
+    shared method n() default {}
+}
+
+template u1 is t {
+    shared method m() default {}
+    shared method n() default {}
+}
+
+template u2 is t {
+    param enable_u2 default true;
+    shared method m() default {}
+    #if (enable_u2) {
+        method n() default {}
+    }
+}
+
+template u3 is (u1, u2) {
+    param enable_u3 default false;
+    #if (enable_u3) {
+        method n() default {}
+    }
+}
+
+template u4 is u3 {
+    shared method m() {}
+    method n() {}
+}
+
+group g1 is u4;
+group g2 is u4 {
+    param enable_u2 = false;
+}
+group g3 is u4 {
+    param enable_u3 = true;
+}
+
+method init() {
+    local u4 x = cast(g1, u4);
+
+    // no error
+    g1.templates.u4.m();
+
+    /// ERROR EAMBTQMIC
+    g1.templates.u3.m();
+
+    /// ERROR EAMBTQMIC
+    g1.templates.u3.n();
+    // no error
+    g2.templates.u3.n();
+    // no error
+    g3.templates.u3.n();
+
+    // no error
+    x.templates.u4.m();
+
+    /// ERROR EAMBTQMIC
+    x.templates.u3.m();
+}

--- a/test/1.4/errors/T_EMEMBER.dml
+++ b/test/1.4/errors/T_EMEMBER.dml
@@ -1,0 +1,91 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+template t0 {
+    method m0() {}
+}
+
+template t1 is t0 {
+    shared method m1() default {}
+}
+
+template t2 is t1 {
+    param enable_t2 default true;
+    #if (enable_t2) {
+        method m1() default {}
+        method m2() default {}
+    }
+}
+
+template t3 is t2 {
+    param enable_t3 default false;
+    #if (enable_t3) {
+        method m1() default {}
+        method m2() default {}
+    }
+}
+
+in each t1 {
+    method m3() {}
+}
+
+group g is t3 {
+    param enable_t2 = false;
+    param enable_t3 = true;
+}
+
+
+template subdeclarer {
+    param declare_subgroup default false;
+
+    #if (declare_subgroup) {
+        group subgroup {
+            method m() {}
+        }
+    }
+}
+
+param declare_subgroup = true;
+is subdeclarer;
+group subgroup is subdeclarer;
+
+method init() {
+    // no error
+    g.templates.t1.m0();
+    g.templates.t1.m1();
+    cast(g, t3).templates.t1.m1();
+
+    /// ERROR EMEMBER
+    g.templates.t1.nonexistent();
+    /// ERROR EMEMBER
+    cast(g, t3).templates.t1.nonexistent();
+
+    // no error (uses t1's implementation)
+    g.templates.t2.m1();
+    /// ERROR EMEMBER
+    g.templates.t2.m2();
+
+    // no error
+    g.templates.t3.m1();
+    g.templates.t3.m2();
+
+    // Even though the in-each guarantees its existence, m3 is still not part
+    // of the template.
+    /// ERROR EMEMBER
+    g.templates.t1.m3();
+
+
+    // Even though it's the 'subdeclarer' template that provides the
+    // implementation of m() for the subgroup, it's not the particular
+    // instantation of the template for the subgroup that provides the
+    // implementation, but rather, the instantation of 'subdeclarer' for the
+    // device template. Because of that, m() is not considered a valid TQMIC
+    // candidate.
+    /// ERROR EMEMBER
+    subgroup.templates.subdeclarer.m();
+}

--- a/test/1.4/errors/T_ENSHAREDTQMIC.dml
+++ b/test/1.4/errors/T_ENSHAREDTQMIC.dml
@@ -1,0 +1,65 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+template t1 {
+    method nonshared() {}
+    shared method abstract1();
+    shared method abstract2();
+    shared method sm1() default {}
+    shared method sm2() default {}
+    shared method sm3() default {}
+}
+
+template t2 is t1 {
+    shared method abstract1() {}
+    shared method sm2() {}
+    // Any method implementation, within an #if or not, that the template gives
+    // for the object instantiating it is considered possibly used for the
+    // purposes of ENSHAREDTQMIC, even if the #if condition is just 'false'.
+    #if (false) {
+        method sm3() {}
+    }
+}
+
+template t3 is t2 {
+    // ... Unless there is a higher-rank shared method implementation given
+    // (which is only possible if the non-shared implementation is never
+    // provided to the instantiated object)
+    shared method sm3() {}
+}
+
+in each t2 {
+    // Since in-each bodies are not considered part of the template, they are
+    // not considered possible candidates and do not provoke
+    // ENSHAREDTQMIC
+    method sm1() {}
+}
+
+group g is t3 {
+    method abstract2() {}
+}
+
+method init() {
+    local t3 x = cast(g, t3);
+    // no error
+    x.templates.t1.sm1();
+    x.templates.t1.sm2();
+    x.templates.t1.sm3();
+    x.templates.t2.abstract1();
+    x.templates.t2.sm2();
+    x.templates.t3.sm3();
+
+    /// ERROR ENSHAREDTQMIC
+    x.templates.t2.nonshared();
+    /// ERROR ENSHAREDTQMIC
+    x.templates.t1.abstract1();
+    /// ERROR ENSHAREDTQMIC
+    x.templates.t2.abstract2();
+    /// ERROR ENSHAREDTQMIC
+    x.templates.t2.sm3();
+}

--- a/test/1.4/errors/T_ETQMIC.dml
+++ b/test/1.4/errors/T_ETQMIC.dml
@@ -1,0 +1,47 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+template t1 {
+    shared method m() {}
+}
+
+template t2 is t1 { }
+
+template t3 is t2 { }
+
+template u {
+    shared method n() {}
+}
+
+is (t3, u);
+
+method init() {
+    local t2 x = cast(dev, t2);
+
+    // no error
+    dev.templates.t1.m();
+    dev.templates.t2.m();
+    dev.templates.t3.m();
+    dev.templates.u.n();
+
+    x.templates.t1.m();
+    x.templates.t2.m();
+
+    /// ERROR ENTMPL
+    dev.templates.nonexistent.m();
+    /// ERROR ENTMPL
+    x.templates.nonexistent.m();
+
+    /// ERROR ETQMIC
+    dev.templates.write.write(4);
+
+    /// ERROR ETTQMIC
+    x.templates.t3.m();
+    /// ERROR ETTQMIC
+    x.templates.u.n();
+}

--- a/test/1.4/expressions/T_tqmic.dml
+++ b/test/1.4/expressions/T_tqmic.dml
@@ -1,0 +1,90 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+
+// Test for Template-Qualified Method Implementation Calls (TQMIC)
+
+dml 1.4;
+device test;
+
+template t {
+    shared method sm() -> (double) default {
+        return 1.0;
+    }
+
+    shared method m() -> (double) default {
+        return 1.0;
+    }
+}
+
+template u1 is t {}
+
+template u2 is t {
+    shared method sm() -> (double) default {
+        return 2.2;
+    }
+
+    shared method m() -> (double) default {
+        return 2.2;
+    }
+}
+
+template u3 is t {
+    shared method sm() -> (double) default {
+        return 2.3;
+    }
+
+    param enable_u3 default true;
+    #if (enable_u3) {
+        method m() -> (double) default {
+            return 2.3;
+        }
+    }
+}
+
+// Redundancy as a smoke test that ancestor vtable merging works properly
+template v is (t, u1, u2, u3) {}
+
+template w is (t, u1, u2, u3, v) {
+    shared method sm() -> (double) default {
+        return 4.0;
+    }
+    method m() -> (double) {
+        return 4.0;
+    }
+}
+
+group g1 is w;
+group g2 is w {
+    param enable_u3 = false;
+}
+
+method init() {
+    local w tref = cast(g1, w);
+    local w *trefp = &tref;
+
+    #foreach g in ([g1, g2]) {
+        assert g.templates.t.sm() == 1.0 && g.templates.t.m() == 1.0;
+        assert g.templates.u1.sm() == 1.0 && g.templates.u1.m() == 1.0;
+        assert g.templates.u2.sm() == 2.2 && g.templates.u2.m() == 2.2;
+        assert g.templates.u3.sm() == 2.3;
+        assert g.templates.w.sm() == 4.0 && g.templates.w.m() == 4.0;
+    }
+    assert tref.templates.t.sm() == 1.0;
+    assert trefp->templates.t.sm() == 1.0;
+
+    assert tref.templates.u1.sm() == 1.0;
+    assert tref.templates.u2.sm() == 2.2;
+    assert tref.templates.u3.sm() == 2.3;
+    assert tref.templates.w.sm() == 4.0;
+
+    // Since g2 lacks u3's def of m(), the TQMIC with v unambiguously resolves
+    // to u2's implementation
+    assert g2.templates.v.m() == 2.2;
+
+    // a TQMIC qualified by the 'object' template is always allowed.
+    // This really only serves as an easy way to call `cancel_after()` or the
+    // internal '_qname()'
+    assert strcmp(tref.templates.object._qname(), "g1") == 0;
+}


### PR DESCRIPTION
Completely untested save that I checked that one (1) existing 1.4 test still passed and nothing else

Currently limited: you can only make a TQMIC if the template specified actually does provide an implementation of the method. In contrast, you could consider that, in principle, if the specified template doesn't provide an implementation then the TQMIC should resolve to the the nearest ancestor of the specified template that provides an implementation. I couldn't think of a good way to do that however with regular methods (shared methods are easy thanks to the `Trait` architecture.)