### PR TITLE
Don't emit linemarks for implicit returns -- SIMICS-22685

### DIFF
--- a/RELEASENOTES-1.4.md
+++ b/RELEASENOTES-1.4.md
@@ -332,3 +332,7 @@
 - `release 6 6329`
 - `note 6` `continue` can now be used within `foreach` loops (use within
   `#foreach` loops remains unsupported)
+- `note 6` C code generated for any implicit return of a method will no longer
+  receive a `#line` directive pointing it to the closing brace of the DML
+  method (fixes SIMICS-22685). This should make coverage and debugging tools
+  ignore implicit returns, as with C.

--- a/py/dml/logging.py
+++ b/py/dml/logging.py
@@ -22,6 +22,8 @@ __all__ = (
     'DumpableSite',
     'TemplateSite',
 
+    'as_simple_site',
+
     'dbg',
     )
 
@@ -258,6 +260,17 @@ class PortingMessage(LogMessage):
                 # messages on Windows
                 os.path.normcase(arg.loc()) if isinstance(arg, Site) else arg
                 for arg in self.args]))
+
+def as_simple_site(site):
+    '''Make a SimpleSite whose description is based on the .loc() of an actual
+    site.
+
+    This is useful for generated statements that are related to DML code at a
+    particular line, but that line can't reasonably be said to describe the
+    generated code. `as_simple_site` can then be used to easily give that
+    generated statement an informative site while guaranteeing that statement
+    won't get linemarked.'''
+    return SimpleSite(site.loc())
 
 class Site(metaclass=abc.ABCMeta):
     __slots__ = ()

--- a/py/dml/traits.py
+++ b/py/dml/traits.py
@@ -222,7 +222,7 @@ class TraitMethod(TraitVTableItem):
               if not self.independent else contextlib.nullcontext()):
             scope = MethodParamScope(self.trait.scope(global_scope))
             implicit_inargs = self.vtable_trait.implicit_args()
-            site = SimpleSite(self.site.loc())
+            site = as_simple_site(self.site)
             if len(self.default_traits) > 1:
                 default = AmbiguousDefaultSymbol(
                     [trait.method_impls[self.name].site


### PR DESCRIPTION
Also some refactoring to make use of a documented `as_simple_site` function for the `SimpleSite(site.loc())` pattern

@TSonono try this PR out and see if you're satisfied with the behavior, or if there's some other strangeness that remains and sticks out to you.