### PR TITLE
Typecheck shared methods after trait processing -- SIMICS-22166

### DIFF
--- a/RELEASENOTES-1.4.md
+++ b/RELEASENOTES-1.4.md
@@ -323,3 +323,9 @@
 - `note 6` The `explicit_param_decls` provisional feature is now considered stable. Its use will be kept supported in the same way as any standard DML feature.
 - `release 7 7036`
 - `note 6` `after` statements now support picoseconds (`ps`) as a unit of time (fixes SIMICS-16019).
+- `note 6` Fixed an issue where overriding a `shared` method with another could
+  cause an internal compiler error if the method signature involves a template
+  type.
+- `note 6` Fixed an issue where the validity of referenced types in the
+  signatures of unused `shared` methods were not properly checked, leading to
+  invalid generated C.

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -259,6 +259,9 @@ def mkglobals(stmts):
             except ETYPE as e:
                 report(e)
 
+    for t in dml.globals.traits.values():
+        t.typecheck_methods()
+
     # Resolve duplicate externs
     for (name, clashes) in extern_clashes.items():
         (canonical_site, canonical_t) = externs[name]
@@ -270,32 +273,6 @@ def mkglobals(stmts):
                                          canonical_t))
             except ETYPE as e:
                 report(e)
-
-def check_named_types(t):
-    '''Checks that a type does not reference a non-existing type'''
-    if isinstance(t, TNamed):
-        if t.c not in typedefs:
-            raise ETYPE(t.declaration_site, t)
-    elif isinstance(t, TStruct):
-        t.resolve()
-        for (mn, mt) in t.members.items():
-            check_named_types(mt)
-    elif isinstance(t, (TPtr, TVector, TArray)):
-        check_named_types(t.base)
-    elif isinstance(t, TFunction):
-        for pt in t.input_types:
-            check_named_types(pt)
-        check_named_types(t.output_type)
-    elif isinstance(t, TTraitList):
-        if t.traitname not in dml.globals.traits:
-            raise ETYPE(t.declaration_site, t)
-    elif isinstance(t, THook):
-        for msg_t in t.msg_types:
-            check_named_types(msg_t)
-    elif isinstance(t, (TVoid, IntegerType, TBool, TFloat, TTrait)):
-        pass
-    else:
-        raise ICE(t.declaration_site, "unknown type %r" % t)
 
 def type_deps(t, include_structs, expanded_typedefs):
     '''Given that t appears inside a DML typedef, return the set of DML

--- a/test/1.4/errors/T_EMETH.dml
+++ b/test/1.4/errors/T_EMETH.dml
@@ -14,9 +14,37 @@ template t {
     method int_args(uint32 a, int_alias_t b) default {}
     method int_return() -> (int) default { return 0; }
     method int_return_2() -> (int_alias_t, uint32) default { return 0; }
+
+    shared method downcast_with_fallback(u fallback) -> (u) default {
+        return fallback;
+    }
 }
 
 is t;
+
+template u is t {}
+
+template v1 is u {
+    // no error
+    shared method downcast_with_fallback(u fallback) -> (u) {
+        return cast(this, u);
+    }
+}
+
+template v2 is u {
+    /// ERROR EMETH
+    shared method downcast_with_fallback(object fallback) -> (u) {
+        return cast(this, u);
+    }
+}
+
+template v3 is u {
+    /// ERROR EMETH
+    shared method downcast_with_fallback(u fallback) -> (object) {
+        return cast(this, object);
+    }
+}
+
 /// ERROR EMETH
 inline method inline_args(int x, inline y) {}
 

--- a/test/1.4/errors/T_ETYPE.dml
+++ b/test/1.4/errors/T_ETYPE.dml
@@ -18,3 +18,43 @@ typedef undefined_type_t undef_ret();
 extern typedef void undef_arg(undefined_type_t);
 /// ERROR ETYPE
 extern typedef undefined_type undef_val;
+
+template t {
+    shared method m(
+        // no error
+        bool a,
+        /// ERROR ETYPE
+        undefined_type b)
+        /// ERROR ETYPE
+        -> (undefined_type);
+    shared method n(
+        // no error
+        bool a,
+        /// ERROR ETYPE
+        undefined_type b)
+        /// ERROR ETYPE
+        -> (undefined_type) {
+        assert false;
+    }
+    shared method o(
+        // no error
+        bool a,
+        /// ERROR ETYPE
+        undefined_type b)
+        /// ERROR ETYPE
+        -> (undefined_type) default {
+        assert false;
+    }
+}
+
+template u is t {
+    shared method o(
+        // no error
+        bool a,
+        /// ERROR ETYPE
+        undefined_type b)
+        /// ERROR ETYPE
+        -> (undefined_type) {
+        assert false;
+    }
+}

--- a/test/1.4/methods/T_traitrefs_in_shared_sigs.dml
+++ b/test/1.4/methods/T_traitrefs_in_shared_sigs.dml
@@ -1,0 +1,27 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+device test;
+
+template t {
+    shared method downcast_with_fallback(u fallback) -> (u) default {
+        return fallback;
+    }
+}
+
+template u is t {
+    shared method downcast_with_fallback(u fallback) -> (u) {
+        return this;
+    }
+}
+
+is u;
+group g is u;
+
+method init() {
+    local t x = cast(dev, t);
+    local u y = x.downcast_with_fallback(cast(g, u));
+    assert x == cast(y, t);
+}


### PR DESCRIPTION
This allows for the use of any template type in the signature of any shared method. The logic has also been extended to check that each named type in the signature is valid.

This new releasenotes format is confusing me. I can only hope this works.

The validation of shared method signatures, even if unused, could potentially break VP as it happens even if the trait is considered dead. I'll run a pretest just in case.