### PR TITLE
Permit also ply 3.10

### DIFF
--- a/py/dml/dmlparse.py
+++ b/py/dml/dmlparse.py
@@ -16,7 +16,7 @@ from . import provisional
 from . import breaking_changes
 
 assert lex.__version__ == yacc.__version__
-assert yacc.__version__ in {"3.4", "3.11"}
+assert yacc.__version__ in {"3.4", "3.10", "3.11"}
 
 class UnexpectedEOF(Exception): pass
 


### PR DESCRIPTION
this is mostly because 3.10 happens to be available on a CI system,
making some internal testing easier
