### PR TITLE
Free the map target when the object is destroyed

### DIFF
--- a/RELEASENOTES-1.4.md
+++ b/RELEASENOTES-1.4.md
@@ -450,3 +450,5 @@
   The device object always instantiates this template.
 - `release 6 6464`
 - `release 7 7160`
+- `note 6` The `map_target` template from `utility.dml` now frees the internally
+ created map target upon device deletion.

--- a/lib/1.4/utility.dml
+++ b/lib/1.4/utility.dml
@@ -1272,6 +1272,13 @@ template map_target is (connect, _qname) {
         this.map_target = obj ? SIM_new_map_target(obj, NULL, NULL) : NULL;
     }
 
+    group _internal_destructor is destroy {
+        method destroy() {
+            SIM_free_map_target(parent.map_target);
+            parent.map_target = NULL;
+        }
+    }
+
     /**
        * `read(uint64 addr, uint64 size) -> (uint64) throws`
 


### PR DESCRIPTION
I tried to make changes to `src/tools/dmlc/test/1.4/lib/T_map_target_connect.py` to test this, but I couldn't find a good way to check if the map target had been free:d. Let me know if you think this is OK or if you have a good way of testing this.