### PR TITLE
Avoid dependency on liblzma

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Override the default compiler in unit tests.
 When set, DMLC does self-profiling and writes the profile to a .prof file.
 
 ### DMLC_DUMP_INPUT_FILES
-When set, DMLC emits a `.tar.xz` archive containing all DML source files,
+When set, DMLC emits a `.tar.bz2` archive containing all DML source files,
 packaged on a form that can be compiled standalone. This is useful when a DML
 problem appears within a complex build environment, and you want to reproduce
 the problem in isolation. In the created archive, all DML files are located in

--- a/py/dml/dmlc.py
+++ b/py/dml/dmlc.py
@@ -182,7 +182,7 @@ def dump_input_files(outputbase, imported):
     prefix = '/'.join(['_'] * max_dotdot)
     # map basename to one of its absolute paths
     basenames: dict[str, str] = {}
-    with tarfile.open(outputbase + ".tar.xz", 'w:xz') as tf:
+    with tarfile.open(outputbase + ".tar.bz2", 'w:bz2') as tf:
         # HACK: if two different files foo.dml are imported, where one is
         # imported as "foo.dml" or "./foo.dml" and the other is only
         # imported using a qualified path such as "bar/foo.dml", then

--- a/test/tests.py
+++ b/test/tests.py
@@ -915,8 +915,8 @@ class DumpInputFilesTestCase(CTestCase):
         super().test()
         dir = Path(self.scratchdir) / 'dumped'
         dir.mkdir()
-        with tarfile.open(Path(self.scratchdir) / f'T_{self.shortname}.tar.xz',
-                          'r:xz') as tf:
+        with tarfile.open(Path(self.scratchdir) / f'T_{self.shortname}.tar.bz2',
+                          'r:bz2') as tf:
             tf.extractall(dir)
         assert (dir.joinpath(*self.prefix)
                 / os.path.basename(self.filename)).is_file()


### PR DESCRIPTION
Not all Pythons are built with xz compression.
