### PR TITLE
Make `explicit_param_decls` stable

### DIFF
--- a/RELEASENOTES-1.4.md
+++ b/RELEASENOTES-1.4.md
@@ -320,3 +320,4 @@
 - `release 6 6321`
 - `release 7 7033`
 - `release 6 6324`
+- `note 6` The `explicit_param_decls` provisional feature is now considered stable. Its use will be kept supported in the same way as any standard DML feature.

--- a/py/dml/dmlparse.py
+++ b/py/dml/dmlparse.py
@@ -1027,7 +1027,7 @@ def object_else_if(t):
 # Parameter specification
 @prod_dml12
 def object_parameter(t):
-    '''param : PARAMETER objident paramspec'''
+    '''param : PARAMETER objident paramspec_maybe_empty'''
     if logging.show_porting:
         report(PPARAMETER(site(t)))
     if logging.show_porting:
@@ -1046,7 +1046,7 @@ def object_parameter_auto(t):
 
 @prod_dml14
 def object_param(t):
-    '''param : PARAM objident paramspec'''
+    '''param : PARAM objident paramspec_maybe_empty'''
     t[0] = ast.param(site(t), t[2], None, *t[3])
 
 @prod_dml14
@@ -1057,13 +1057,15 @@ def object_param_auto(t):
 @prod_dml14
 def object_param_walrus(t):
     '''param : PARAM objident COLON paramspec'''
+    param_type = ast.walrus(site(t, 3))
     if provisional.explicit_param_decls not in t.parser.file_info.provisional:
         report(ESYNTAX(site(t, 3), ':', "expected '=' or 'default'"))
-    t[0] = ast.param(site(t), t[2], ast.walrus(site(t, 3)), *t[4])
+        param_type = None
+    t[0] = ast.param(site(t), t[2], param_type, *t[4])
 
 @prod_dml14
 def object_param_typed(t):
