### PR TITLE
Put back Python version condition

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -963,8 +963,8 @@ all_tests.append(ErrorTest(["missing"], "xyz",
                            errors=[("xyz", 0, "ENOFILE")],
                            includepath=()))
 # On Windows NUL is not exactly a file in the same way.
-# Path resolve into an UNC path, i.e. with extra characters.
-if is_windows():
+# Path resolves into an UNC path, i.e. with extra characters.
+if is_windows() and sys.version_info.minor > 10:
     devnull_path = "NUL"
 else:
     devnull_path = str(Path(os.devnull).resolve())


### PR DESCRIPTION
This was removed in 41a745c6 but it turns out to be needed.
