### PR TITLE
Use exit code 2 for partial failure

### DIFF
--- a/py/port_dml.py
+++ b/py/port_dml.py
@@ -1130,7 +1130,7 @@ def main(argv):
         sys.stderr.write(f'''\
 *** Failed to apply {errors} out of {total} porting tags; partial result saved to {args.dest}. Consider applying the failed tags manually.
 ''')
-        exit(1)
+        exit(2)
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/test/tests.py
+++ b/test/tests.py
@@ -1367,7 +1367,7 @@ class PortingConvert(CTestCase):
 
 class PortingConvertFail(PortingConvert):
     __slots__ = ()
-    port_dml_status = 1
+    port_dml_status = 2
     def test(self):
         super(PortingConvert, self).test()
         stdout = join(self.scratchdir, 'stdout.port-dml')


### PR DESCRIPTION
Such failures are usually not so bad, so port-dml-module
wants to spot the difference and proceed.