-    '''param : PARAM objident COLON ctypedecl paramspec'''
+    '''param : PARAM objident COLON ctypedecl paramspec_maybe_empty'''
     (is_default, value) = t[5]
     if (value is not None
         and (provisional.explicit_param_decls
@@ -1075,8 +1077,13 @@ def object_param_typed(t):
                      is_default, value)
 
 @prod
-def paramspec_empty(t):
-    'paramspec : SEMI'
+def paramspec_maybe_empty_nonempty(t):
+    'paramspec_maybe_empty : paramspec'
+    t[0] = t[1]
+
+@prod
+def paramspec_maybe_empty_empty(t):
+    'paramspec_maybe_empty : SEMI'
     t[0] = (True, None)
 
 @prod

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -1140,10 +1140,12 @@ class EAUTOPARAM(DMLError):
 
 class ENOVERRIDE(DMLError):
     """When the `explict_param_decls` provisional feature is enabled, parameter
-    declarations that do not override existing declarations must be
-    declared using the `:=` or `:default` syntax.
+    definitions written using `=` and `default` are only accepted if the
+    parameter has already been declared.
+    To declare and define a new parameter not already declared, use the `:=` or
+    `:default` syntax.
     """
-    fmt = ("parameter '%s' not previously declared."
+    fmt = ("parameter '%s' not declared previously."
            " To declare and define a new parameter, use the ':%s' syntax.")
 
     def log(self):
@@ -1158,16 +1160,19 @@ class ENOVERRIDE(DMLError):
 
 class EOVERRIDE(DMLError):
     """When the `explict_param_decls` provisional feature is enabled,
-    parameters declared using `:=` or `:default` syntax may not override
-    other parameters.
+    any parameter declared via `:=` or `:default` may not already
+    have been declared. This means `:=` or `:default` syntax can't be used
+    to override existing parameter declarations (not even those lacking a
+    definition of the parameter.)
     """
-    fmt = "The :%s syntax may not be used to override an existing parameter"
-    def __init__(self, site, other_site, token):
-        super().__init__(site, token)
+    fmt = ("the parameter '%s' has already been declared "
+           + "(':%s' syntax may not be used for parameter overrides)")
+    def __init__(self, site, other_site, name, token):
+        super().__init__(site, name, token)
         self.other_site = other_site
     def log(self):
         DMLError.log(self)
-        self.print_site_message(self.other_site, "overridden parameter")
+        self.print_site_message(self.other_site, "existing declaration")
 
 class EVARPARAM(DMLError):
     """

--- a/py/dml/provisional.py
+++ b/py/dml/provisional.py
@@ -69,7 +69,7 @@ class explicit_param_decls(ProvisionalFeature):
     the parameter definitions specified in that file.
     '''
     short = "Require := syntax for defining new params"
-    stable = False
+    stable = True
 
 def parse_provisional(
         provs: list[("Site", str)]) -> dict[ProvisionalFeature, "Site"]:

--- a/py/dml/provisional.py
+++ b/py/dml/provisional.py
@@ -32,9 +32,10 @@ def feature(cls: type[ProvisionalFeature]):
 
 @feature
 class explicit_param_decls(ProvisionalFeature):
-    '''This feature extends the DML syntax for parameter declarations to
+    '''This feature extends the DML syntax for parameter definitions to
     distinguish between an intent to declare a new parameter, and an intent to
-    override an existing parameter. This distinction allows DML to capture
+    override an existing parameter (including when providing a definition
+    for an abstract parameter). This distinction allows DML to capture
     misspelled parameter overrides as compile errors.
 
     The following new forms are introduced to mark the intent of
@@ -65,9 +66,9 @@ class explicit_param_decls(ProvisionalFeature):
     an override or a new parameter, and no error will be printed.
 
     Enabling the `explicit_param_decls` feature in a file only affects
-    parameter declarations in that file.
+    the parameter definitions specified in that file.
     '''
-    short = "Require := syntax for assigning new params"
+    short = "Require := syntax for defining new params"
     stable = False
 
 def parse_provisional(

--- a/py/dml/structure.py
+++ b/py/dml/structure.py
@@ -675,9 +675,10 @@ def merge_parameters(params, obj_specs):
 
     all_ranks = {rank for (rank, _) in params}
     minimal_ancestry = traits.calc_minimal_ancestry(frozenset(all_ranks))
+
     for (rank, p) in defs.items():
         if p.site.provisional_enabled(provisional.explicit_param_decls):
-            (_, type_info, is_default, _) = p.args
+            (name, type_info, is_default, _) = p.args
             if type_info is None:
                 declared_as_override = True
             else:
@@ -687,10 +688,10 @@ def merge_parameters(params, obj_specs):
             if not declared_as_override and parent_ranks:
                 [parent, *_] = (parent for (parent_rank, parent) in params
                                 if parent_rank in parent_ranks)
-                report(EOVERRIDE(type_info.site, parent.site,
+                report(EOVERRIDE(type_info.site, parent.site, name,
                                  'default' if is_default else '='))
             if not declared_as_override and rank in decls:
-                report(EOVERRIDE(type_info.site, decls[rank].site,
+                report(EOVERRIDE(type_info.site, decls[rank].site, name,
                                  'default' if is_default else '='))
             elif (not parent_ranks and declared_as_override
                   and rank not in decls):

--- a/test/1.4/provisional/T_explicit_param_decls_EOVERRIDE.dml
+++ b/test/1.4/provisional/T_explicit_param_decls_EOVERRIDE.dml
@@ -48,6 +48,7 @@ template t {
     /// ERROR EOVERRIDE
     param p8b: int default 6;
     param p9: int = 7;
+    param p10 := 10;
 }
 
 group g is t {
@@ -66,4 +67,6 @@ group g is t {
     param p8a default 88;
     /// ERROR EOVERRIDE
     param p8b :default 88;
+    // no error
+    param p10;
 }

--- a/test/1.4/provisional/T_explicit_param_decls_ESYNTAX.dml
+++ b/test/1.4/provisional/T_explicit_param_decls_ESYNTAX.dml
@@ -1,0 +1,13 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+
+dml 1.4;
+
+provisional explicit_param_decls;
+
+device test;
+
+/// ERROR ESYNTAX
+param p:;


### PR DESCRIPTION
I want this in in time for SQPFU.