### PR TITLE
Limited scope for function_io_memory

### DIFF
--- a/RELEASENOTES-1.4.docu
+++ b/RELEASENOTES-1.4.docu
@@ -558,4 +558,7 @@
       in multiple inheritance: it allows any method that overrides multiple
       implementations from unrelated templates to individually reference and
       call the implementations it overrides.</add-note></build-id>
+  <build-id _6="next" _7="next"><add-note> Template <tt>function_io_memory</tt>
+      now searches for the bank in the same `subdevice`/`device` scope as the
+      `implement`. </add-note></build-id>
 </rn>

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1122,15 +1122,17 @@ template function_io_memory {
         error "The function_io_memory template can only be instantiated"
             + " inside 'implement io_memory'";
     }
-    param port_parent = (this.parent.objtype == "device" 
-                        || this.parent.objtype == "subdevice")
-                        #? this.parent.obj
-                        #: SIM_port_object_parent(this.parent.obj);
+    param subdev_parent = (this.parent.objtype == "device"
+                           || this.parent.objtype == "subdevice")
+                        #? this.parent
+                        // Implement is for a port or bank
+                        #: this.parent._nongroup_parent;
+
     method operation(generic_transaction_t *mem_op,
                      map_info_t map_info) -> (exception_type_t) {
         local uint64 offset = map_info.start - map_info.base;
-        foreach b in (each function_mapped_bank in (dev)) {
-            if (SIM_port_object_parent(b._bank_obj()) == port_parent) {
+        foreach b in (each function_mapped_bank in (subdev_parent)) {
+            if (SIM_port_object_parent(b._bank_obj()) == subdev_parent.obj) {
                 if (b.function == map_info.function) {
                     if (!b.use_io_memory) {
                         local map_target_t *mt = SIM_new_map_target(

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1136,14 +1136,12 @@ template function_io_memory {
                 && b.function == map_info.function)
             {
                 if (!b.use_io_memory) {
-                    local map_target_t *mt = SIM_new_map_target(
-                        b._bank_obj(), NULL, NULL);
+                    local map_target_t *mt = SIM_new_map_target(b._bank_obj(),
+                                                                 NULL, NULL);
                     if (!mt) {
-                        local exception_type_t _ex = SIM_clear_exception();
-                        log error: "failed to create map target "
-                            + "for %s: %s",
-                            SIM_object_name(b._bank_obj()),
-                            SIM_last_error();
+                        local exception_type_t _exc = SIM_clear_exception();
+                        log error: "failed to create map target for %s: %s",
+                            SIM_object_name(b._bank_obj()), SIM_last_error();
                         return Sim_PE_IO_Not_Taken;
                     }
                     // hack: VT_map_target_access doesn't accept a map_info
@@ -1151,8 +1149,7 @@ template function_io_memory {
                     // Work around by temporarily patching the memop.
                     local uint64 before = SIM_get_mem_op_physical_address(
                         mem_op);
-                    SIM_set_mem_op_physical_address(mem_op,
-                                                    before + offset);
+                    SIM_set_mem_op_physical_address(mem_op, before + offset);
                     local exception_type_t ret
                         = VT_map_target_access(mt, mem_op);
                     SIM_set_mem_op_physical_address(mem_op, before);

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1093,7 +1093,8 @@ template function_mapped_bank is bank {
 Only valid in `implement` objects named `io_memory`. Implements the `io_memory`
 interface by function mapping: An incoming memory transaction is handled by
 finding a bank that instantiates the
-[`function_mapped_bank`](#function_mapped_bank) template, and has a function
+[`function_mapped_bank`](#function_mapped_bank) template inside
+the same (sub)device as `implement`, and has a function
 number that matches the memory transaction's. If such a bank exists, the
 transaction is handled by that bank. If no such bank exists, an error message
 is logged and a miss is reported for the access.

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1122,50 +1122,50 @@ template function_io_memory {
         error "The function_io_memory template can only be instantiated"
             + " inside 'implement io_memory'";
     }
-    param subdev_parent = (this.parent.objtype == "device"
-                           || this.parent.objtype == "subdevice")
-                        #? this.parent
-                        // Implement is for a port or bank
-                        #: this.parent._nongroup_parent;
+    param _subdev_parent = (this.parent.objtype == "device"
+                            || this.parent.objtype == "subdevice")
+                         #? this.parent
+                         // Implement is for a port or bank
+                         #: this.parent._nongroup_parent;
 
     method operation(generic_transaction_t *mem_op,
                      map_info_t map_info) -> (exception_type_t) {
         local uint64 offset = map_info.start - map_info.base;
-        foreach b in (each function_mapped_bank in (subdev_parent)) {
-            if (SIM_port_object_parent(b._bank_obj()) == subdev_parent.obj) {
-                if (b.function == map_info.function) {
-                    if (!b.use_io_memory) {
-                        local map_target_t *mt = SIM_new_map_target(
-                            b._bank_obj(), NULL, NULL);
-                        if (!mt) {
-                            local exception_type_t _ex = SIM_clear_exception();
-                            log error: "failed to create map target "
-                                + "for %s: %s",
-                                SIM_object_name(b._bank_obj()),
-                                SIM_last_error();
-                            return Sim_PE_IO_Not_Taken;
-                        }
-                        // hack: VT_map_target_access doesn't accept a map_info
-                        // (even though the underlying implementation does).
-                        // Work around by temporarily patching the memop.
-                        local uint64 before = SIM_get_mem_op_physical_address(
-                            mem_op);
-                        SIM_set_mem_op_physical_address(mem_op,
-                                                        before + offset);
-                        local exception_type_t ret
-                            = VT_map_target_access(mt, mem_op);
-                        SIM_set_mem_op_physical_address(mem_op, before);
-                        SIM_free_map_target(mt);
-                        return ret;
-                    }
-                    if (b.io_memory_access(
-                            mem_op,
-                            SIM_get_mem_op_physical_address(mem_op) + offset,
-                            NULL)) {
-                        return Sim_PE_No_Exception;
-                    } else {
+        foreach b in (each function_mapped_bank in (_subdev_parent)) {
+            if (SIM_port_object_parent(b._bank_obj()) == _subdev_parent.obj
+                && b.function == map_info.function)
+            {
+                if (!b.use_io_memory) {
+                    local map_target_t *mt = SIM_new_map_target(
+                        b._bank_obj(), NULL, NULL);
+                    if (!mt) {
+                        local exception_type_t _ex = SIM_clear_exception();
+                        log error: "failed to create map target "
+                            + "for %s: %s",
+                            SIM_object_name(b._bank_obj()),
+                            SIM_last_error();
                         return Sim_PE_IO_Not_Taken;
                     }
+                    // hack: VT_map_target_access doesn't accept a map_info
+                    // (even though the underlying implementation does).
+                    // Work around by temporarily patching the memop.
+                    local uint64 before = SIM_get_mem_op_physical_address(
+                        mem_op);
+                    SIM_set_mem_op_physical_address(mem_op,
+                                                    before + offset);
+                    local exception_type_t ret
+                        = VT_map_target_access(mt, mem_op);
+                    SIM_set_mem_op_physical_address(mem_op, before);
+                    SIM_free_map_target(mt);
+                    return ret;
+                }
+                if (b.io_memory_access(
+                        mem_op,
+                        SIM_get_mem_op_physical_address(mem_op) + offset,
+                        NULL)) {
+                    return Sim_PE_No_Exception;
+                } else {
+                    return Sim_PE_IO_Not_Taken;
                 }
             }
         }

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1121,40 +1121,48 @@ template function_io_memory {
         error "The function_io_memory template can only be instantiated"
             + " inside 'implement io_memory'";
     }
-
+    param port_parent = (this.parent.objtype == "device" 
+                        || this.parent.objtype == "subdevice")
+                        #? this.parent.obj
+                        #: SIM_port_object_parent(this.parent.obj);
     method operation(generic_transaction_t *mem_op,
                      map_info_t map_info) -> (exception_type_t) {
         local uint64 offset = map_info.start - map_info.base;
         foreach b in (each function_mapped_bank in (dev)) {
-            if (b.function == map_info.function) {
-                if (!b.use_io_memory) {
-                    local map_target_t *mt = SIM_new_map_target(b._bank_obj(),
-                                                                 NULL, NULL);
-                    if (!mt) {
-                        local exception_type_t _exc = SIM_clear_exception();
-                        log error: "failed to create map target for %s: %s",
-                            SIM_object_name(b._bank_obj()), SIM_last_error();
+            if (SIM_port_object_parent(b._bank_obj()) == port_parent) {
+                if (b.function == map_info.function) {
+                    if (!b.use_io_memory) {
+                        local map_target_t *mt = SIM_new_map_target(
+                            b._bank_obj(), NULL, NULL);
+                        if (!mt) {
+                            local exception_type_t _ex = SIM_clear_exception();
+                            log error: "failed to create map target "
+                                + "for %s: %s",
+                                SIM_object_name(b._bank_obj()),
+                                SIM_last_error();
+                            return Sim_PE_IO_Not_Taken;
+                        }
+                        // hack: VT_map_target_access doesn't accept a map_info
+                        // (even though the underlying implementation does).
+                        // Work around by temporarily patching the memop.
+                        local uint64 before = SIM_get_mem_op_physical_address(
+                            mem_op);
+                        SIM_set_mem_op_physical_address(mem_op,
+                                                        before + offset);
+                        local exception_type_t ret
+                            = VT_map_target_access(mt, mem_op);
+                        SIM_set_mem_op_physical_address(mem_op, before);
+                        SIM_free_map_target(mt);
+                        return ret;
+                    }
+                    if (b.io_memory_access(
+                            mem_op,
+                            SIM_get_mem_op_physical_address(mem_op) + offset,
+                            NULL)) {
+                        return Sim_PE_No_Exception;
+                    } else {
                         return Sim_PE_IO_Not_Taken;
                     }
-                    // hack: VT_map_target_access doesn't accept a map_info
-                    // (even though the underlying implementation does).
-                    // Work around by temporarily patching the memop.
-                    local uint64 before = SIM_get_mem_op_physical_address(
-                        mem_op);
-                    SIM_set_mem_op_physical_address(mem_op, before + offset);
-                    local exception_type_t ret
-                        = VT_map_target_access(mt, mem_op);
-                    SIM_set_mem_op_physical_address(mem_op, before);
-                    SIM_free_map_target(mt);
-                    return ret;
-                }
-                if (b.io_memory_access(
-                        mem_op,
-                        SIM_get_mem_op_physical_address(mem_op) + offset,
-                        NULL)) {
-                    return Sim_PE_No_Exception;
-                } else {
-                    return Sim_PE_IO_Not_Taken;
                 }
             }
         }

--- a/test/1.4/lib/T_io_memory.dml
+++ b/test/1.4/lib/T_io_memory.dml
@@ -46,10 +46,6 @@ subdevice ab {
     implement io_memory {
         is function_io_memory;
     }
-    // this bank's qname should be earlier alphabetically than
-    // qname of the bank we compare it against on device level
-    // because we test `foreach` cycle
-    // and otherwise it works nevertherless
     bank b {
         is function_mapped_bank;
         param function = 0xb;

--- a/test/1.4/lib/T_io_memory.dml
+++ b/test/1.4/lib/T_io_memory.dml
@@ -14,10 +14,23 @@ implement io_memory {
     is function_io_memory;
 }
 
+port function_io_memory_port {
+    implement io_memory {
+        is function_io_memory;
+    }
+}
+
 port bare {
     implement io_memory {
         is bank_io_memory;
         param bank = a;
+    }
+}
+
+bank function_io_memory_bank {
+    param use_io_memory = false;  // not using bank_io_memory
+    implement io_memory {
+        is function_io_memory;
     }
 }
 
@@ -27,6 +40,34 @@ bank a {
     method read(uint64 address, uint64 enabled_bytes, void *user)
         -> (uint64) throws {
         return 0xaa;
+    }
+}
+subdevice ab {
+    implement io_memory {
+        is function_io_memory;
+    }
+    // this bank's qname should be earlier alphabetically than
+    // qname of the bank we compare it against on device level
+    // because we test `foreach` cycle
+    // and otherwise it works nevertherless
+    bank b {
+        is function_mapped_bank;
+        param function = 0xb;
+        method read(uint64 address, uint64 enabled_bytes, void *user)
+            -> (uint64) throws {
+            return 0xab;
+        }
+    }
+    port function_io_memory_port {
+        implement io_memory {
+            is function_io_memory;
+        }
+    }
+    bank function_io_memory_bank {
+        param use_io_memory = false;  // not using bank_io_memory
+        implement io_memory {
+            is function_io_memory;
+        }
     }
 }
 bank b {

--- a/test/1.4/lib/T_io_memory.dml
+++ b/test/1.4/lib/T_io_memory.dml
@@ -78,6 +78,14 @@ subdevice ab {
             }
         }
     }
+    group _group {
+        bank function_io_memory_bank {
+            param use_io_memory = false;  // not using bank_io_memory
+            implement io_memory {
+                is function_io_memory;
+            }
+        }
+    }
 }
 bank b {
     is function_mapped_bank;

--- a/test/1.4/lib/T_io_memory.dml
+++ b/test/1.4/lib/T_io_memory.dml
@@ -65,6 +65,19 @@ subdevice ab {
             is function_io_memory;
         }
     }
+    subdevice cc {
+        implement io_memory {
+            is function_io_memory;
+        }
+        bank b {
+            is function_mapped_bank;
+            param function = 0xb;
+            method read(uint64 address, uint64 enabled_bytes, void *user)
+                -> (uint64) throws {
+                return 0xcc;
+            }
+        }
+    }
 }
 bank b {
     is function_mapped_bank;

--- a/test/1.4/lib/T_io_memory.py
+++ b/test/1.4/lib/T_io_memory.py
@@ -7,13 +7,25 @@ import dev_util
 # bank_io_memory works
 stest.expect_equal(dev_util.Register_LE(obj.port.bare, 0, size=1).read(), 0xaa)
 # function_io_memory works ..
-stest.expect_equal(dev_util.Register_LE((obj, 0xb, 0), size=1).read(), 0xbb)
 stest.expect_equal(dev_util.Register_LE((obj, 0xc, 0), size=1).read(), 0xcc)
 stest.expect_equal(dev_util.Register_LE((obj, 0x10, 0), size=1).read(), 0x0)
 stest.expect_equal(dev_util.Register_LE((obj, 0x11, 0), size=1).read(), 0x1)
 stest.expect_equal(dev_util.Register_LE((obj, 0x12, 0), size=1).read(), 0x10)
 stest.expect_equal(dev_util.Register_LE((obj, 0x13, 0), size=1).read(), 0x11)
 stest.expect_equal(dev_util.Register_LE((obj, 0xf, 0x100), size=1).read(), 0xff)
+# function_io_memory inside bank
+stest.expect_equal(dev_util.Register_LE((obj.bank.function_io_memory_bank,
+                                         0xb, 0), size=1).read(), 0xbb)
+# function_io_memory inside port 
+stest.expect_equal(dev_util.Register_LE((obj.port.function_io_memory_port,
+                                         0xb, 0), size=1).read(), 0xbb)
+# subdevice io_memory isolation works
+stest.expect_equal(dev_util.Register_LE((obj.ab, 0xb, 0), size=1).read(), 0xab)
+stest.expect_equal(dev_util.Register_LE((obj, 0xb, 0), size=1).read(), 0xbb)
+stest.expect_equal(dev_util.Register_LE((obj.ab.port.function_io_memory_port,
+                                         0xb, 0), size=1).read(), 0xab)
+stest.expect_equal(dev_util.Register_LE((obj.ab.bank.function_io_memory_bank,
+                                         0xb, 0), size=1).read(), 0xab)
 # accessing 0x10 hits address 0x100 in the bank
 ms = SIM_create_object('memory-space', 'ms', map=[[0x10, obj, 0xf, 0x100, 1]])
 ms.iface.memory_space.read(None, 0x10, 1, False)

--- a/test/1.4/lib/T_io_memory.py
+++ b/test/1.4/lib/T_io_memory.py
@@ -26,6 +26,9 @@ stest.expect_equal(dev_util.Register_LE((obj.ab.port.function_io_memory_port,
                                          0xb, 0), size=1).read(), 0xab)
 stest.expect_equal(dev_util.Register_LE((obj.ab.bank.function_io_memory_bank,
                                          0xb, 0), size=1).read(), 0xab)
+# bank inside group inside subdevice is a part of subdevice scope
+stest.expect_equal(dev_util.Register_LE(
+    (obj.ab._group.bank.function_io_memory_bank, 0xb, 0), size=1).read(), 0xab)
 # subdevice of subdevice is also isolated
 stest.expect_equal(dev_util.Register_LE((obj.ab.cc, 0xb, 0), size=1).read(),
                                          0xcc)

--- a/test/1.4/lib/T_io_memory.py
+++ b/test/1.4/lib/T_io_memory.py
@@ -26,6 +26,9 @@ stest.expect_equal(dev_util.Register_LE((obj.ab.port.function_io_memory_port,
                                          0xb, 0), size=1).read(), 0xab)
 stest.expect_equal(dev_util.Register_LE((obj.ab.bank.function_io_memory_bank,
                                          0xb, 0), size=1).read(), 0xab)
+# subdevice of subdevice is also isolated
+stest.expect_equal(dev_util.Register_LE((obj.ab.cc, 0xb, 0), size=1).read(),
+                                         0xcc)
 # accessing 0x10 hits address 0x100 in the bank
 ms = SIM_create_object('memory-space', 'ms', map=[[0x10, obj, 0xf, 0x100, 1]])
 ms.iface.memory_space.read(None, 0x10, 1, False)


### PR DESCRIPTION
Legacy pci bus maps pci_config banks as Device/Subdevice + function number instead of bank objects.
When we have 2+ PCI devices in 1 DML device (e.g. by using subdevice) such pcI_config bank can be unreachable because pci bank function number is hardcoded to 255.
This PR introduces a limited scope for function_io_memory - closest port object parent.