### PR TITLE
Polish treatment of log levels for error-like log kinds -- SIMICS-22401

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -210,3 +210,13 @@
   (fixes SIMICS-19133).
 - `release 6 6354`
 - `release 7 7059`
+- `note 6` Log statements of kind `warning`, `error`, or `criticial` now
+  support the use of `5` as a subsequent log level, meaning the log will only
+  happen once. Any other value of the subsequent log level but `1` will be
+  treated as `5` for these logging kinds.
+- `note 6` Added checks that cause DMLC to reject the use of any log level but
+  `1` for log statements of kind `warning`, `error`, or `critical`; and reject
+  the use of any subsequent log level for these logging kinds but `1` or `5`
+  (fixes SIMICS-22401). For compatibility reasons, these checks are not
+  performed with Simics API version 7 or below unless
+  `--no-compat=meaningless_log_levels` is passed to DMLC.

--- a/doc/1.4/language.md
+++ b/doc/1.4/language.md
@@ -3670,7 +3670,7 @@ response of manager, even if the manager responds synchronously.
 ### Log Statements
 
 <pre>
-log <em>log-type</em>[, <em>level</em> [ then <em>subsequent_level</em> ] [, <em>groups</em>] ]: <em>format-string</em>, <em>e1</em>, ..., <em>eN</em>;
+log <em>log-type</em>[, <em>level</em> [ then <em>subsequent-level</em> ] [, <em>groups</em>] ]: <em>format-string</em>, <em>e1</em>, ..., <em>eN</em>;
 </pre>
 
 Outputs a formatted string to the Simics logging facility. The string
@@ -3702,10 +3702,16 @@ messages, by matching on the three main properties of each message:
   4. Debugging level with low level model detail (Mainly used for model
      development)
 
-* If *`subsequent_level`* is specified, then all logs after the first
-  issued will be on the level *`subsequent_level`*. You are allowed
-  to specify a *`subsequent_level`* of 5, meaning no logging after the
+  If the *`log-type`* is one of `warning`, `error` or `critical`, then *`level`*
+  may only be 1.
+
+* If *`subsequent-level`* is specified, then all logs after the first
+  issued will be on the level *`subsequent-level`*. You are allowed
+  to specify a *`subsequent-level`* of 5, meaning no logging after the
   initial log.
+
+  If the *`log-type`* is one of `warning`, `error` or `critical`, then
+  *`subsequent-level`* may only be either 1 or 5.
 
 * The *`groups`* argument is an integer whose bit
   representation is used to select which log groups the message belongs

