### PR TITLE
Avoid deprecated command line parameters

### DIFF
--- a/test/1.4/hooks/T_checkpointing.cont.py
+++ b/test/1.4/hooks/T_checkpointing.cont.py
@@ -1,4 +1,6 @@
 # © 2024 Intel Corporation
 # SPDX-License-Identifier: MPL-2.0
 
+SIM_read_configuration("checkpointing.chkp")
+
 conf.obj.test_state = None

--- a/test/1.4/hooks/T_checkpointing.py
+++ b/test/1.4/hooks/T_checkpointing.py
@@ -14,5 +14,4 @@ subprocess.check_call(
     ["--batch-mode", "--quiet", "--no-copyright", "--dump-core", "--werror",
      '--project', conf.sim.project,
      "-L", scratchdir,
-     "-c", "checkpointing.chkp",
-     "-p", join(basedir, "T_checkpointing.cont.py")])
+     join(basedir, "T_checkpointing.cont.py")])


### PR DESCRIPTION
These are deprecated in 7.