### PR TITLE
doc: Correct read_bits/write_bits -> read_field/write_field

### DIFF
--- a/doc/1.4/language.md
+++ b/doc/1.4/language.md
@@ -573,9 +573,9 @@ categories of templates:
   the `read` or `write` template. The template leaves
     a simple method `read` (or `write`) abstract;
     custom behaviour is provided by overriding the method. There is
-    also a pair of templates `read_bits`
-    and `write_bits`, which similarly provide abstract
-    methods `read_bits` and `write_bits`. These
+    also a pair of templates `read_field`
+    and `write_field`, which similarly provide abstract
+    methods `read_field` and `write_field`. These
     functions have some extra parameters, making them less convenient
     to use, but they also offer some extra information about the
     access.

--- a/lib/1.4/dml-builtins.dml
+++ b/lib/1.4/dml-builtins.dml
@@ -3531,7 +3531,7 @@ The default behaviour depends on whether the register has fields:
   new value, using the `set` method.
 
 * If the register has fields, then the default behavior is to
-  invoke the `write_fields` method of all sub-fields covered at
+  invoke the `write_field` method of all sub-fields covered at
   least partially by `enabled_bytes`, in order from
   least to most significant bit. Then `write_unmapped_bits`
   is called with the enabled bits that were not covered by fields.


### PR DESCRIPTION
The documentation was only partially corrected regarding these in 2021 in commit b6f8d3097d7ff779c7261a0d389a7831698964ae in Simics-Base (back when DMLC was part of that repository).

Also fix a documentation typo in dml-builtins.dml.