### PR TITLE
Update changes-manual: unmapped fields and constant registers

### DIFF
--- a/doc/1.4/changes-manual.md
+++ b/doc/1.4/changes-manual.md
@@ -404,3 +404,7 @@ by `--strict-dml12`, and must be adjusted manually:
   The first message is logged on level 2 by `silent_unimpl`,
   and level 1 by all the other templates, while subsequent messages
   are logged on level 3 in all templates.
+
+* Registers that instantiate the `constant` template should use the `init_val`
+  parameter to declare their reset value, changed from the `value` parameter in
+  DML 1.2.


### PR DESCRIPTION
I haven't checked whether these would be caught by --strict-dml12. I guessed that they would not. Do you know off-hand if this is true?