--- a/lib/1.2/dml-builtins.dml
+++ b/lib/1.2/dml-builtins.dml
@@ -217,6 +217,7 @@ template device {
     parameter _compat_legacy_attributes auto;
     parameter _compat_lenient_typechecking auto;
     parameter _compat_no_method_index_asserts auto;
+    parameter _compat_meaningless_log_levels auto;
     parameter _compat_dml12_inline auto;
     parameter _compat_dml12_not auto;
     parameter _compat_dml12_goto auto;

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -623,6 +623,7 @@ template device {
     param _compat_legacy_attributes auto;
     param _compat_lenient_typechecking auto;
     param _compat_no_method_index_asserts auto;
+    param _compat_meaningless_log_levels auto;
     param _compat_dml12_inline auto;
     param _compat_dml12_not auto;
     param _compat_dml12_goto auto;

--- a/py/dml/compat.py
+++ b/py/dml/compat.py
@@ -256,6 +256,18 @@ class no_method_index_asserts(CompatFeature):
     last_api_version = api_7
 
 @feature
+class meaningless_log_levels(CompatFeature):
+    '''The log level that may be specified for logs of kind "warning", "error"
+    or "critical" typically must be 1, and any subsequent log level must
+    typically be 5. This compatibility feature makes it so either log level may
+    be any integer between 1 and 4 for these log kinds. The primary log level
+    is always treated as 1, and any other value than 1 for the subsequent log
+    level will be treated as 5 (that is, the log will only happen once)'''
+    short = ("Allow other log levels than '1' and '1 then 5' for log kinds "
+             + "'warning', 'error', and 'critical'")
+    last_api_version = api_7
+
+@feature
 class dml12_inline(CompatFeature):
     '''When using `inline` to inline a method in a DML 1.2 device,
     constant arguments passed in typed parameters are inlined as

--- a/py/dml/messages.py
+++ b/py/dml/messages.py
@@ -771,10 +771,12 @@ class ELTYPE(DMLError):
 
 class ELLEV(DMLError):
     """
-    The log level given in a log statement must be an integer between 1 and 4.
-    Or 1 and 5 for a subsequent log level (`then ...`).
+    The log level given in a log statement must be an integer between 1 and 4,
+    or 1 and 5 for a subsequent log level (`then ...`), unless the log kind is
+    one of "warning", "error", or "critical", in which case it must be 1 (or 5
+    for subsequent log level).
     """
-    fmt = "log level must be an integer between 1 and %d"
+    fmt = "log level must be %s"
 
 class ESYNTAX(DMLError):
     """

--- a/test/1.4/legacy/T_meaningless_log_levels_disabled.dml
+++ b/test/1.4/legacy/T_meaningless_log_levels_disabled.dml
@@ -1,0 +1,13 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+/// COMPILE-ONLY
+/// DMLC-FLAG --no-compat=meaningless_log_levels
+/// WARNING WREDUNDANTLEVEL meaningless_log_levels.dml
+/// SCAN-FOR-TAGS meaningless_log_levels.dml
+import "meaningless_log_levels.dml";

--- a/test/1.4/legacy/T_meaningless_log_levels_enabled.dml
+++ b/test/1.4/legacy/T_meaningless_log_levels_enabled.dml
@@ -1,0 +1,12 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+dml 1.4;
+
+device test;
+
+/// COMPILE-ONLY
+/// DMLC-FLAG --simics-api=7
+/// WARNING WREDUNDANTLEVEL meaningless_log_levels.dml
+import "meaningless_log_levels.dml";

--- a/test/1.4/legacy/T_meaningless_log_levels_enabled.dml
+++ b/test/1.4/legacy/T_meaningless_log_levels_enabled.dml
@@ -6,7 +6,6 @@ dml 1.4;
 
 device test;
 
-/// COMPILE-ONLY
 /// DMLC-FLAG --simics-api=7
 /// WARNING WREDUNDANTLEVEL meaningless_log_levels.dml
 import "meaningless_log_levels.dml";

--- a/test/1.4/legacy/T_meaningless_log_levels_enabled.py
+++ b/test/1.4/legacy/T_meaningless_log_levels_enabled.py
@@ -1,0 +1,41 @@
+# © 2024 Intel Corporation
+# SPDX-License-Identifier: MPL-2.0
+
+import stest
+
+class LogCapture(object):
+    def __init__(self):
+        self.messages = []
+        self.filter = sim_commands.logger.filter(self.callback)
+    def __enter__(self):
+        self.filter.__enter__()
+        return self
+    def __exit__(self, *args):
+        return self.filter.__exit__(*args)
+    def callback(self, obj_, kind, msg):
+        stest.expect_equal(obj_, obj)
+        self.messages.append(msg)
+
+with stest.allow_log_mgr(obj, 'warning'),  \
+     stest.allow_log_mgr(obj, 'error'),    \
+     stest.allow_log_mgr(obj, 'critical'), \
+     LogCapture() as capture:
+    obj.good_logs = None
+    stest.expect_equal(capture.messages,
+                       ['error 1', 'warning 1', 'critical 1',
+                        'error 1 then 1', 'warning 1 then 5'])
+    capture.messages.clear()
+    obj.good_logs = None
+    stest.expect_equal(capture.messages,
+                       ['error 1', 'warning 1', 'critical 1',
+                        'error 1 then 1'])
+    capture.messages.clear()
+
+    obj.bad_logs = None
+    stest.expect_equal(capture.messages,
+                       ['error 2', 'warning 2', 'critical 2', 'error 1 then 2',
+                        'warning 1 then 2', 'critical 2 then 3'])
+    capture.messages.clear()
+    obj.bad_logs = None
+    stest.expect_equal(capture.messages,
+                       ['error 2', 'warning 2', 'critical 2'])

--- a/test/1.4/legacy/meaningless_log_levels.dml
+++ b/test/1.4/legacy/meaningless_log_levels.dml
@@ -7,36 +7,48 @@ dml 1.4;
 
 // expectations in this file are selectively enabled using SCAN-FOR-TAGS
 
-method init() {
-    // no error
-    log error, 1: "log";
-    log warning, 1: "log";
-    log critical, 1: "log";
+template test_attr is write_only_attr {
+    param type = "n";
+    shared method test();
+    shared method set(attr_value_t val) throws { test(); }
+}
 
-    log error,
-        /// ERROR ELLEV
-        2: "log";
-    log warning,
-        /// ERROR ELLEV
-        2: "log";
-    log critical,
-        /// ERROR ELLEV
-        2: "log";
+attribute good_logs is test_attr {
+    method test() {
+        // no error
+        log error, 1: "error 1";
+        log warning, 1: "warning 1";
+        log critical, 1: "critical 1";
 
-    // no error
-    log error, 1 then 1: "log";
-    log warning, 1 then 5: "log";
+        // no error
+        log error, 1 then 1: "error 1 then 1";
+        log warning, 1 then 5: "warning 1 then 5";
+    }
+}
 
-    log error, 1 then
-        /// ERROR ELLEV
-        2: "log";
-    log warning, 1 then
-        /// ERROR ELLEV
-        2: "log";
+attribute bad_logs is test_attr {
+    method test() {
+        log error,
+            /// ERROR ELLEV
+            2: "error 2";
+        log warning,
+            /// ERROR ELLEV
+            2: "warning 2";
+        log critical,
+            /// ERROR ELLEV
+            2: "critical 2";
 
-    log critical,
-        /// ERROR ELLEV
-        2 then
-        /// ERROR ELLEV
-        3: "log";
+        log error, 1 then
+            /// ERROR ELLEV
+            2: "error 1 then 2";
+        log warning, 1 then
+            /// ERROR ELLEV
+            2: "warning 1 then 2";
+
+        log critical,
+            /// ERROR ELLEV
+            2 then
+            /// ERROR ELLEV
+            3: "critical 2 then 3";
+    }
 }

--- a/test/1.4/legacy/meaningless_log_levels.dml
+++ b/test/1.4/legacy/meaningless_log_levels.dml
@@ -1,0 +1,42 @@
+/*
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: MPL-2.0
+*/
+
+dml 1.4;
+
+// expectations in this file are selectively enabled using SCAN-FOR-TAGS
+
+method init() {
+    // no error
+    log error, 1: "log";
+    log warning, 1: "log";
+    log critical, 1: "log";
+
+    log error,
+        /// ERROR ELLEV
+        2: "log";
+    log warning,
+        /// ERROR ELLEV
+        2: "log";
+    log critical,
+        /// ERROR ELLEV
+        2: "log";
+
+    // no error
+    log error, 1 then 1: "log";
+    log warning, 1 then 5: "log";
+
+    log error, 1 then
+        /// ERROR ELLEV
+        2: "log";
+    log warning, 1 then
+        /// ERROR ELLEV
+        2: "log";
+
+    log critical,
+        /// ERROR ELLEV
+        2 then
+        /// ERROR ELLEV
+        3: "log";
+}

--- a/test/1.4/statements/T_subsequent_log.dml
+++ b/test/1.4/statements/T_subsequent_log.dml
@@ -87,3 +87,19 @@ attribute test_arrays is bool_attr {
         }
     }
 }
+
+attribute test_warning_once is bool_attr {
+    method set(attr_value_t val) throws {
+        log warning, 1 then 5: "warning once";
+    }
+}
+attribute test_error_once is bool_attr {
+    method set(attr_value_t val) throws {
+        log error, 1 then 5: "error once";
+    }
+}
+attribute test_critical_once is bool_attr {
+    method set(attr_value_t val) throws {
+        log critical, 1 then 5: "critical once";
+    }
+}

--- a/test/1.4/statements/T_subsequent_log.py
+++ b/test/1.4/statements/T_subsequent_log.py
@@ -64,3 +64,19 @@ with LogCapture() as capture:
         stest.expect_true("shared in array" in mess)
     for mess in messages[4:]:
         stest.expect_true("array method" in mess)
+
+with LogCapture() as capture:
+    with stest.expect_log_mgr(obj, 'warning'):
+        obj.test_warning_once = True
+    with stest.expect_log_mgr(obj, 'error'):
+        obj.test_error_once = True
+    with stest.expect_log_mgr(obj, 'critical'):
+        obj.test_critical_once = True
+    stest.expect_equal(capture.messages,
+                       ['warning once', 'error once', 'critical once'])
+
+with LogCapture() as capture:
+    obj.test_warning_once = True
+    obj.test_error_once = True
+    obj.test_critical_once = True
+    stest.expect_equal(capture.messages, [])


### PR DESCRIPTION
This adds support for `1 then 5` for `warning`, `error` and `critical`, as well as restricting the valid log levels for these to 1 (and 5)

SIMICS-22401 is not a **perfect** fit for this, but it mentions log level 0, which was part of the original discussion about how we should treat `warning`, `error` and `critical`.