### PR TITLE
Relax rule for naming groups 'port'/'bank'

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -180,3 +180,10 @@
 - `release 6 6321`
 - `release 7 7033`
 - `release 6 6324`
+- `note 6` Relaxed the rule which conditionally forbade naming a `group` "port"
+  or "bank". Any `group` may now be named "port" or "bank" regardless of
+  context, but `port`s, `bank`s, or `subdevice`s may not be declared underneath
+  any `group` named "port" or "bank". (For DML 1.2 devices, this change only
+  applies to naming a group "port", as naming any object "bank" in 1.2 devices
+  is impossible due to every object of a 1.2 device having the `bank`
+  parameter.)

--- a/lib/1.2/dml-builtins.dml
+++ b/lib/1.2/dml-builtins.dml
@@ -185,12 +185,9 @@ template group {
     is object;
     parameter objtype = "group";
     parameter log_group = undefined;
-    if (($this._nongroup_parent.objtype == "port"
-         || $this._nongroup_parent.objtype == "device")
-        && $this.name == "port") {
-         error "Cannot name a group 'port' in a location where"
-             + " port objects are allowed";
-    }
+    parameter _simics_namespace_clash =
+        $this.name == "port" || ($parent.objtype == "group"
+                                 ? $parent._simics_namespace_clash : false);
 }
 
 template device {
@@ -385,6 +382,9 @@ template bank {
     is object;
     is _hard_reset;
     is _soft_reset;
+
+    // Need not check if any parent groups are named 'port': banks must be
+    // top-level in 1.2 devices due to SIMICS-19009
 
     data _callback_vect_t _before_read_callbacks;
     data _callback_vect_t _after_read_callbacks;
@@ -1926,6 +1926,10 @@ template event {
 template port {
     is object;
     parameter objtype = "port";
+
+    if ($parent.objtype == "group" ? $parent._simics_namespace_clash : false) {
+        error "Cannot declare a port underneath a group named 'port'";
+    }
 }
 
 template subdevice {
@@ -1933,6 +1937,9 @@ template subdevice {
     parameter objtype = "subdevice";
     if ($this.name == "port") {
          error "A subdevice may not be named 'port'";
+    }
+    if ($parent.objtype == "group" ? $parent._simics_namespace_clash : false) {
+        error "Cannot declare a subdevice underneath a group named 'port'";
     }
 }
 

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -659,19 +659,17 @@ as parent.
 The `group` template contains no particular methods or parameters other
 than what is inherited from the [`object`](#object) template.
 
-In a group hierarchy directly below a `port` or `device` object, none of the
-group object may be named `bank` or `port`; this is to avoid name clashes.
+You may not declare any `bank`, `port` or `subdevice` underneath any group
+named "bank" or "port". This is to avoid namespace clashes in Simics.
 */
 template group is object {
     param objtype = "group";
     param _is_simics_object = false;
     param log_group = undefined;
-    #if ((_nongroup_parent.objtype == "subdevice"
-          || _nongroup_parent.objtype == "device")
-         && (this.name == "port" || this.name == "bank")) {
-         error "Cannot name a group 'port' or 'bank' in a location where"
-             + " port or bank objects are allowed";
-    }
+    param _simics_namespace_clash =
+        this.name == "bank" || this.name == "port"
+        || (parent.objtype == "group"
+            #? parent._simics_namespace_clash #: false);
 }
 
 session bool _issuing_state_callbacks = false;
@@ -1532,6 +1530,12 @@ template port is object {
     param limitations = undefined;
     param obj = dev._compat_port_obj_param #? dev.obj #: _port_obj();
 
+    #if (parent.objtype == "group"
+         #? parent._simics_namespace_clash #: false) {
+        error "Cannot declare a port underneath a group named 'port' or "
+            + "'bank'";
+    }
+
     session conf_object_t *_cached_port_obj;
     shared method _port_obj() -> (conf_object_t *) {
         if (this._cached_port_obj != NULL) {
@@ -1569,6 +1573,11 @@ template subdevice is object {
     }
     #if (this.name == "port" || this.name == "bank") {
          error "A subdevice may not be named 'port' or 'bank'";
+    }
+    #if (parent.objtype == "group"
+         #? parent._simics_namespace_clash #: false) {
+        error "Cannot declare a subdevice underneath a group named 'port' or "
+            + "'bank'";
     }
 }
 
@@ -1859,6 +1868,12 @@ When compiling with Simics API 6 or newer, evaluates to the bank's port object.
 </dd></dl>
 */
 template bank is (object, shown_desc) {
+    #if (parent.objtype == "group"
+         #? parent._simics_namespace_clash #: false) {
+        error "Cannot declare a bank underneath a group named 'port' or "
+            + "'bank'";
+    }
+
     // compatibility: referencing 'obj' in a bank method must evaluate to
     // dev.obj in code that can compile on both 5 and 6
     // TODO: we should probably make obj an immutable session variable

--- a/test/1.2/errors/EERRSTMT_dml14.dml
+++ b/test/1.2/errors/EERRSTMT_dml14.dml
@@ -19,29 +19,60 @@ method m_dml14() {
     }
 }
 
-// Groups and ports may not be named "port" in devices
-// since thy might otherwise cause Simics conf-object names to clash.
+// Subdevices may not be named "port" in devices
+// since that might otherwise cause Simics conf-object names to clash.
 // Unlike DML 1.4, no need to test 'bank' here since that ENAMECOLLs with
 // a parameter.
 /// ERROR EERRSTMT
 subdevice port;
+
+// Banks, ports, and subdevices may not be declared underneath any group named
+// "port" (as that would introduce conflicting namespaces)
 group g1 {
-    /// ERROR EERRSTMT
-    subdevice port;
-    group g {
+    group port {
         /// ERROR EERRSTMT
-        group port;
+        subdevice s;
+        /// ERROR EERRSTMT
+        port p;
+        group g {
+            /// ERROR EERRSTMT
+            subdevice s;
+            /// ERROR EERRSTMT
+            port p;
+        }
     }
 }
-subdevice p1 {
-    group g {
+
+group g2 {
+    port port;
+}
+
+group g3 {
+    /// ERROR EERRSTMT
+    subdevice port;
+}
+
+subdevice s {
+    group g1 {
+        group port {
+            group g {
+                /// ERROR EERRSTMT
+                subdevice s;
+                /// ERROR EERRSTMT
+                port p;
+            }
+        }
+    }
+    group g2 {
         /// ERROR EERRSTMT
         subdevice port;
     }
 }
-port p2 {
-    // currently an error (but harmless, really: port in port is not allowed)
-    /// ERROR EERRSTMT
+
+// no error
+port p {
     group port;
 }
-
+bank b {
+    group port;
+}

--- a/test/1.4/errors/T_EERRSTMT.dml
+++ b/test/1.4/errors/T_EERRSTMT.dml
@@ -35,37 +35,69 @@ method m5() {
     }
 }
 
-// Groups and ports may not be named "bank" or "port" in devices
-// since thy might otherwise cause Simics conf-object names to clash.
-/// ERROR EERRSTMT
-group bank;
+// Subdevices may not be named "bank" or "port" in devices
+// since that might otherwise cause Simics conf-object names to clash.
 /// ERROR EERRSTMT
 subdevice port;
+/// ERROR EERRSTMT
+subdevice bank;
+
+// Banks, ports, and subdevices may not be declared underneath any group named
+// "bank" or "port" (as that would introduce conflicting namespaces)
 group g1 {
+    group bank {
+        /// ERROR EERRSTMT
+        subdevice s;
+        /// ERROR EERRSTMT
+        port p;
+        /// ERROR EERRSTMT
+        bank b;
+        group g {
+            /// ERROR EERRSTMT
+            subdevice s;
+            /// ERROR EERRSTMT
+            port p;
+            /// ERROR EERRSTMT
+            bank b;
+        }
+    }
+}
+
+group g2 {
     // no error
+    bank port;
     port bank;
+}
+
+group g3 {
     /// ERROR EERRSTMT
     subdevice port_ { param name = "port"; }
     // no error
     subdevice port { param name = "port_"; }
-    group g {
-        /// ERROR EERRSTMT
-        group port;
-    }
 }
-subdevice p1 {
+
+subdevice s {
     group g {
-        /// ERROR EERRSTMT
-        group port;
+        group port {
+            group g {
+                /// ERROR EERRSTMT
+                subdevice s;
+                /// ERROR EERRSTMT
+                port p;
+                /// ERROR EERRSTMT
+                bank b;
+            }
+        }
         /// ERROR EERRSTMT
         subdevice bank;
     }
 }
 
-// no error: name clash cannot happen since ports/banks can't have subobjects
-port p2 {
-    group port;
-    group bank;
+// no error
+port p {
+    group port {
+        group bank;
+    }
 }
 bank b {
     group port {


### PR DESCRIPTION
~This exists purely for TC to be aware of it.~ Now a proper PR.