### PR TITLE
Add provisional as a keyword in DML

### DIFF
--- a/syntaxes/Dml.tmlanguage
+++ b/syntaxes/Dml.tmlanguage
@@ -57,7 +57,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(#if|#else|connect|constant|device|dml|bank|bitorder|param|import|interface|loggroup|log|local|template|is|implement|method|independent|memoized|saved|startup|inline|event|attribute|throw|try|catch|nothrow|delete|group|port|size|sizeoftype|shared|#select|%header|%footer|subdevice|then)\b</string>
+			<string>\b(#if|#else|connect|constant|device|dml|bank|bitorder|param|import|interface|loggroup|log|local|template|is|implement|method|independent|memoized|saved|startup|inline|event|attribute|throw|try|catch|nothrow|delete|group|port|size|sizeoftype|shared|#select|%header|%footer|subdevice|then|provisional)\b</string>
 			<key>name</key>
 			<string>keyword.control.dml</string>
 		</dict>


### PR DESCRIPTION
This is applied to the DML TML file.

The vscode extension needs a new submodule reference after this is merged.