### PR TITLE
Added length method to bank template

### DIFF
--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -1954,6 +1954,15 @@ template bank is (object, shown_desc) {
         return (src, num);
     }
 
+    shared independent method length() -> (uint64) {
+        local (const register *regs, int num_mapped_regs) = _sorted_regs();
+        if (num_mapped_regs > 0) {
+            local const register last_reg = regs[num_mapped_regs - 1];
+            return last_reg.offset + last_reg._size();
+        }
+        return 0;
+    }
+
     // Register dispatcher. Given the offset and size of an access, return a
     // list of registers that the access covers, and a bitmask showing 0xff for
     // all bytes of the access that were not mapped to a register. The register


### PR DESCRIPTION
Does not add startup time but utilizes the startup memoized method `_sorted_regs()` which means this method should not scale on bank length.

Feel free to close this PR if it doesn't make sense to include this in dml-builtins.