### PR TITLE
Document msys2 dependency on Windows (addresses #330)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ and create a Simics project (automatic in the default installation flow).
 
 ### Building DMLC from a Simics project
 In your Simics project, check out the DML repository into the `modules/dmlc`
-directory.  At the top-level of the project, do `make dmlc`
-(or `bin\make dmlc` on Windows). 
+directory.  At the top-level of the project, do `make dmlc` (or `bin\make dmlc`
+on Windows).  The build depends on some standard Unix tools like `touch`; on
+Windows this means you also need to install a GNU toolchain such as
+[msys2](https://www.msys2.org/).
 
 ### Testing DMLC from a Simics project
 To run the unit tests provided with DMLC, run `make test-dmlc` or


### PR DESCRIPTION
- **Make attributes internal if missing _both_ doc & desc**
- **Make subsequent_log use trait identity as key**
- **Make subsequent log in object arrays work correctly**
- **Make write-outside-fields in registers only log once**
- **Enable "Blocking Issues" github action**
- **Try harder to enable action**
- **Try to enable "Dependent issues" github action**
- **Update test**
- **Add some basic gitignores**
- **Switch to local fork**
- **Remove "Blocking Issues" action**
- **Refactor script to avoid side-effects on toplevel**
- **Generate github wiki**
- **Improve logging test**
- **Mention that sizeoftype does not count as a constant**
- **Move topsort to module traits**
- **Refactor: Move method sorting to traits.py**
- **Improve how irrelevant porting messages are presented.**
- **Revert commits pushed by mistake**
- **Ignore gitignore**
- **Improve generation of array de/serialization functions -- SIMICS-18440**
- **De/serialize uint8 arrays as data values**
- **Flexible de/serialization for byte array types**
- **Add rudimentary readme**
- **Add missing copyright**
- **Improve logging test**
- **Mention that sizeoftype does not count as a constant**
- **Move topsort to module traits**
- **Refactor: Move method sorting to traits.py**
- **Improve how irrelevant porting messages are presented.**
- **Remove dollar from DML 1.4 error messages -- SIMICS-18421**
- **Remove unused macro**
- **Add map_target template**
- **Provide byte order information in register_view for DML 1.4**
- **Check that byte order metadata is generated correctly**
- **Use explicit parameter to control the bitorder presented in register_view**
- **Don't create XML files, they are no longer needed by DML 1.4**
- **Cache mapped_registers in get_register and num_registers**
- **Add logging on map-target access**
- **Extend transaction-testing with big-endian bank**
- **Split transaction accesses at 8-byte address boundaries**
- **Avoid intermediate transaction**
- **Auto-fix copyright year from test**
- **Update copyright year**
- **Optimize EREGOL check, SIMICS-7038**
- **Fix build-id to match actual releases**
- **Implement --dep-target and --no-dep-phony arguments**
- **Update doc for --no-dep-phony and --dep-target**
- **Fix docs**
- **Designated initializers (SIMICS-17252); non-constant compound initializers**
- **Generate refman title page for github wiki**
- **Fix python warnings (from fisketur)**
- **upload_simics: replace "next" with build-id 6139**
- **Remove run-time dependency on simicsutils**
- **Check explicitly for utf8_mode**
- **Validate PLY version**
- **Allow t126 to enforce a custom python interpreter**
- **Fix typo**
- **Add support for `break` in `#foreach` statements**
- **Introduce the env var DMLC_CC to make gcc configurable in unit tests**
- **upload_simics: replace "next" with build-id 6141**
- **Allocate trait vtable instances on the heap**
- **Add support for cancelling events posted via after -- SIMICS-17930**
- **Fix stringop-truncation warning in dmllib tests**
- **Rearrange device struct: propagate array dimensions to leaf members**
- **Rearrange device struct: propagate array dimensions to leaf members**
- **Fix map_target documentation**
- **Improvements on const -- SIMICS-9440, SIMICS-10197**
- **upload_simics: replace "next" with build-id 6143**
- **Added a unit test case for DMLC_PROFILE**
- **Replaced hotshot with cProfile**
- **Update docs re. `in each` in #if; true/false in experimental #if -- SIMICS-18702**
- **Support break inside DML 1.4 foreach statements -- SIMICS-18719**
- **Support omitting object array dimension sizes when redundant -- SIMICS-18580**
- **Fix incorrect check in T_ECONDINEACH**
- **Docs: Rename "Statements" section to "Method Statements" -- SIMICS-18692**
- **Revert the [i < ...] array syntax.**
- **upload_simics: replace "next" with build-id 6145**
- **Suppress warning when testing semantics of discouraged comparisons**
- **Restore the [i < ...] array syntax.**
- **Use nullcontext to avoid the overly complex ExitStack**
- **Repair and run test**
- **Provide a sensible default for api_version**
- **Simplify profiling test case**
- **Add environment variable DMLC_DUMP_INPUT_FILES**
- **Remove _**
- **Clarify that some code is hacky**
- **Disable part of test on Windows**
- **Generate github wiki as a tarball**
- **Correct path to public Simics simulator + more (#62)**
- **Remove dead code**
- **upload_simics: replace "next" with build-id 6147**
- **Don't forgive missing Simics version**
- **Make map_target.issue 'default'**
- **Fix review-comment**
- **Fix typo in release notes**
- **Spell DML in uppercase**
- **Make release note headers abide to Intel standards**
- **Repair error reporting**
- **Defensive deserialization of values of serializable types -- SIMICS-18522**
- **Add missing copyright header**
- **Improve error message on partial failure**
- **upload_simics: replace "next" with build-id 6148**
- **Allow ports/bank in groups, and add 'subdevice' object type**
- **Fix DML according to IPLDT standards**
- **Fix bug in naming when init_as_subobj is instantiated in a bank or port**
- **upload_simics: replace "next" with build-id 6149**
- **Allow declaration of multiple variables in one statement -- SIMICS-7027**
- **Provide initiator in bank instrumentation**
- **Set theme jekyll-theme-midnight**
- **ignore _config.yml**
- **Repair documentation of field access order, and add test**
- **Pass -r flag to gcc directly**
- **upload_simics: replace "next" with build-id 6150**
- **Add signal_port and signal_connect templates**
- **Independent methods -- SIMICS-6181, SIMICS-6182, SIMICS-17632**
- **Fix documentation mistakes**
- **upload_simics: replace "next" with build-id 6153**
- **Method Reference to Function Pointer Conversion -- SIMICS-14921**
- **Suggest `sizeoftype` when erroring on `sizeof` -- SIMICS-17991**
- **upload_simics: replace "next" with build-id 6154**
- **upload_simics: replace "next" with build-id 6154**
- **Add field range checks in 1.4 -- SIMICS-19194**
- **Allow independent, startup and memoized as idents**
- **Fix mistakes in docs re. independent methods**
- **Remove self-defeatist coment in DMLC hacking guide**
- **DMLC hacking guide: fix grammar mistake**
- **upload_simics: replace "next" with build-id 6157**
- **port-dml: substitute unmapped_offset for undefined -- SIMICS-19191**
- **upload_simics: replace "next" with build-id 6158**
- **Fix issue where certain 1.4 params couldn't referenced in 1.2 modules**
- **Doc improvements -- SIMICS-18539, -18138, -18373, -18381, -19209**
- **Simple uses of independent startup memoized in dml-builtins**
- **Fix independent methods not being exported correctly**
- **upload_simics: replace "next" with build-id 6160**
- **upload_simics: replace "next" with build-id 6161**
- **Don't expect <undefined> fields in register_view**
- **Clarify the intended use of the read_constant template**
- **Turn all template references into links**
- **Remove redundant "Log output: None" statements**
- **Improve -g documentation, scaffolding for patches to dml-gdb**
- **Whitelist based type checking for casts -- SIMICS-17955**
- **Revert "Allocate trait vtable instances on the heap"**
- **Use indices from traitref, instead of inferring from pointer arithmetic**
- **Cover nontrivial indexing of session variables**
- **Rename crep**
- **Use encoded index when accessing session variables**
- **Represent parameters in object arrays as arrays in vtables**
- **Share vtable instance across object arrays**
- **Only allocate params dynamically in multidim objects**
- **Disable optimization for trait init methods**
- **Capture early when 'each in' is used with implicit static indices**
- **Disallow template references to objects with implicit static indices**
- **Only array-expand parameters that rely on an index variable**
- **Avoid duplicate side-effects in session refs**
- **Don't split trait initialization into multiple functions**
- **Correctly initialize params with partially const types**
- **Avoid vtable array expansion for 'each T in this'**
- **Split vtable initialization into smaller functions again**
- **More tests, address non-indexed const typed params**
- **Remove dead error**
- **Add EASZLARGE error**
- **Improve test for large vtable arrays**
- **Reduce the size of each_in_t**
- **Print Simics command line if it failed**
- **Avoid generating arrays of size 0**
- **Move related functions closer to each other**
- **explode_ranges: bail out if EIDXVAR**
- **Fix rebase issues with shared independent startup memoized methods**
- **Repair test**
- **1.4: utility: Allow user to override signal methods in hreset template**
- **Repair IS_INT64 macro**
- **T_trait_largearray: bump memory bounds check to 1024 KiB**
- **upload_simics: replace "next" with build-id 6171**
- **Log messages for unmapped accesses from unmapped_{read,write}**
- **Refactor logic for before/after callbacks**
- **Add comment**
- **upload_simics: replace "next" with build-id 6173**
- **Keep line numbers separately in SimpleSite**
- **Generate deinit before processing method queue -- SIMICS-19598**
- **Update BZ references to JIRA references**
- **upload_simics: replace "next" with build-id 6176**
- **Port test and create issue for BZ 4582**
- **Don't pollute stderr**
- **Remove strange tests**
- **Relabel test that happens to cover SIMICS-11957**
- **Change failures into stability tests**
- **Make instantiating _qname free -- SIMICS-19564**
- **Repair XFAIL further, SIMICS-11098**
- **Update signatures to match DML 1.4 syntax, SIMICS-18445**
- **Add '...' syntax to allow partial designated initializers -- SIMICS-18705**
- **Revert previous SimpleSite change**
- **Polish site strings**
- **Don't generate #line directives for SimpleSite**
- **Add sites to all symbols**
- **Allow enabling line directives when running test suite**
- **Improve test output on failure**
- **Move some % formatting to f-strings**
- **Improve documentation configuration param, SIMICS-18590**
- **Add releasenote for 59462160dea5035165cff6c9b0b09690a02d4a1d**
- **upload_simics: replace "next" with build-id 6177**
- **Clarify documentation for the `destroy` method**
- **Ensure serialized identity of device is unique -- SIMICS-19679**
- **Serializable template types -- SIMICS-18507**
- **Only report None tokens as EOF**
- **upload_simics: replace "next" with build-id 6178**
- **Remove questionable code**
- **Specify that methods are static**
- **Create attributes for saved in port in group, SIMICS-19422**
- **Fix ICE from trait reference initializers -- SIMICS-20145**
- **Don't reference register numbers in documentation**
- **upload_simics: replace "next" with build-id 6183**
- **Reverse order of conditions**
- **Check that we don't write -- in markdown**
- **upload_simics: replace "next" with build-id 6184**
- **Fix trait reference params causing broken debug files -- SIMICS-20200**
- **Make the method map_target.set 'default'**
- **upload_simics: replace "next" with build-id 6187**
- **Codegen empty vtables as empty structs**
- **Allow casts from any template type to object -- SIMICS-19950**
- **Update FSM example in docs to use serializable template types**
- **Fix live vtables causing methods of dead vtables to be live -- SIMICS-20308**
- **Update binaries path**
- **upload_simics: replace "next" with build-id 6190**
- **Add init_val param to standard attribute templates -- SIMICS-20108**
- **Make NULL a magic constant**
- **Softcode attribute registration for `_conf_attribute`s -- SIMICS-6271**
- **Propagate sets of proxy array attributes during configuration**
- **Make vtables live when the template type is serialized -- SIMICS-20301**
- **Tweak test 1.4/structure/trait_dce to be more robust**
- **Fix bug in DMLC_DUMP_INPUT_FILES**
- **register_view: unique names for fields in arrays -- SIMICS-18244**
- **Support `.len` for any expression of sequence type -- SIMICS-20278**
- **upload_simics: replace "next" with build-id 6191**
- **Update copyright year**
- **Dodge name clash, HSD-ES 15012582368**
- **Remove obsolete copyright code**
- **remove obsolete XFAIL**
- **Add test that ambiguous inheritance can be resolved by override**
- **Avoid having to pass -L when re-running test manually**
- **Don't declare a temporary struct instance as a local variable**
- **upload_simics: replace "next" with build-id 6195**
- **Add DMLC_GATHER_SIZE_STATISTICS environment variable**
- **Also profile code sizes from shared methods**
- **Add test for DMLC_GATHER_SIZE_STATISTICS**
- **Add --noline flag, needed when run from the t226_pypy test**
- **Distribute dmlc as .py instead of .pyc**
- **Run tests in mini-python**
- **Enable line directives by default**
- **Implement a set data structure whose iteration preserves insertion order**
- **Replace set with Set and list to avoid nondeterministic output**
- **Validate that two runs with different pythons give the same C output**
- **fix minor typos**
- **replace OrderedDict with dict and Set**
- **Enforce gcc -O2**
- **Skip GCC step for some tests where this is irrelevant and slow**
- **Reduce GCC time in slow test**
- **Add releasenote**
- **Distribute newly added file**
- **Remove the expect function from the 1.4 test framework**
- **Avoid possible undefined behaviour**
- **upload_simics: replace "next" with build-id 6200**
- **Coverity Support and Undocumented Pragma**
- **Remove redundant WEXPERIMENTAL annotation**
- **Add releasenote for --coverity option**
- **Typed set/get variants for standard attribute templates -- SIMICS-17951**
- **Do not emit WEXPERIMENTAL about multiple defaults in dml12-compatibility**
- **`inline` methods: fix ICE and mistreatment by -g -- SIMICS-20549**
- **Fix nondeterminism in `Template.traits()`**
- **Revert "Typed set/get variants for standard attribute templates -- SIMICS-17951"**
- **upload_simics: replace "next" with build-id 6205**
- **Add repo-local spelling passlist**
- **Add porting rule for converting int1 to uint1**
- **Remove the testing.dml lib for DML 1.4**
- **Change empty catch blocks to assert false**
- **Address review comments**
- **Minor de/serialization revamp**
- **Abstract extending late_global_struct_defs; add TStruct.anonymous**
- **Touch-ups of stmt_after and LValue.write()**
- **Initializer syntax for arguments -- SIMICS-20473**
- **Tweak stmt_local logic re. try_codegen_invocation**
- **upload_simics: replace "next" with build-id 6213**
- **Support Simics API 7 for DML 1.2**
- **Repair indentation**
- **Random polish**
- **Polish porting of return statements**
- **Avoid inserting locals for outargs if unused**
- **Add release note**
- **Avoid old style command line options (SIMICS-20622)**
- **Support function_mapped_bank on banks with use_io_memory=false**
- **upload_simics: replace "next" with build-id 6215**
- **Do not use 5 API tests in Simics 7**
- **Remove integer_t and uinteger_t in Simics 7**
- **Improve DML_DUMP_INPUT_FILES**
- **Avoid legacy Register_LE form**
- **Enable `use_io_memory` for generated io_memory_access overrides**
- **Make explicit assumptions on use_io_memory**
- **Use io_memory explicitly in shared 1.2/1.4 banks**
- **Improve how DML 1.2 survives common code with use_io_memory=false**
- **Address review feedback**
- **Fix typos**
- **Remove the dml12_compat_access_override template**
- **Avoid broken C code generation, SIMICS-21044**
- **upload_simics: replace "next" with build-id 6218**
- **Avoid relying on which exact exception an attribute getter throws**
- **Warn about bad pointer-to-pointer casts -- SIMICS-20863**
- **Suppress `copy_paste_error` Coverity false positive in dml-builtins**
- **`mkCast`: permit cast from expr of struct type to that same struct**
- **Fix deconstifying bugs in deserialization**
- **`TLayout.clone()`: clone `.members` if available**
- **Support up to 63 log groups -- SIMICS-21138**
- **Revert "Support up to 63 log groups -- SIMICS-21138"**
- **Remove module signing**
- **Remove use of simicsutils.internal.is_same_file**
- **upload_simics: replace "next" with build-id 6223**
- **Adapt to new package-spec format**
- **Temporarily permit both old and new package-specs format**
- **Have zero-initialized _identity_t be invalid**
- **Hooks and after-on-hooks -- SIMICS-20358**
- **Avoid deprecated option forms**
- **Avoid internal function simics_root_path**
- **Remove dangling reference to hook arrays in documentation**
- **Remove compat hack**
- **Test distributed API files only**
- **Make equalities with zero-initialized traitrefs raise critical error**
- **Add 1.4 variant of the ethernet common code**
- **Make the 1.4 ethernet code common for 1.2 and 1.4**
- **Revert "Merge pull request #197 from intel/ethernet-1-4"**
- **Add 7-specific dmlc groups**
- **upload_simics: replace "next" with build-id 6231**
- **Read the previous register value before a partial inquiry write**
- **Fix ICE when serializing `long` or `size_t` -- SIMICS-21424**
- **Give size_t and long dedicated type signatures**
- **Don't rely on UB enum semantics for more than 32 log groups**
- **Immediate After Statement -- SIMICS-20379**
- **Soothe static analysis on Windows**
- **Fix HookSendApply.read() returning a statement rather than an expression**
- **Fix attribute registration inside ports in object arrays -- SIMICS-21474**
- **Update docs for signal_port and signal_connect**
- **Trait trampolines: declare `_flat_index` as uint32**
- **upload_simics: replace "next" with build-id 6244**
- **Warn if log groups are used as log level, or vice versa -- SIMICS-21138**
- **Shut up linter**
- **Remove the --illegal-attrs flag**
- **Remove --version, which was ignored**
- **Migrate from optparse to argparse**
- **Rename function**
- **Refactor: Re-use common function**
- **Factor out params for API version ranges**
- **Add option for listing all warning tags**
- **upload_simics: replace "next" with build-id 6247**
- **Correct some line directives, to avoid noise in coverage reports**
- **Add --deprecate=PORT_PROXY_IFACES**
- **Add PORT_PROXY_ATTRS deprecation**
- **Add documentation for --deprecation**
- **Convert --strict-dml12 to three deprecation tags**
- **Use integers to represent API versions**
- **Change --deprecate to --no-compat**
- **Refactor: represent API versions with a dedicated class**
- **Validate that dml-builtins declares all autoparams**
- **Use compat system for --strict-int**
- **Use compat to control the default of use_io_memory param**
- **Use compat system for the obj param of ports/banks**
- **Repair odd ICE**
- **Avoid errors on `typeof $this` in arrays of registers or fields**
- **Avoid overflow with --no-compat=dml12_int**
- **Add rudimentary tests for help flags**
- **Add release note for --no-compat flag**
- **Avoid incorrect ENAMECOLL with dml12_misc**
- **Extract goto to a separate compat feature**
- **Temporarily bump last API of port proxy flags to 7**
- **Improve some #line directives**
- **Add script to find globally dead DML methods**
- **Split CC environment variable in case compiler is decorated**
- **Make releasenotes display consistently**
- **Address inconsistencies across specs of `CompatFeature.short`**
- **`STATIC_ASSERT` to forbid device structs 4 GiB or larger**
- **Fix logging always using the device object within shared methods -- SIMICS-11346**
- **Gate fix behind `--no-compat=shared_logs_on_device`**
- **Use the `_log_object_assocs` array for softcoded proxy attribute registration**
- **upload_simics: replace "next" with build-id 6252**
- **Selectively allow generation of line directives**
- **Fix inconsistency with linemark generation with assignments**
- **Address bugs due to lack of linemark generation**
- **Add linemarks test, address issues found by it**
- **Windows hotfix for linemarks test**
- **Don't transform empty compounds to `;`**
- **Avoid wrapping constants in multiple layers of InlineParam**
- **Prettify C generation for `if`-`else` chains**
- **Hotfix for `If.toc_stmt()`: check for `VectorForeach`**
- **Adapt release note to new test for build-id**
- **Remove fallback**
- **Unify reginfo error handling**
- **Replace fallback logic with mutating `*_fixup` variants of functions**
- **Survive ENAMEID better**
- **Fix spelling**
- **Remove redundant flag**
- **Make global device list available only during code generation**
- **Make global hook list available only during code generation**
- **Only worry about None names in obsolete DML**
- **`connect.set_attribute`: Suppress Coverity event `var_deref_model`**
- **Avoid old sim attributes (SIMICS-21519)**
- **upload_simics: replace "next" with build-id 6255**
- **Add test for `if`-`else` ambiguity**
- **Fix `TryCatch` not attempting to avoid `Wparentheses`.**
- **Add FIXME and HACK workaround for SIMICS-21719**
- **Fix incorrect linemark tracking with `--coverity`**
- **remove unused method**
- **Use counting sort to sort in linear instead of quadratic time**
- **Only test reverse execution when supported**
- **upload_simics: replace "next" with build-id 6262**
- **Resolved paths in generated C-file's sources list**
- **Add JIRA-referencing TODO comment**
- **upload_simics: replace "next" with build-id 7006**
- **Update copyright year**
- **Update copyright year test**
- **Update copyright notice generation**
- **Batch-update copyright notices to new format**
- **Delete .github/workflows/dependent-issues.yml**
- **update ignorelist**
- **fix typo**
- **Change of API SIMICS-21363**
- **Repair subtitles in generated deprecation tables**
- **Make the suppression of `WLOGMIXUP` a proper compatibility feature**
- **upload_simics: replace "next" with build-id 6274**
- **Make some internal methods independent**
- **Make test works with sym-linked sources**
- **upload_simics: replace "next" with build-id 7007**
- **Use project mini-python**
- **Update obsolete note**
- **Leverage location when typechecking method overrides**
- **upload_simics: replace "next" with build-id 6283**
- **Fix typo in documentation of `read_field`/`write_field`**
- **Create SECURITY.md**
- **Update SECURITY.md**
- **upload_simics: replace "next" with build-id 7011**
- **Update bug references**
- **Fix EREGOL not being reported for registers of banks in groups/subdevices**
- **Address Erik's feedback**
- **Explain default initializer for local variables**
- **upload_simics: replace "next" with build-id 7012**
- **upload_simics: replace "next" with build-id 6287**
- **Fix immediate after callbacks not notifying about state change**
- **upload_simics: replace "next" with build-id 6295**
- **upload_simics: replace "next" with build-id 7016**
- **Use the new 6-only macro to reduce duplication**
- **Repair test**
- **Add uint64_t and int64_t types**
- **Break out default implementations of `read_register`/`write_register`**
- **Add support for `log warning`**
- **1.4:utility.dml: template miss_pattern_bank: Allow method overrides**
- **`miss_pattern_bank`: Fix bugs, add docs, release notes, tests**
- **upload_simics: replace "next" with build-id 6297**
- **Factor out methods**
- **Capture invalid uses of functions as subtypes**
- **Refactor method**
- **Disallow const functions**
- **Test and repair `const` variants of all types**
- **Add error tests for bad `implement`s**
- **Add compatibility feature for `void f(x)` syntax in iface struct members**
- **Extract new error message for mismatching interface method type**
- **Polish messages for test failures**
- **Improve linemarks for struct declarations**
- **upload_simics: replace "next" with build-id 6298**
- **upload_simics: replace "next" with build-id 7017**
- **Use compat features to deprecate bad version statements**
- **Improve wording**
- **Use package_path from Simics base**
- **Document order semantics of `each`-`in` and `init`**
- **Template-Qualified Method Implementation Calls -- SIMICS-22264**
- **Permit conflicting shared impls. if overridden -- SIMICS-20431**
- **TQMIC docs, tests, fixes, touch-ups, and addressed feedback**
- **Avoid test failure on systems where stack is unlimited by default**
- **upload_simics: replace "next" with build-id 7020**
- **Add TODO comment re. memoizing `merge_method_impl_maps` in `mkobj2`**
- **Permit custom implementations of register_view**
- **Limited scope for io_memory**
- **Comment**
- **Test case, documentation**
- **Use _nongroup_parent**
- **Releasenotes function_io_memory**
- **Prefix, indentation**
- **Fix indentation after indentation revert**
- **Port inside group inside subdevice case**
- **upload_simics: replace "next" with build-id 6309**
- **upload_simics: replace "next" with build-id 7021**
- **Refactor grammar for 'device'**
- **Add base syntax for provisional features**
- **Add syntax for walrus params**
- **Unify ASTs for param and typedparam**
- **Report errors for walrus violations**
- **Adjust some tests**
- **Recognize the new `param` AST node in dead_dml_methods**
- **Fixed a bug in dead_dml_methods script**
- **Require auto declarations for autoparams also in DML 1.2**
- **Add documentation for provisional features**
- **Factor out handling of DML 1.2 compat and auto**
- **Fix subtle ENAMECOLL bug**
- **Memoize minimal_ancestry and use it also for is_override**
- **Polish error message**
- **Fix up some backticks in release notes**
- **Report ENTMPL on conditional is, gated on compat feature**
- **upload_simics: replace "next" with build-id 6310**
- **Add test for recently accidentally improved corner**
- **Document requirment on class registration ordering**
- **upload_simics: replace "next" with build-id 7022**
- **Immediate after: improve configuration and deletion semantics -- SIMICS-22264**
- **Have separate `Sim_Notify_Object_Delete` and `deinit` hooks**
- **Improve TQMIC error messages**
- **Fixup short desc of `broken_conditional_is`**
- **dmllib.h: Only use `VT_log_warning` if available**
- **Don't use definition lists in release notes**
- **Migrate away from `SIM_register_typed_attribute` -- SIMICS-22406**
- **Gate `SIM_register_typed_attribute` behind a compat feature**
- **Add Release-notes declaration for the dmlc group**
- **upload_simics: replace "next" with build-id 7023**
- **Type Equality/Compatibility Revamp -- SIMICS-9504**
- **Fix signatures of `LOAD` family of `extern`:d macros**
- **mkCast: add ad-hoc exception for bitfields**
- **`shallow_const`, `deep_const`, `safe_realtype_unconst`: Ignore `TVector`**
- **Add compatibility feature and releasenotes**
- **Get rid of remaining ungated usages of `compatible_types_fuzzy`**
- **Make bitfields compatible only with identically specified bitfields**
- **Touch-ups, tests, addressing Erik's feedback**
- **upload_simics: replace "next" with build-id 6312**
- **upload_simics: replace "next" with build-id 6313**
- **Idempotent Externs -- SIMICS-22472**
- **Refactor membership checks to use set literals**
- **upload_simics: replace "next" with build-id 7024**
- **upload_simics: replace "next" with build-id 7025**
- **Check indices passed to method functions -- SIMICS-22491**
- **Alternate mechanism for index assertions**
- **Tweak mechanism to minimize compile-time overhead**
- **upload_simics: replace "next" with build-id 6313**
- **upload_simics: replace "next" with build-id 6313**
- **Repair WNEGCONSTCOMP for uint8**
- **Add compatibility feature to gate method index assertions**
- **upload_simics: replace "next" with build-id 7026**
- **dml-builtins.dml: massage types to soothe Coverity**
- **`suppress_linemarks()`: Also suppress Coverity annotations**
- **upload_simics: replace "next" with build-id 9999**
- **Revert "upload_simics: replace "next" with build-id 9999"**
- **upload_simics: replace "next" with build-id 147957**
- **Fix mistake after running release step manually**
- **Convert release-notes to markdown**
- **Add `major 7` marker to 1.2 release-notes**
- **upload_simics: replace "next" with build-id 6316**
- **upload_simics: replace "next" with build-id 7027**
- **upload_simics: replace "next" with build-id 7027**
- **Add linemarks to dmldep.c file**
- **upload_simics: replace "next" with build-id 6138**
- **upload_simics: replace "next" with build-id 7029**
- **upload_simics: replace "next" with build-id 6320**
- **upload_simics: replace "next" with build-id 7032**
- **upload_simics: replace "next" with build-id 6321**
- **upload_simics: replace "next" with build-id 7033**
- **upload_simics: replace "next" with build-id 6324**
- **Fixup badly formatted releasenote**
- **Remove invalid release markers**
- **Added initial TM file taken from vscode extension**
- **Added tml file to copyright ignore list**
- **Forbid `param p:;` grammatically**
- **Touch up `explicit_param_decls` docs and errors**
- **Make `explicit_param_decls` stable**
- **upload_simics: replace "next" with build-id 7036**
- **Add picoseconds (`ps`) as a unit of time -- SIMICS-16019**
- **Typecheck shared methods after trait processing -- SIMICS-22166**
- **upload_simics: replace "next" with build-id 6329**
- **Support `continue` within `foreach` (on sequences)**
- **Remove RELEASENOTES.docu files**
- **upload_simics: replace "next" with build-id 6330**
- **upload_simics: replace "next" with build-id 7037**
- **Add the access_count explicitly**
- **Suppress warnings when --dep is passed**
- **Repair pypy run of WREDUNDANTLEVEL_dep**
- **`destroy` template -- SIMICS-16161**
- **upload_simics: replace "next" with build-id 6333**
- **upload_simics: replace "next" with build-id 7041**
- **upload_simics: replace "next" with build-id 7042**
- **Add provisional as a keyword in DML**
- **Relax rule for naming groups 'port'/'bank'**
- **extern `ATOM_LIST_END` in dml-builtins -- SIMICS-22363**
- **upload_simics: replace "next" with build-id 7044**
- **upload_simics: replace "next" with build-id 6336**
- **dml-builtins: Minor documentation fixes**
- **upload_simics: replace "next" with build-id 7045**
- **Document msys2 dependency on Windows (addresses #330)**
