### PR TITLE
Dml 1.2 compatibility templates - inquiry

### DIFF
--- a/lib/1.2/dml12-compatibility.dml
+++ b/lib/1.2/dml12-compatibility.dml
@@ -293,6 +293,9 @@ method _make_write_memop(uint64 enabled_bytes, uint64 *value)
 template dml12_compat_read_register {
     inline method read_access(generic_transaction_t *memop,
                               inline msb1, inline lsb) -> (uint64) {
+        if (SIM_get_mem_op_inquiry(memop)) {
+            return default(memop, msb1, lsb);
+        }
         #if (defined(msb1)) {
             local uint64 mask = 0;
             mask[msb1 - 1 : lsb] = ~0;
@@ -309,6 +312,10 @@ template dml12_compat_read_register {
 template dml12_compat_write_register {
     inline method write_access(generic_transaction_t *memop,
                                inline msb1, inline lsb, uint64 value) {
+        if (SIM_get_mem_op_inquiry(memop)) {
+            default(memop, msb1, lsb, value);
+            return;
+        }
         #if (defined(msb1)) {
             local uint64 mask = 0;
             mask[msb1 - 1 : lsb] = ~0;

--- a/test/1.2/misc/dml14.dml
+++ b/test/1.2/misc/dml14.dml
@@ -216,6 +216,26 @@ bank field_regs {
         value = 0;
         assert this.io_memory_access(&read_memop, 25, NULL);
         assert value == 0x1234;
+
+        // Test that inquiry accesses bypass dml12_compat_read_register and
+        // dml12_compat_write_register (r6 inverts bits in read_register/
+        // write_register; inquiry should access storage directly)
+        local uint32 inq_val;
+        local buffer_t inq_buf = {.len=4, .data=cast(&inq_val, uint8 *)};
+        local generic_transaction_t inq_read = SIM_make_mem_op_read(
+            0, inq_buf, true, NULL);
+        local generic_transaction_t inq_write = SIM_make_mem_op_write(
+            0, buffer_bytes(inq_buf), true, NULL);
+        r6.set(0x12345678);
+        // Inquiry read: should return stored value directly, not inverted
+        assert this.io_memory_access(&inq_read, 24, NULL);
+        assert inq_val == 0x12345678;
+        // Inquiry write: should store value directly, not inverted
+        inq_val = 0xAABBCCDD;
+        assert this.io_memory_access(&inq_write, 24, NULL);
+        r6val = r6.get();
+        assert r6val == 0xAABBCCDD;
+
         r4.f.val = 42;
         r4.f.val += 1;
         value = r4.get();

--- a/test/1.2/misc/dml14.dml
+++ b/test/1.2/misc/dml14.dml
@@ -220,7 +220,7 @@ bank field_regs {
         // Test that inquiry accesses bypass dml12_compat_read_register and
         // dml12_compat_write_register (r6 inverts bits in read_register/
         // write_register; inquiry should access storage directly)
-        local uint32 inq_val;
+        local uint32_le_t inq_val;
         local buffer_t inq_buf = {.len=4, .data=cast(&inq_val, uint8 *)};
         local generic_transaction_t inq_read = SIM_make_mem_op_read(
             0, inq_buf, true, NULL);


### PR DESCRIPTION
1.2 read_access(write_access) has conditional logic based on `inquiry`
1.4 calls either get() or read() (set()/write()) in io_memory based on `inquiry`

compatibility templates ignored that