### PR TITLE
Fix casts to template types not checking for non-values

### DIFF
--- a/py/dml/ctree.py
+++ b/py/dml/ctree.py
@@ -3733,6 +3733,8 @@ class TraitObjectCast(Expression):
                 + '(_traitref_t) {_object_vtables[__id.id], __id};})')
 
 def mkTraitUpcast(site, sub, parent):
+    if isinstance(sub, NonValue):
+        raise sub.exc()
     typ = safe_realtype(sub.ctype())
     assert dml.globals.object_trait
     if isinstance(typ, TTrait):

--- a/test/1.4/errors/T_ENVAL.dml
+++ b/test/1.4/errors/T_ENVAL.dml
@@ -46,6 +46,9 @@ method init() {
     b.r1;
     /// ERROR ENVAL
     b.r2.f;
+
+    /// ERROR ENVAL
+    cast([], t);
 }
 
 // dev is not a value in 1.4.  Need to capture this with a rather unnatural


### PR DESCRIPTION
As encountered by @gwikland. This would previously provoke an ICE. Jonatan, you're lone reviewer unless Erik happens to see this on vacation.