### PR TITLE
Test annotation parsing: strip line endings

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -526,7 +526,7 @@ class DMLFileTestCase(BaseTestCase):
         else:
             flags = append_to
         for (linenum, line) in enumerate(open(filename, "rb"), 2):
-            m = annotation_re.match(line)
+            m = annotation_re.match(line.rstrip(b'\r\n'))
             if not m:
                 continue
             (key, data) = m.groups()


### PR DESCRIPTION
This is to work around what seems to be a bug with Pypy on Windows, where regex fails to handle carriage returns properly.