### PR TITLE
Add the access_count explicitly

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -1700,6 +1700,12 @@ class CompareIllegalAttrs(BaseTestCase):
                       encoding='utf-8').stdout.splitlines()
               if x.startswith('ATTR ')}
 
+        # access count is added for objects implementing io_memory or
+        # transaction interfaces. In DML the name is illegal to avoid a clash in
+        # bank objects. TODO: we should adjust the test to also extract the set
+        # of attributes from an empty bank, not only the device object.
+        sl.add("access_count")
+
         # Extract list of illegal attributes from dmlc
         dl = dml.globals.illegal_attributes
 


### PR DESCRIPTION
Soon in Simics, the access_count is not added for objects that do not need it. So the test class used here does not get the access_count attribute. So the test fails for the expected attributes. By adding it explicitly here, the test will pass.